### PR TITLE
Refine absolute path lint mechanics

### DIFF
--- a/R/lint-framework.R
+++ b/R/lint-framework.R
@@ -75,13 +75,15 @@ lint <- function(project, file = "") {
   if (file.exists(project) && !isTRUE(file.info(project)$isdir))
     stop("Path '", project, "' is not a directory")
 
+  project <- normalizePath(project, mustWork = TRUE)
+
   # Perform actions within the project directory (so relative paths are easily used)
   owd <- getwd()
   on.exit(setwd(owd))
   setwd(project)
 
   # List the files that will be bundled
-  projectFiles <- bundleFiles(project, file, TRUE)
+  projectFiles <- bundleFiles(project, file, TRUE) %relativeTo% project
   projectFiles <- gsub("^\\./", "", projectFiles)
   names(projectFiles) <- projectFiles
 
@@ -236,4 +238,26 @@ collectSuggestions <- function(fileResults) {
     }))
   })
   Reduce(union, suggestions)
+}
+
+`%relativeTo%` <- function(paths, directory) {
+
+  nd <- nchar(directory)
+
+  unlist(lapply(paths, function(path) {
+    np <- nchar(path)
+    if (nd > np) {
+      warning("'", path, "' is not a subdirectory of '", directory, "'")
+      return(path)
+    }
+
+    if (substring(path, 1, nd) != directory) {
+      warning("'", path, "' is not a subdirectory of '", directory, "'")
+      return(path)
+    }
+
+    offset <- if (substring(directory, nd, nd) == "/") 1 else 2
+    substring(path, nd + offset, np)
+  }))
+
 }

--- a/R/lint-framework.R
+++ b/R/lint-framework.R
@@ -75,7 +75,7 @@ lint <- function(project, file = "") {
   if (file.exists(project) && !isTRUE(file.info(project)$isdir))
     stop("Path '", project, "' is not a directory")
 
-  project <- normalizePath(project, mustWork = TRUE)
+  project <- normalizePath(project, mustWork = TRUE, winslash = "/")
 
   # Perform actions within the project directory (so relative paths are easily used)
   owd <- getwd()

--- a/tests/testthat/shinyapp-with-absolute-paths/server.R
+++ b/tests/testthat/shinyapp-with-absolute-paths/server.R
@@ -12,9 +12,7 @@ shinyServer(function(input, output) {
   output$distPlot <- renderPlot({
 
     # read a file on disk
-    file <- read.table("C:\\results.txt")
-    fileForward <- read.table("C:/results.txt")
-    otherFile <- read.table("/usr/local/files/files.txt")
+    otherFile <- read.table("~/.rsconnect/local-file.txt")
     anotherFile <- readLines('../../foo.bar')
     serverFile <- "\\\\server\\path\\to\\file"
     validWeblink <- "//www.google.com/"

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -23,8 +23,10 @@ isConnectRunning <- function() {
 
 test_that("Users API", {
 
-  if (!isConnectRunning())
-    stop("Couldn't find a running connect instance (expected './bin/connect' in 'ps -a'")
+  if (!isConnectRunning()) {
+    cat("No running 'connect' instance detected -- tests skipped.")
+    return()
+  }
 
   ## rm db/*.db
   server <- getDefaultServer(local = TRUE)

--- a/tests/testthat/test-lint.R
+++ b/tests/testthat/test-lint.R
@@ -2,16 +2,26 @@ context("lint")
 
 test_that("linter warns about absolute paths and relative paths", {
 
-  serverPath <- list.files("shinyapp-with-absolute-paths", pattern = "server\\.R$")
+  ## Create a local file that 'server.R' tries to use
+  testDir <- "~/.rsconnect-tests"
+  exists <- file.exists(testDir)
+
+  dir.create("~/.rsconnect-tests", showWarnings = FALSE)
+  file.create("~/.rsconnect/local-file.txt")
+
+  serverPath <- list.files("shinyapp-with-absolute-paths",
+                           pattern = "server\\.R$")
+
   result <- lint("shinyapp-with-absolute-paths")
 
-  printLinterResults(result)
-
   absPathLintedIndices <- result[[serverPath]]$absolute.paths$indices
-  expect_identical(as.numeric(absPathLintedIndices), c(15, 16, 17, 19))
+  expect_identical(as.numeric(absPathLintedIndices), 15)
 
   relPathLintedIndices <- result[[serverPath]]$invalid.relative.paths$indices
-  expect_identical(as.numeric(relPathLintedIndices), 18)
+  expect_identical(as.numeric(relPathLintedIndices), 16)
+
+  if (!exists)
+    unlink(testDir, recursive = TRUE)
 })
 
 test_that("badRelativePaths identifies bad paths correctly", {
@@ -38,7 +48,7 @@ test_that("The linter identifies files not matching in case sensitivity", {
   result <- lint("shinyapp-with-absolute-paths")
   server.R <- result[["server.R"]]
   filepath.capitalization <- server.R[["filepath.capitalization"]]
-  expect_true(filepath.capitalization$indices == 33)
+  expect_true(filepath.capitalization$indices == 31)
 })
 
 test_that("The linter believes that the Shiny example apps are okay", {


### PR DESCRIPTION
Previously, we used a set of regular expressions applied on strings in documents indiscriminately to try and pull entries out that looked like absolute paths. This caused a lot of false positives, especially with URIs beginning with `/`, for example (as those can 'look like' absolute paths to files on the local filesystem).

This PR refines that behaviour by:

1. Extracting all (single and double quoted) strings in the document of at least 5 characters in length, and
2. Warning only if they 'look like' absolute paths, _and_ they exist on the local filesystem.