### PR TITLE
feature/migrate shinyapps

### DIFF
--- a/R/deployments.R
+++ b/R/deployments.R
@@ -60,8 +60,12 @@ deployments <- function(appDir, nameFilter = NULL, accountFilter = NULL,
       file.remove(shinyappsDCF)
     }
 
-    # remove shinyapps dir
-    unlink(shinyappsDir, TRUE)
+    # remove shinyapps dir if it's completely empty
+    remainingFiles <- list.files(shinyappsDir,
+                                 recursive = TRUE,
+                                 all.files = TRUE)
+    if (length(remainingFiles) == 0)
+      unlink(shinyappsDir, recursive = TRUE)
   }
 
   # build list of deployment records


### PR DESCRIPTION
This PR implements migration of the deployment records in the `shinyapps` directory to the `rsconnect` directory.

Prior to enumerating existing application deployments we check for the presence of a `shinyapps` directory. If it's there then we move it's contents into the `rsconnect/shinyapps.io` directory by reading in all of the DCF files, adding `server: shinyapps.io` to each record, then writing them into the appropriate spot within the `rsconnect` directory.

Note that this is a _move_ rather than _copy_ operation. This is because if we left the files in the shinyapps directory then:
1. We'd have to somehow _know_ which deployment record was current (i.e. whether we needed to migrate again, which one to actually use when there are two, etc.);
2. Users would be confused by the presence of two directories and might delete one of them incorrectly.

At the end of the migration if the `shinyapps` directory is completely empty (i.e. nothing other than deployment records were in there) we also remove it from the filesystem.
