### PR TITLE
Store deployment records for individual documents

### DIFF
--- a/R/applications.R
+++ b/R/applications.R
@@ -115,12 +115,11 @@ applicationTask <- function(taskDef, appName, account, server, quiet) {
 #'
 #' Show the logs for a deployed ShinyApps application.
 #'
-#' @param appDir The directory where the local copy of the application
-#' resides.
+#' @param appPath The path to the directory or file that was deployed.
 #' @param appName The name of the application to show logs for. May be omitted
-#' if only one application deployment was made from \code{appDir}.
+#'   if only one application deployment was made from \code{appPath}.
 #' @param account The account under which the application was deployed. May be
-#' omitted if only one account is registered on the system.
+#'   omitted if only one account is registered on the system.
 #' @param entries The number of log entries to show. Defaults to 50 entries.
 #' @param streaming Whether to stream the logs. If \code{TRUE}, then the
 #'   function does not return; instead, log entries are written to the console
@@ -129,11 +128,11 @@ applicationTask <- function(taskDef, appName, account, server, quiet) {
 #' @note This function works only for ShinyApps servers.
 #'
 #' @export
-showLogs <- function(appDir = getwd(), appName = NULL, account = NULL,
-                     entries = 50, streaming = FALSE) {
+showLogs <- function(appPath = getwd(), appFile = NULL, appName = NULL,
+                     account = NULL, entries = 50, streaming = FALSE) {
 
   # determine the log target and target account info
-  target <- deploymentTarget(appDir, appName, account)
+  target <- deploymentTarget(appPath, appName, account)
   accountInfo <- accountInfo(target$account)
   lucid <- lucidClient(.lucidServerInfo$url, accountInfo)
   application <- getAppByName(lucid, accountInfo, target$appName)

--- a/R/auth.R
+++ b/R/auth.R
@@ -173,7 +173,7 @@ getPasswordFile <- function(appPath) {
 
   # normalize appPath and ensure it exists
   appPath <- normalizePath(appPath, mustWork = FALSE)
-  if (!file.exists(appPath) || !file.info(appPath)$isdir)
+  if (!file.exists(appPath))
     stop(appPath, " is not a valid file or directory", call. = FALSE)
 
   dataDir <- rsconnectRootPath(appPath)

--- a/R/auth.R
+++ b/R/auth.R
@@ -2,7 +2,8 @@
 #'
 #' @param username The user name.
 #' @param password The password.
-#' @param appDir Directory containing application. Defaults to current working directory.
+#' @param appPath Directory or file that was deployed. Defaults to current
+#'   working directory.
 #' @examples
 #' \dontrun{
 #'
@@ -15,7 +16,7 @@
 #' }
 #' @seealso \code{\link{removeAuthorizedUser}} and \code{\link{authorizedUsers}}
 #' @export
-addAuthorizedUser <- function(username, password = NULL, appDir = getwd()) {
+addAuthorizedUser <- function(username, password = NULL, appPath = getwd()) {
 
   if (!require(scrypt)) {
     stop("scrypt package is not installed.")
@@ -39,7 +40,7 @@ addAuthorizedUser <- function(username, password = NULL, appDir = getwd()) {
   hash <- paste("{scrypt}", hashPassword(password), sep="")
 
   # read password file
-  path <- getPasswordFile(appDir)
+  path <- getPasswordFile(appPath)
   if (file.exists(path)) {
     passwords <- readPasswordFile(path)
   } else {
@@ -70,7 +71,8 @@ addAuthorizedUser <- function(username, password = NULL, appDir = getwd()) {
 #' Remove authorized user from an application
 #'
 #' @param username The user name.
-#' @param appDir Directory containing application. Defaults to current working directory.
+#' @param appPath Directory or file that was deployed. Defaults to current
+#'   working directory.
 #' @examples
 #' \dontrun{
 #'
@@ -80,10 +82,10 @@ addAuthorizedUser <- function(username, password = NULL, appDir = getwd()) {
 #' }
 #' @seealso \code{\link{addAuthorizedUser}} and \code{\link{authorizedUsers}}
 #' @export
-removeAuthorizedUser <- function(username, appDir = getwd()) {
+removeAuthorizedUser <- function(username, appPath = getwd()) {
 
   # read password file
-  path <- getPasswordFile(appDir)
+  path <- getPasswordFile(appPath)
   if (file.exists(path)) {
     passwords <- readPasswordFile(path)
   } else {
@@ -104,12 +106,13 @@ removeAuthorizedUser <- function(username, appDir = getwd()) {
 
 #' List authorized users for an application
 #'
-#' @param appDir Directory containing application. Defaults to current working directory.
+#' @param appPath Directory or file that was deployed. Defaults to current
+#'   working directory.
 #' @export
-authorizedUsers <- function(appDir = getwd()) {
+authorizedUsers <- function(appPath = getwd()) {
 
   # read password file
-  path <- getPasswordFile(appDir)
+  path <- getPasswordFile(appPath)
   if (file.exists(path)) {
     passwords <- readPasswordFile(path)
   } else {
@@ -164,16 +167,16 @@ promptPassword <- function() {
   return(password.one)
 }
 
-getPasswordFile <- function(appDir) {
-  if (!isStringParam(appDir))
-    stop(stringParamErrorMessage("appDir"))
+getPasswordFile <- function(appPath) {
+  if (!isStringParam(appPath))
+    stop(stringParamErrorMessage("appPath"))
 
-  # normalize appDir path and ensure it exists
-  appDir <- normalizePath(appDir, mustWork = FALSE)
-  if (!file.exists(appDir) || !file.info(appDir)$isdir)
-    stop(appDir, " is not a valid directory", call. = FALSE)
+  # normalize appPath and ensure it exists
+  appPath <- normalizePath(appPath, mustWork = FALSE)
+  if (!file.exists(appPath) || !file.info(appPath)$isdir)
+    stop(appPath, " is not a valid file or directory", call. = FALSE)
 
-  dataDir <- file.path(appDir, "rsconnect")
+  dataDir <- rsconnectRootPath(appPath)
   if (!file.exists(dataDir))
     dir.create(dataDir, recursive=TRUE)
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -47,7 +47,10 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryRmd, accountInfo) {
   )
 
   # get application users
-  users <- authorizedUsers(appDir)
+  users <- authorizedUsers(if (is.null(appPrimaryRmd))
+                               appDir
+                          else
+                               file.path(appDir, appPrimaryRmd))
 
   # generate the manifest and write it into the bundle dir
   manifestJson <- enc2utf8(createAppManifest(bundleDir, accountInfo, appFiles,

--- a/R/configureApp.R
+++ b/R/configureApp.R
@@ -75,10 +75,10 @@ configureApp <- function(appName, appDir=getwd(), account = NULL, server = NULL,
 #' @param propertyName Name of property to set
 #' @param propertyValue Nalue to set property to
 #' @param appName Name of application
-#' @param appDir Directory containing application. Defaults to
-#'   current working directory.
-#' @param account Account name. If a single account is registered on the
-#'   system then this parameter can be omitted.
+#' @param appPath Directory or file that was deployed. Defaults to current
+#'   working directory.
+#' @param account Account name. If a single account is registered on the system
+#'   then this parameter can be omitted.
 #' @param force Forcibly set the property
 #'
 #' @note This function only works for ShinyApps servers.
@@ -94,11 +94,11 @@ configureApp <- function(appName, appDir=getwd(), account = NULL, server = NULL,
 #'
 #' }
 #' @export
-setProperty <- function(propertyName, propertyValue, appDir=getwd(),
-                        appName=NULL, account = NULL, force=FALSE) {
+setProperty <- function(propertyName, propertyValue, appPath = getwd(),
+                        appName = NULL, account = NULL, force = FALSE) {
 
   # resolve the application target and target account info
-  target <- deploymentTarget(appDir, appName, account)
+  target <- deploymentTarget(appPath, appName, account)
   accountInfo <- accountInfo(target$account)
   lucid <- lucidClient(.lucidServerInfo$url, accountInfo)
   application <- getAppByName(lucid, accountInfo, target$appName)
@@ -119,8 +119,8 @@ setProperty <- function(propertyName, propertyValue, appDir=getwd(),
 #'
 #' @param propertyName Name of property to unset
 #' @param appName Name of application
-#' @param appDir Directory containing application. Defaults to current working
-#'   directory.
+#' @param appPath Directory or file that was deployed. Defaults to current
+#'   working directory.
 #' @param account Account name. If a single account is registered on the system
 #'   then this parameter can be omitted.
 #' @param force Forcibly unset the property
@@ -135,11 +135,11 @@ setProperty <- function(propertyName, propertyValue, appDir=getwd(),
 #'
 #' }
 #' @export
-unsetProperty <- function(propertyName, appDir=getwd(), appName=NULL,
+unsetProperty <- function(propertyName, appPath = getwd(), appName=NULL,
                           account = NULL, force=FALSE) {
 
   # resolve the application target and target account info
-  target <- deploymentTarget(appDir, appName, account)
+  target <- deploymentTarget(appPath, appName, account)
   accountInfo <- accountInfo(target$account)
   lucid <- lucidClient(.lucidServerInfo$url, accountInfo)
   application <- getAppByName(lucid, accountInfo, target$appName)
@@ -158,18 +158,18 @@ unsetProperty <- function(propertyName, appDir=getwd(), appName=NULL,
 #' Show propreties of an application deployed to ShinyApps.
 #'
 #' @param appName Name of application
-#' @param appDir Directory containing application. Defaults to
-#'   current working directory.
+#' @param appPath Directory or file that was deployed. Defaults to current
+#'   working directory.
 #' @param account Account name. If a single account is registered on the
 #'   system then this parameter can be omitted.
 #'
 #' @note This function works only for ShinyApps servers.
 #'
 #' @export
-showProperties <- function(appDir=getwd(), appName=NULL, account = NULL) {
+showProperties <- function(appPath = getwd(), appName = NULL, account = NULL) {
 
   # determine the log target and target account info
-  target <- deploymentTarget(appDir, appName, account)
+  target <- deploymentTarget(appPath, appName, account)
   accountInfo <- accountInfo(target$account)
   lucid <- lucidClient(.lucidServerInfo$url, accountInfo)
   application <- getAppByName(lucid, accountInfo, target$appName)

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -322,7 +322,8 @@ deploymentTarget <- function(appPath, appName, account, server = NULL) {
   # neither specified but a single existing deployment
   else if (nrow(appDeployments) == 1) {
 
-    createDeploymentTarget(appName, appDeployments$account,
+    createDeploymentTarget(appDeployments$name,
+                           appDeployments$account,
                            appDeployments$server)
 
   }

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -314,7 +314,9 @@ deploymentTarget <- function(appPath, appName, account, server = NULL) {
       }
     }
     accountDetails <- accountInfo(account, server)
-    createDeploymentTarget(basename(appDir), account, accountDetails$server)
+    createDeploymentTarget(
+      tools::file_path_sans_ext(basename(appPath)),
+      account, accountDetails$server)
   }
 
   # neither specified but a single existing deployment
@@ -331,7 +333,9 @@ deploymentTarget <- function(appPath, appName, account, server = NULL) {
     # single account we can default to
     if (length(accounts) == 1) {
       accountDetails <- accountInfo(accounts)
-      createDeploymentTarget(basename(appDir), accounts, accountDetails$server)
+      createDeploymentTarget(
+        tools::file_path_sans_ext(basename(appPath)),
+        accounts, accountDetails$server)
     }
     else
       stop("Please specify the account and server to which you want to deploy ",

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -74,6 +74,15 @@ deployApp <- function(appDir = getwd(),
     stop(appDir, " does not exist")
   }
 
+  # create the full path that we'll deploy (append document if requested)
+  appPath <- appDir
+  if (!is.null(appPrimaryRmd)) {
+    appPath <- file.path(appPath, appPrimaryRmd)
+    if (!file.exists(appPath)) {
+      stop(appPath, " does not exist")
+    }
+  }
+
   # if a specific file is named, make sure it's an Rmd, and just deploy a single
   # document in this case
   rmdFile <- ""
@@ -142,7 +151,7 @@ deployApp <- function(appDir = getwd(),
   # initialize connect client
 
   # determine the deployment target and target account info
-  target <- deploymentTarget(appDir, appName, account, server)
+  target <- deploymentTarget(appPath, appName, account, server)
   accountDetails <- accountInfo(target$account, target$server)
   client <- clientForAccount(accountDetails)
 
@@ -180,7 +189,7 @@ deployApp <- function(appDir = getwd(),
   }
 
   # save the deployment info for subsequent updates
-  saveDeployment(appDir,
+  saveDeployment(appPath,
                  target$appName,
                  target$account,
                  accountDetails$server,
@@ -220,7 +229,7 @@ deployApp <- function(appDir = getwd(),
 
 # calculate the deployment target based on the passed parameters and
 # any saved deployments that we have
-deploymentTarget <- function(appDir, appName, account, server = NULL) {
+deploymentTarget <- function(appPath, appName, account, server = NULL) {
 
   # read existing accounts
   accounts <- accounts(server)[,"name"]
@@ -236,14 +245,14 @@ deploymentTarget <- function(appDir, appName, account, server = NULL) {
   }
 
   # read existing deployments
-  appDeployments <- deployments(appDir)
+  appDeployments <- deployments(appPath = appPath)
 
   # function to create a deployment target list (checks whether the target
   # is an update and adds that field)
   createDeploymentTarget <- function(appName, account, server) {
 
     # check to see whether this is an update
-    existingDeployment <- deployments(appDir,
+    existingDeployment <- deployments(appPath,
                                       nameFilter = appName,
                                       accountFilter = account,
                                       serverFilter = server)
@@ -265,7 +274,8 @@ deploymentTarget <- function(appDir, appName, account, server = NULL) {
   else if (!is.null(appName)) {
 
     # find any existing deployments of this application
-    appDeployments <- deployments(appDir, nameFilter = appName)
+    appDeployments <- deployments(appPath,
+                                  nameFilter = appName)
 
     # if there are none then we can create it if there is a single account
     # registered that we can default to

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -1,16 +1,17 @@
 
 
-saveDeployment <- function(appDir, name, account, server, bundleId, url) {
+saveDeployment <- function(appPath, name, account, server, bundleId, url) {
 
   deployment <- deploymentRecord(name, account, server, bundleId, url)
-  write.dcf(deployment, deploymentFile(appDir, name, account, server))
+  write.dcf(deployment, deploymentFile(appPath, name, account, server))
   invisible(NULL)
 }
 
 #' List Application Deployments
 #'
-#' List deployment records for a given application directory.
-#' @param appDir The directory from which to read deployment records.
+#' List deployment records for a given application.
+#' @param appPath The path to the content that was deployed, either a directory
+#'   or an individual document.
 #' @param nameFilter Return only deployments matching the given name (optional)
 #' @param accountFilter Return only deployments matching the given account
 #'   (optional)
@@ -34,15 +35,22 @@ saveDeployment <- function(appDir, name, account, server, bundleId, url) {
 #' @seealso \code{\link{applications}} to get a list of deployments from the
 #'   server, and \code{\link{deployApp}} to create a new deployment.
 #' @export
-deployments <- function(appDir, nameFilter = NULL, accountFilter = NULL,
+deployments <- function(appPath, nameFilter = NULL, accountFilter = NULL,
                         serverFilter = NULL) {
 
   # calculate rsconnect dir
-  rsconnectDir <- file.path(appDir, "rsconnect")
+  rsconnectDir <- rsconnectRootPath(appPath)
 
   # migrate shinyapps package created records if necessary
   shinyappsDir <- file.path(appDir, "shinyapps")
   if (file.exists(shinyappsDir)) {
+    # calculate migration dir--all shinyapps deployment records go into the root
+    # folder since it wasn't possible to deploy individual docs using the
+    # shinyapps package
+    migrateDir <- file.path(if (isDocumentPath(appPath)) dirname(appPath)
+                            else appPath,
+                            "rsconnect")
+
     for (shinyappsFile in list.files(shinyappsDir, glob2rx("*.dcf"),
                                      recursive = TRUE)) {
       # read deployment record
@@ -52,7 +60,7 @@ deployments <- function(appDir, nameFilter = NULL, accountFilter = NULL,
       deployment$server <- "shinyapps.io"
 
       # write the new record
-      rsconnectDCF <- file.path(rsconnectDir, "shinyapps.io", shinyappsFile)
+      rsconnectDCF <- file.path(migrateDir, "shinyapps.io", shinyappsFile)
       dir.create(dirname(rsconnectDCF), showWarnings = FALSE, recursive = TRUE)
       write.dcf(deployment, rsconnectDCF)
 
@@ -116,8 +124,8 @@ deployments <- function(appDir, nameFilter = NULL, accountFilter = NULL,
   deploymentRecs
 }
 
-deploymentFile <- function(appDir, name, account, server) {
-  accountDir <- file.path(appDir, "rsconnect", server, account)
+deploymentFile <- function(appPath, name, account, server) {
+  accountDir <- file.path(rsconnectRootPath(appPath), server, account)
   if (!file.exists(accountDir))
     dir.create(accountDir, recursive=TRUE)
   file.path(accountDir, paste(name, ".dcf", sep=""))

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -41,16 +41,15 @@ deployments <- function(appPath, nameFilter = NULL, accountFilter = NULL,
   # calculate rsconnect dir
   rsconnectDir <- rsconnectRootPath(appPath)
 
-  # migrate shinyapps package created records if necessary
-  shinyappsDir <- file.path(appDir, "shinyapps")
-  if (file.exists(shinyappsDir)) {
-    # calculate migration dir--all shinyapps deployment records go into the root
-    # folder since it wasn't possible to deploy individual docs using the
-    # shinyapps package
-    migrateDir <- file.path(if (isDocumentPath(appPath)) dirname(appPath)
-                            else appPath,
-                            "rsconnect")
+  # calculate migration dir--all shinyapps deployment records go into the root
+  # folder since it wasn't possible to deploy individual docs using the
+  # shinyapps package
+  migrateRoot <- if (isDocumentPath(appPath)) dirname(appPath) else appPath
 
+  # migrate shinyapps package created records if necessary
+  shinyappsDir <- file.path(migrateRoot, "shinyapps")
+  if (file.exists(shinyappsDir)) {
+    migrateDir <- file.path(migrateRoot, "rsconnect")
     for (shinyappsFile in list.files(shinyappsDir, glob2rx("*.dcf"),
                                      recursive = TRUE)) {
       # read deployment record

--- a/R/tasks.R
+++ b/R/tasks.R
@@ -83,7 +83,7 @@ taskLog <- function(taskId, account = NULL, server = NULL, output = NULL) {
 
   # get child task logs
   for (task in tasks) {
-    taskLog(task['id'], account, output)
+    taskLog(task['id'], account = account, server = server, output = output)
   }
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -140,3 +140,17 @@ fileLeaf <- function(path) {
     component[length(component)]
   }))
 }
+
+# whether the given path points to an R Markdown document
+isDocumentPath <- function(path) {
+  identical(tolower(tools::file_ext(path)), "rmd")
+}
+
+# given a path, return the directory under which rsconnect package state is
+# stored
+rsconnectRootPath <- function(appPath) {
+  if (isDocumentPath(appPath))
+    file.path(dirname(appPath), "rsconnect", basename(appPath))
+  else
+    file.path(appPath, "rsconnect")
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -150,7 +150,7 @@ isDocumentPath <- function(path) {
 # stored
 rsconnectRootPath <- function(appPath) {
   if (isDocumentPath(appPath))
-    file.path(dirname(appPath), "rsconnect", basename(appPath))
+    file.path(dirname(appPath), "rsconnect", "documents", basename(appPath))
   else
     file.path(appPath, "rsconnect")
 }

--- a/man/addAuthorizedUser.Rd
+++ b/man/addAuthorizedUser.Rd
@@ -4,14 +4,15 @@
 \alias{addAuthorizedUser}
 \title{Add authorized user for application}
 \usage{
-addAuthorizedUser(username, password = NULL, appDir = getwd())
+addAuthorizedUser(username, password = NULL, appPath = getwd())
 }
 \arguments{
 \item{username}{The user name.}
 
 \item{password}{The password.}
 
-\item{appDir}{Directory containing application. Defaults to current working directory.}
+\item{appPath}{Directory or file that was deployed. Defaults to current
+working directory.}
 }
 \description{
 Add authorized user for application

--- a/man/authorizedUsers.Rd
+++ b/man/authorizedUsers.Rd
@@ -4,10 +4,11 @@
 \alias{authorizedUsers}
 \title{List authorized users for an application}
 \usage{
-authorizedUsers(appDir = getwd())
+authorizedUsers(appPath = getwd())
 }
 \arguments{
-\item{appDir}{Directory containing application. Defaults to current working directory.}
+\item{appPath}{Directory or file that was deployed. Defaults to current
+working directory.}
 }
 \description{
 List authorized users for an application

--- a/man/deployments.Rd
+++ b/man/deployments.Rd
@@ -4,11 +4,12 @@
 \alias{deployments}
 \title{List Application Deployments}
 \usage{
-deployments(appDir, nameFilter = NULL, accountFilter = NULL,
+deployments(appPath, nameFilter = NULL, accountFilter = NULL,
   serverFilter = NULL)
 }
 \arguments{
-\item{appDir}{The directory from which to read deployment records.}
+\item{appPath}{The path to the content that was deployed, either a directory
+or an individual document.}
 
 \item{nameFilter}{Return only deployments matching the given name (optional)}
 
@@ -28,7 +29,7 @@ Returns a data frame with the following columns:
 }
 }
 \description{
-List deployment records for a given application directory.
+List deployment records for a given application.
 }
 \examples{
 \dontrun{

--- a/man/removeAuthorizedUser.Rd
+++ b/man/removeAuthorizedUser.Rd
@@ -4,12 +4,13 @@
 \alias{removeAuthorizedUser}
 \title{Remove authorized user from an application}
 \usage{
-removeAuthorizedUser(username, appDir = getwd())
+removeAuthorizedUser(username, appPath = getwd())
 }
 \arguments{
 \item{username}{The user name.}
 
-\item{appDir}{Directory containing application. Defaults to current working directory.}
+\item{appPath}{Directory or file that was deployed. Defaults to current
+working directory.}
 }
 \description{
 Remove authorized user from an application

--- a/man/setProperty.Rd
+++ b/man/setProperty.Rd
@@ -4,7 +4,7 @@
 \alias{setProperty}
 \title{Set Application property}
 \usage{
-setProperty(propertyName, propertyValue, appDir = getwd(), appName = NULL,
+setProperty(propertyName, propertyValue, appPath = getwd(), appName = NULL,
   account = NULL, force = FALSE)
 }
 \arguments{
@@ -12,13 +12,13 @@ setProperty(propertyName, propertyValue, appDir = getwd(), appName = NULL,
 
 \item{propertyValue}{Nalue to set property to}
 
-\item{appDir}{Directory containing application. Defaults to
-current working directory.}
+\item{appPath}{Directory or file that was deployed. Defaults to current
+working directory.}
 
 \item{appName}{Name of application}
 
-\item{account}{Account name. If a single account is registered on the
-system then this parameter can be omitted.}
+\item{account}{Account name. If a single account is registered on the system
+then this parameter can be omitted.}
 
 \item{force}{Forcibly set the property}
 }

--- a/man/showLogs.Rd
+++ b/man/showLogs.Rd
@@ -4,15 +4,14 @@
 \alias{showLogs}
 \title{Show Application Logs}
 \usage{
-showLogs(appDir = getwd(), appName = NULL, account = NULL, entries = 50,
-  streaming = FALSE)
+showLogs(appPath = getwd(), appFile = NULL, appName = NULL,
+  account = NULL, entries = 50, streaming = FALSE)
 }
 \arguments{
-\item{appDir}{The directory where the local copy of the application
-resides.}
+\item{appPath}{The path to the directory or file that was deployed.}
 
 \item{appName}{The name of the application to show logs for. May be omitted
-if only one application deployment was made from \code{appDir}.}
+if only one application deployment was made from \code{appPath}.}
 
 \item{account}{The account under which the application was deployed. May be
 omitted if only one account is registered on the system.}

--- a/man/showProperties.Rd
+++ b/man/showProperties.Rd
@@ -4,11 +4,11 @@
 \alias{showProperties}
 \title{Show Application property}
 \usage{
-showProperties(appDir = getwd(), appName = NULL, account = NULL)
+showProperties(appPath = getwd(), appName = NULL, account = NULL)
 }
 \arguments{
-\item{appDir}{Directory containing application. Defaults to
-current working directory.}
+\item{appPath}{Directory or file that was deployed. Defaults to current
+working directory.}
 
 \item{appName}{Name of application}
 

--- a/man/unsetProperty.Rd
+++ b/man/unsetProperty.Rd
@@ -4,14 +4,14 @@
 \alias{unsetProperty}
 \title{Unset Application property}
 \usage{
-unsetProperty(propertyName, appDir = getwd(), appName = NULL,
+unsetProperty(propertyName, appPath = getwd(), appName = NULL,
   account = NULL, force = FALSE)
 }
 \arguments{
 \item{propertyName}{Name of property to unset}
 
-\item{appDir}{Directory containing application. Defaults to current working
-directory.}
+\item{appPath}{Directory or file that was deployed. Defaults to current
+working directory.}
 
 \item{appName}{Name of application}
 


### PR DESCRIPTION
This change alters the way deployment records are stored when individual documents are deployed, with the goal of making deployments of individual documents feel like first-class operations rather than scoped deployments of their parent directories. 

Formerly, all records for any deployment made from a directory were stored in a subdirectory called `rsconnect`, which was further partitioned into folders for servers and username.

    rsconnect
    | 
    +--servername
       |
       +--username 
          |
          +--appname1.dcf
          |
          +--appname2.dcf
    
After the change, there's a new folder beneath `rsconnect` that stores deployment records for individual documents; each document has its own `rsconnect/documents/docname.Rmd` folder. The structure of this folder mirrors that of the deployment records for the directory as a whole. (Note that it's relatively unlikely that the same directory will contain both directory-level and document-level deployments). 

    rsconnect
    | 
    +--documents
    |  |
    |  +--mydocument.Rmd
    |     |
    |     +--servername
    |        |
    |        +--username 
    |           |
    |           +--appname1.dcf
    |           |
    |           +--appname2.dcf
    |
    +--servername
       |
       +--username 
          |
          +--appname3.dcf
          |
          +--appname4.dcf
    

Most of the functions that formerly took an `appDir` to specify a directory now take an `appPath`, which can refer either to a directory or an individual document. For instance, to show the logs for an individual document after deploying it:

    rsconnect::showLogs("~/mydir/myfile.Rmd")

