### PR TITLE
don't automatically create shinyapps dir when looking for password file

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -246,12 +246,7 @@ getPasswordFile <- function(appDir) {
   if (!file.exists(appDir) || !file.info(appDir)$isdir)
     stop(appDir, " is not a valid directory", call. = FALSE)
 
-  dataDir <- file.path(appDir, "shinyapps")
-  if (!file.exists(dataDir))
-    dir.create(dataDir, recursive=TRUE)
-
-  passwordFile <- file.path(dataDir, paste("passwords", ".txt", sep=""))
-  return(passwordFile)
+  file.path(appDir, "shinyapps", "passwords.txt")
 }
 
 readPasswordFile <- function(path) {


### PR DESCRIPTION
It may be that previous to the first-gen authorization functions being deprecated we relied on getPasswordFile to actually create the shinyapps directory. This no longer appears to be the case so we can just return the path without creating the directory.

@kippandrew Could you review and merge when you get a chance?
