### PR TITLE
Add content category field to app manifest

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rsconnect
 Type: Package
 Title: Deployment Interface for Shiny Applications
-Version: 0.3.79
+Version: 0.3.80
 Date: 2013-11-03
 Author: JJ Allaire
 Maintainer: JJ Allaire <jj@rstudio.com>

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -15,7 +15,8 @@ bundleFiles <- function(appDir) {
   files
 }
 
-bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, accountInfo) {
+bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, contentCategory,
+                      accountInfo) {
 
   # create a directory to stage the application bundle in
   bundleDir <- tempfile()
@@ -46,8 +47,9 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, accountInfo) {
                                file.path(appDir, appPrimaryDoc))
 
   # generate the manifest and write it into the bundle dir
-  manifestJson <- enc2utf8(createAppManifest(bundleDir, appMode, accountInfo, appFiles,
-                                             appPrimaryDoc, users))
+  manifestJson <- enc2utf8(createAppManifest(bundleDir, appMode,
+                                             contentCategory, accountInfo,
+                                             appFiles, appPrimaryDoc, users))
   writeLines(manifestJson, file.path(bundleDir, "manifest.json"),
              useBytes = TRUE)
 
@@ -116,8 +118,8 @@ inferAppMode <- function(appDir, files) {
   return(NA)
 }
 
-createAppManifest <- function(appDir, appMode, accountInfo, files,
-                              appPrimaryDoc, users) {
+createAppManifest <- function(appDir, appMode, contentCategory, accountInfo,
+                              files, appPrimaryDoc, users) {
 
   # provide package entries for all dependencies
   packages <- list()
@@ -222,6 +224,9 @@ createAppManifest <- function(appDir, appMode, accountInfo, files,
   metadata$primary_rmd <- ifelse(grepl("\\brmd\\b", appMode), primaryDoc, NA)
   metadata$primary_html <- ifelse(appMode == "static", primaryDoc, NA)
 
+  # emit content category (plots, etc)
+  metadata$content_category <- ifelse(!is.null(contentCategory),
+                                      contentCategory, NA)
   # add metadata
   manifest$metadata <- metadata
 

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -18,6 +18,8 @@
 #'   \code{\link{deployments}} is associated with the source document.
 #' @param appName Name of application (names must be unique within an
 #'   account). Defaults to the base name of the specified \code{appDir}.
+#' @param contentCategory Optional; the kind of content being deployed (e.g.
+#'   \code{"plot"}, \code{"document"}, or \code{"application"}).
 #' @param account Account to deploy application to. This
 #'   parameter is only required for the initial deployment of an application
 #'   when there are multiple accounts configured on the system (see
@@ -66,6 +68,7 @@ deployApp <- function(appDir = getwd(),
                       appPrimaryDoc = NULL,
                       appSourceDoc = NULL,
                       appName = NULL,
+                      contentCategory = NULL,
                       account = NULL,
                       server = NULL,
                       upload = TRUE,
@@ -192,7 +195,7 @@ deployApp <- function(appDir = getwd(),
     withStatus(paste("Uploading bundle for application:",
                      application$id), {
       bundlePath <- bundleApp(target$appName, appDir, appFiles,
-                              appPrimaryDoc, accountDetails)
+                              appPrimaryDoc, contentCategory, accountDetails)
       bundle <- client$uploadApplication(application$id, bundlePath)
     })
   } else {

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -5,9 +5,10 @@
 \title{Deploy an Application}
 \usage{
 deployApp(appDir = getwd(), appFiles = NULL, appPrimaryDoc = NULL,
-  appSourceDoc = NULL, appName = NULL, account = NULL, server = NULL,
-  upload = TRUE, launch.browser = getOption("rsconnect.launch.browser",
-  interactive()), quiet = FALSE, lint = TRUE, metadata = list(), ...)
+  appSourceDoc = NULL, appName = NULL, contentCategory = NULL,
+  account = NULL, server = NULL, upload = TRUE,
+  launch.browser = getOption("rsconnect.launch.browser", interactive()),
+  quiet = FALSE, lint = TRUE, metadata = list(), ...)
 }
 \arguments{
 \item{appDir}{Directory containing application. Defaults to current working
@@ -29,6 +30,9 @@ qualified path. Deployment information returned by
 
 \item{appName}{Name of application (names must be unique within an
 account). Defaults to the base name of the specified \code{appDir}.}
+
+\item{contentCategory}{Optional; the kind of content being deployed (e.g.
+\code{"plot"}, \code{"document"}, or \code{"application"}).}
 
 \item{account}{Account to deploy application to. This
 parameter is only required for the initial deployment of an application


### PR DESCRIPTION
This change adds a new field to the application manifest's freeform metadata field, set via a new `contentCategory` argument to `deployApp`. 

The new field is intended to help the server distinguish among different kinds of static HTML content (for instance, plots and documents). 
