### PR TITLE
Emit primary R Markdown filename to manifest JSON (infer if unspecified)

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -187,9 +187,12 @@ createAppManifest <- function(appDir, accountInfo, files, appPrimaryRmd, users) 
   # create the manifest
   manifest <- list()
   manifest$version <- 1
-  manifest$metadata <- list()
-  manifest$metadata$appmode <- appMode
   manifest$platform <- paste(R.Version()$major, R.Version()$minor, sep=".")
+
+  # add metadata
+  manifest$metadata <- list(
+    appmode = appMode,
+    primary_rmd = if (is.null(appPrimaryRmd)) NA else appPrimaryRmd)
 
   # if there are no packages set manifes$packages to NA (json null)
   if (length(packages) > 0) {
@@ -209,12 +212,6 @@ createAppManifest <- function(appDir, accountInfo, files, appPrimaryRmd, users) 
   } else {
     manifest$users <- NA
   }
-
-  # supply the primary R Markdown document
-  manifest$metadata$primary_rmd <- if (is.null(appPrimaryRmd))
-      NA
-    else
-      appPrimaryRmd
 
   # return it as json
   RJSONIO::toJSON(manifest, pretty = TRUE)

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -187,8 +187,8 @@ createAppManifest <- function(appDir, accountInfo, files, appPrimaryRmd, users) 
   # create the manifest
   manifest <- list()
   manifest$version <- 1
-  if (!isShinyapps(accountInfo))
-    manifest$appmode <- appMode
+  manifest$metadata <- list()
+  manifest$metadata$appmode <- appMode
   manifest$platform <- paste(R.Version()$major, R.Version()$minor, sep=".")
 
   # if there are no packages set manifes$packages to NA (json null)
@@ -211,12 +211,10 @@ createAppManifest <- function(appDir, accountInfo, files, appPrimaryRmd, users) 
   }
 
   # supply the primary R Markdown document
-  if (!isShinyapps(accountInfo)) {
-    manifest$primary_rmd <- if (is.null(appPrimaryRmd))
+  manifest$metadata$primary_rmd <- if (is.null(appPrimaryRmd))
       NA
     else
       appPrimaryRmd
-  }
 
   # return it as json
   RJSONIO::toJSON(manifest, pretty = TRUE)

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -210,10 +210,13 @@ createAppManifest <- function(appDir, accountInfo, files, appPrimaryRmd, users) 
     manifest$users <- NA
   }
 
-  manifest$primary_rmd <- if (is.null(appPrimaryRmd))
-    NA
-  else
-    appPrimaryRmd
+  # supply the primary R Markdown document
+  if (!isShinyapps(accountInfo)) {
+    manifest$primary_rmd <- if (is.null(appPrimaryRmd))
+      NA
+    else
+      appPrimaryRmd
+  }
 
   # return it as json
   RJSONIO::toJSON(manifest, pretty = TRUE)

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -7,6 +7,10 @@
 #' @param appFiles The files to bundle and deploy (only if \code{upload =
 #'   TRUE}). Can be \code{NULL}, in which case all the files in the directory
 #'   containing the application are bundled.
+#' @param appPrimaryRmd If the application is contains one or more R Markdown
+#'   documents, this parameter indicates the primary one. Can be \code{NULL}, in
+#'   which case the primary document is inferred from the contents being
+#'   deployed.
 #' @param appName Name of application (names must be unique within an
 #'   account). Defaults to the base name of the specified \code{appDir}.
 #' @param account Account to deploy application to. This
@@ -51,6 +55,7 @@
 #' @export
 deployApp <- function(appDir = getwd(),
                       appFiles = NULL,
+                      appPrimaryRmd = NULL,
                       appName = NULL,
                       account = NULL,
                       server = NULL,
@@ -149,7 +154,8 @@ deployApp <- function(appDir = getwd(),
   if (upload) {
     # create, and upload the bundle
     withStatus("Uploading application bundle", {
-      bundlePath <- bundleApp(target$appName, appDir, appFiles, accountDetails)
+      bundlePath <- bundleApp(target$appName, appDir, appFiles,
+                              appPrimaryRmd, accountDetails)
       bundle <- client$uploadApplication(application$id, bundlePath)
     })
   } else {

--- a/R/deployDoc.R
+++ b/R/deployDoc.R
@@ -42,6 +42,7 @@ deployDoc <- function(doc, ...) {
   # deploy the document with the discovered dependencies
   deployApp(appDir = dirname(qualified_doc),
             appFiles = c(res$path, basename(qualified_doc)),
+            appPrimaryRmd = basename(qualified_doc),
             ...)
 }
 

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -4,8 +4,8 @@
 \alias{deployApp}
 \title{Deploy an Application}
 \usage{
-deployApp(appDir = getwd(), appFiles = NULL, appName = NULL,
-  account = NULL, server = NULL, upload = TRUE,
+deployApp(appDir = getwd(), appFiles = NULL, appPrimaryRmd = NULL,
+  appName = NULL, account = NULL, server = NULL, upload = TRUE,
   launch.browser = getOption("rsconnect.launch.browser", interactive()),
   quiet = FALSE, lint = TRUE)
 }
@@ -16,6 +16,11 @@ directory.}
 \item{appFiles}{The files to bundle and deploy (only if \code{upload =
 TRUE}). Can be \code{NULL}, in which case all the files in the directory
 containing the application are bundled.}
+
+\item{appPrimaryRmd}{If the application is contains one or more R Markdown
+documents, this parameter indicates the primary one. Can be \code{NULL}, in
+which case the primary document is inferred from the contents being
+deployed.}
 
 \item{appName}{Name of application (names must be unique within an
 account). Defaults to the base name of the specified \code{appDir}.}


### PR DESCRIPTION
This change emits a new parameter to the manifest JSON that identifies the primary R Markdown document being deployed. The parameter can be user-specified in `deployApp`, but can also be inferred from the contents being deployed.