### PR TITLE
Don't attempt to read authorized users for doc deployments

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -54,11 +54,11 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, contentCategory,
     }
   }
 
-  # get application users
-  users <- suppressWarnings(authorizedUsers(if (is.null(appPrimaryDoc))
-                                                appDir
-                                            else
-                                                file.path(appDir, appPrimaryDoc)))
+  # get application users (for non-document deployments)
+  users <- NULL
+  if (is.null(appPrimaryDoc)) {
+    users <- suppressWarnings(authorizedUsers(appDir))
+  }
 
   # generate the manifest and write it into the bundle dir
   manifestJson <- enc2utf8(createAppManifest(bundleDir, appMode,


### PR DESCRIPTION
Change https://github.com/rstudio/rsconnect/commit/029251d50da4697ab4dc71545a4152debb9359fc added some validation for paths when reading the authorized user list. We don't really have a per-document mechanism for storing these lists (and they're deprecated anyway) so this change skips bundling the auth user list when deploying a doc. 