### PR TITLE
Add rsconnect.http.trace.json for showing JSON sent/received

### DIFF
--- a/man/options.Rd
+++ b/man/options.Rd
@@ -19,6 +19,7 @@ Supported global options include:
    If no option is specified then \code{rcurl} is used by default.
    }
    \item{\code{rsconnect.http.trace}}{When \code{TRUE}, trace http calls (prints the method, path, and total milliseconds for each http request)}
+   \item{\code{rsconnect.http.trace.json}}{When \code{TRUE}, trace JSON content (shows JSON payloads sent to and received from the server))}
    \item{\code{rsconnect.http.verbose}}{When \code{TRUE}, print verbose output for http connections (useful only for debugging SSL certificate or http connection problems)}
    \item{\code{rsconnect.launch.browser}}{When \code{TRUE}, automatically launch a browser to view applications after they are deployed}
    \item{\code{rsconnect.locale.cache}}{When \code{FALSE}, disable the detected locale cache (Windows only). }
@@ -37,6 +38,9 @@ options(rsconnect.http.trace = TRUE)
 
 # print verbose output for http requests
 options(rsconnect.http.verbose = TRUE)
+
+# print JSON content
+options(rsconnect.http.trace.json = TRUE)
 
 # don't automatically launch a browser after deployment
 options(rsconnect.launch.browser = FALSE)


### PR DESCRIPTION
This change adds a new JSON tracing option to rsconnect. It's designed to work with the http tracing already built into the package, and shows both the JSON sent to and received from the server.

With `rsconnect.http.trace`:

    POST /__api__/applications/3/deploy 1086ms

With `rsconnect.http.trace.json`, too:

    POST /__api__/applications/3/deploy 1086ms
    << {
    	"bundle" : 47
    }
    >> {"id":43,"user_id":1,"status":["Deploying to R version '3.2.0' (Local version is '3.2.0')","Packrat version: 0.4.3.27"],"finished":false,"code":0,"error":"","last_status":"2"}

