### PR TITLE
Use the server-provided application url as-is.

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -247,19 +247,8 @@ deployApp <- function(appDir = getwd(),
     }
   }
 
-  # append the file to be launched to the URL if necessary
-  amendedUrl <- application$url
-
-  # check for a launch file (i.e. an Rmd file)
-  launchFile <- if (nzchar(rmdFile)) rmdFile else guessLaunchFile(appDir)
-  if (length(launchFile) > 0 && nchar(launchFile) > 0) {
-    if (substr(amendedUrl, nchar(amendedUrl), nchar(amendedUrl)) != "/")
-      amendedUrl = paste(amendedUrl, "/", sep = "")
-    amendedUrl = paste(amendedUrl, launchFile, sep = "")
-  }
-
   # launch the browser if requested
-  showURL(amendedUrl)
+  showURL(application$url)
 
   # successful deployment!
   invisible(TRUE)
@@ -426,29 +415,4 @@ applicationForTarget <- function(client, accountInfo, target) {
 
   # return the application
   app
-}
-
-# given a directory, return the name of the file from the directory to launch,
-# or an empty string if it's meaningful to launch the directory with no file.
-guessLaunchFile <- function(appDir) {
-  # no file to launch for Shiny, or for folders with an index.Rmd
-  if (file.exists(file.path(appDir, "ui.R")) ||
-      file.exists(file.path(appDir, "server.R")) ||
-      file.exists(file.path(appDir, "index.Rmd")))
-    return("")
-
-  # otherwise, guess an Rmd to launch
-  appFiles <- list.files(path = appDir, pattern = glob2rx("*.Rmd"),
-                         recursive = FALSE, ignore.case = TRUE)
-
-  # no Rmd to launch? how about an HTML file?
-  if (length(appFiles) == 0) {
-    appFiles <- list.files(path = appDir, pattern = glob2rx("*.html"),
-                           recursive = FALSE, ignore.case = TRUE)
-  }
-
-  # launch whichever file was most recently saved in the folder (presumably the
-  # one the user has been working on)
-  appFileInfo <- file.info(file.path(appDir, appFiles))
-  appFiles[which.max(appFileInfo$mtime)]
 }


### PR DESCRIPTION
@jmcphers Were there situations where the `amendedUrl` was necessary? It feels as if the server has more complete information about how to serve this content.

Fixes #33.