### PR TITLE
Don't post-process gathered content from HTTP responses with RCurl

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -1,0 +1,51 @@
+handleResponse <- function(response, jsonFilter = NULL) {
+
+  # function to report errors
+  reportError <- function(msg) {
+    stop(paste(response$path, response$status, "-", msg), call. = FALSE)
+  }
+
+  # json responses
+  if (isContentType(response, "application/json")) {
+
+    json <- RJSONIO::fromJSON(response$content, simplify = FALSE)
+
+    if (response$status %in% 200:399)
+      if (!is.null(jsonFilter))
+        jsonFilter(json)
+      else
+        json
+    else if (!is.null(json$error))
+      reportError(json$error)
+    else
+      reportError(paste("Unexpected json response:", response$content))
+  }
+
+  # for html responses we can attempt to extract the body
+  else if (isContentType(response, "text/html")) {
+
+    body <- regexExtract(".*?<body>(.*?)</body>.*", response$content)
+    if (response$status >= 200 && response$status < 400){
+      # Good response, return the body if we have one, or the content if not
+      if (!is.null(body)){
+        body
+      } else{
+        response$content
+      }
+    } else {
+      # Error response
+      if (!is.null(body))
+        reportError(body)
+      else
+        reportError(response$content)
+    }
+  }
+
+  # otherwise just dump the whole thing
+  else {
+    if (response$status %in% 200:399)
+      response$content
+    else
+      reportError(response$content)
+  }
+}

--- a/R/connect.R
+++ b/R/connect.R
@@ -202,50 +202,6 @@ listRequest = function(service, authInfo, path, query, listName, page = 100,
   return(results)
 }
 
-handleResponse <- function(response, jsonFilter = NULL) {
-
-  # function to report errors
-  reportError <- function(msg) {
-    stop(paste(response$path, response$status, "-", msg), call. = FALSE)
-  }
-
-  # json responses
-  if (isContentType(response, "application/json")) {
-
-    json <- RJSONIO::fromJSON(response$content, simplify = FALSE)
-
-    if (response$status %in% 200:399)
-      if (!is.null(jsonFilter))
-        jsonFilter(json)
-      else
-        json
-    else if (!is.null(json$error))
-      reportError(json$error)
-    else
-      reportError(paste("Unexpected json response:", response$content))
-  }
-
-  # for html responses we can attempt to extract the body
-  else if (isContentType(response, "text/html")) {
-
-    body <- regexExtract(".*?<body>(.*?)</body>.*", response$content)
-    if (response$status %in% 200:399)
-      body
-    else if (!is.null(body))
-      reportError(body)
-    else
-      reportError(response$content)
-  }
-
-  # otherwise just dump the whole thing
-  else {
-    if (response$status %in% 200:399)
-      response$content
-    else
-      reportError(response$content)
-  }
-}
-
 filterQuery <- function(param, value, operator = NULL) {
   if (is.null(operator)) {
     op <- ":"

--- a/R/http.R
+++ b/R/http.R
@@ -253,8 +253,12 @@ httpRCurl <- function(protocol,
   options$cainfo <- system.file("cert/cacert.pem", package = "rsconnect")
   headerGatherer <- RCurl::basicHeaderGatherer()
   options$headerfunction <- headerGatherer$update
+
+  # the text processing done by .mapUnicode has the unfortunate side effect
+  # of turning escaped backslashes into ordinary backslashes but leaving
+  # ordinary backslashes alone, which can create malformed JSON.
   textGatherer <- if (is.null(writer))
-      RCurl::basicTextGatherer()
+      RCurl::basicTextGatherer(.mapUnicode = FALSE)
     else
       writer
 

--- a/R/lucid.R
+++ b/R/lucid.R
@@ -193,58 +193,6 @@ listRequest = function(service, authInfo, path, query, listName, page = 100,
   return(results)
 }
 
-handleResponse <- function(response, jsonFilter = NULL) {
-
-  # function to report errors
-  reportError <- function(msg) {
-    stop(paste(response$path, response$status, "-", msg), call. = FALSE)
-  }
-
-  # json responses
-  if (isContentType(response, "application/json")) {
-
-    json <- RJSONIO::fromJSON(response$content, simplify = FALSE)
-
-    if (response$status %in% 200:399)
-      if (!is.null(jsonFilter))
-        jsonFilter(json)
-      else
-        json
-    else if (!is.null(json$error))
-      reportError(json$error)
-    else
-      reportError(paste("Unexpected json response:", response$content))
-  }
-
-  # for html responses we can attempt to extract the body
-  else if (isContentType(response, "text/html")) {
-
-    body <- regexExtract(".*?<body>(.*?)</body>.*", response$content)
-    if (response$status >= 200 && response$status < 400){
-      # Good response, return the body if we have one, or the content if not
-      if (!is.null(body)){
-        body
-      } else{
-        response$content
-      }
-    } else {
-      # Error response
-      if (!is.null(body))
-        reportError(body)
-      else
-        reportError(response$content)
-    }
-  }
-
-  # otherwise just dump the whole thing
-  else {
-    if (response$status %in% 200:399)
-      response$content
-    else
-      reportError(response$content)
-  }
-}
-
 filterQuery <- function(param, value, operator = NULL) {
   if (is.null(operator)) {
     op <- ":"


### PR DESCRIPTION
This change fixes a bug in which RSConnect can mangle returned JSON. 

RCurl's `basicTextGatherer`, with default settings, attempts to decode Unicode escape sequences of the form `\u0000`. Unfortunately, it also has a side effect: it turns sequences of two backslashes into one backslash, but leaves sequences of one backslash alone. This means that backslashes that were formerly escaped become meaningful, and if they are in an unlucky location (such as next to a quote), they will make the entire text unparseable.

Since there's no known need to decode Unicode escape sequences here, the fix is just to turn off this RCurl feature for our usage. 

(I've also de-duped `handleResponse` since there's no need for separate connect/lucid copies of this function.)