### PR TITLE
don't include appmode in manifest for shinyapps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rsconnect
 Type: Package
 Title: Deployment Interface for Shiny Applications
-Version: 0.3.72
+Version: 0.3.73
 Date: 2013-11-03
 Author: JJ Allaire
 Maintainer: JJ Allaire <jj@rstudio.com>

--- a/R/accounts.R
+++ b/R/accounts.R
@@ -350,6 +350,10 @@ resolveAccount <- function(account, server = NULL) {
   }
 }
 
+isShinyapps <- function(accountInfo) {
+  identical(accountInfo$server, "shinyapps.io")
+}
+
 stopWithNoAccount <- function() {
   stop("You must register an account using setAccountInfo prior to ",
        "proceeding.", call. = FALSE)

--- a/R/applications.R
+++ b/R/applications.R
@@ -61,7 +61,7 @@ applications <- function(account = NULL, server = NULL) {
 
     # this may be provided by the server at some point, but for now infer it
     # from the account type
-    x$config_url <- if (identical(accountDetails$server, "shinyapps.io"))
+    x$config_url <- if (isShinyapps(accountDetails))
       paste("https://www.shinyapps.io/admin/#/application", x$id, sep = "/")
     else
       sub("/__api__", paste("/connect/#/apps", x$id, sep = "/"),

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -28,7 +28,7 @@ bundleFiles <- function(appDir, rmdFile, fullNames) {
     files
 }
 
-bundleApp <- function(appName, appDir, rmdFile) {
+bundleApp <- function(appName, appDir, accountInfo, rmdFile) {
 
   # create a directory to stage the application bundle in
   bundleDir <- tempfile()
@@ -66,7 +66,7 @@ bundleApp <- function(appName, appDir, rmdFile) {
   users <- authorizedUsers(appDir)
 
   # generate the manifest and write it into the bundle dir
-  manifestJson <- enc2utf8(createAppManifest(bundleDir, files, users))
+  manifestJson <- enc2utf8(createAppManifest(bundleDir, accountInfo, files, users))
   writeLines(manifestJson, file.path(bundleDir, "manifest.json"), useBytes=TRUE)
 
   # if necessary write an index.htm for shinydoc deployments
@@ -118,7 +118,7 @@ inferAppMode <- function(appDir, files) {
   return(NA)
 }
 
-createAppManifest <- function(appDir, files, users) {
+createAppManifest <- function(appDir, accountInfo, files, users) {
 
   # provide package entries for all dependencies
   packages <- list()
@@ -184,7 +184,8 @@ createAppManifest <- function(appDir, files, users) {
   # create the manifest
   manifest <- list()
   manifest$version <- 1
-  manifest$appmode <- appMode
+  if (!isShinyapps(accountInfo))
+    manifest$appmode <- appMode
   manifest$platform <- paste(R.Version()$major, R.Version()$minor, sep=".")
 
   # if there are no packages set manifes$packages to NA (json null)

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -137,7 +137,7 @@ deployApp <- function(appDir = getwd(),
   if (upload) {
     # create, and upload the bundle
     withStatus("Uploading application bundle", {
-      bundlePath <- bundleApp(target$appName, appDir, rmdFile)
+      bundlePath <- bundleApp(target$appName, appDir, accountDetails, rmdFile)
       bundle <- client$uploadApplication(application$id, bundlePath)
     })
   } else {


### PR DESCRIPTION
shinyapps.io does strong validation of deployment manifests so will fail if an extra field (appmode in this case) is included. This PR makes the accountInfo available to the manifest generation code and only includes appmode if we aren't running against shinyapps.io. 