### PR TITLE
Show RStudio source markers for lint, if enabled

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,8 @@ Imports:
     PKI,
     RCurl,
     RJSONIO,
-    packrat (>= 0.4.2-1)
+    packrat (>= 0.4.2-1),
+    rstudioapi (>= 0.2)
 Suggests:
     scrypt,
     knitr,

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -82,6 +82,13 @@ deployApp <- function(appDir = getwd(),
     if (hasLint(lintResults)) {
 
       if (interactive()) {
+        # if enabled, show warnings in friendly marker tab in addition to
+        # printing to console
+        if (getOption("rsconnect.rstudio_source_markers", TRUE) &&
+            rstudioapi::hasFun("sourceMarkers"))
+        {
+          showRstudioSourceMarkers(lintResults)
+        }
         message("The following potential problems were identified in the project files:\n")
         printLinterResults(lintResults)
         response <- readline("Do you want to proceed with deployment? [Y/n]: ")

--- a/R/ide.R
+++ b/R/ide.R
@@ -50,3 +50,30 @@ findLocalServer <- function(url) {
     name
   }
 }
+
+# generate the markers
+showRstudioSourceMarkers <- function(basePath, lint) {
+  markers <- list()
+  applied <- lapply(lint, function(file) {
+    lapply(file, function(linter) {
+      lapply(linter$indices, function(index) {
+        marker <- list()
+        marker$type <- "warning"
+        marker$file <- linter$file
+        marker$line <- index
+        marker$column <- 1
+        marker$message <- linter$suggestion
+        markers <<- c(markers, list(marker))
+        marker
+      })
+    })
+  })
+
+  rstudioapi::callFun("sourceMarkers",
+                      name = "rsconnect",
+                      markers = markers,
+                      basePath = basePath,
+                      autoSelect = "first")
+}
+
+


### PR DESCRIPTION
This change integrates the file linter with the new Source Marker API in RStudio. When running under a suitable version of RStudio, clickable lint results will be presented in the Marker tab in addition to being emitted to the console. 