### PR TITLE
exclude packrat directory from deployment

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -11,6 +11,7 @@ bundleFiles <- function(appDir, rmdFile, fullNames) {
   files <- files[!grepl(glob2rx("*.Rproj"), files)]
   files <- files[!grepl(glob2rx(".DS_Store"), files)]
   files <- files[!grepl(glob2rx(".gitignore"), files)]
+  files <- files[!grepl(glob2rx("packrat/*"), files)]
 
   # if deploying a specific Rmd file, exclude other Rmd files
   if (nchar(rmdFile) > 0) {


### PR DESCRIPTION
Assuming this is the behavior we want but submitting as a PR just as a sanity check.