### PR TITLE
Ensure deployment failure is shown on last line (RStudio Deployment tab)

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -210,15 +210,14 @@ deployApp <- function(appDir = getwd(),
   task <- client$deployApplication(application$id, bundle$id)
   taskId <- if (is.null(task$task_id)) task$id else task$task_id
   response <- client$waitForTask(taskId, quiet)
+  # wait 1/10th of a second for any queued output get picked by RStudio
+  # before emitting the final status, to ensure it's the last line the user sees
+  Sys.sleep(0.10)
   if (!is.null(response$code) && response$code != 0) {
-    # wait 1/10th of a second for any queued output get picked by RStudio
-    # before emitting this, to ensure it's the last line the user sees
-    Sys.sleep(0.10)
     displayStatus(paste0("Application deployment failed with error: ",
                          response$error, "\n"))
     return(invisible(FALSE))
   } else {
-    Sys.sleep(0.10)
     displayStatus(paste0("Application successfully deployed to ",
                         application$url, "\n"))
   }

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -211,10 +211,14 @@ deployApp <- function(appDir = getwd(),
   taskId <- if (is.null(task$task_id)) task$id else task$task_id
   response <- client$waitForTask(taskId, quiet)
   if (!is.null(response$code) && response$code != 0) {
+    # wait 1/10th of a second for any queued output get picked by RStudio
+    # before emitting this, to ensure it's the last line the user sees
+    Sys.sleep(0.10)
     displayStatus(paste0("Application deployment failed with error: ",
                          response$error, "\n"))
     return(invisible(FALSE))
   } else {
+    Sys.sleep(0.10)
     displayStatus(paste0("Application successfully deployed to ",
                         application$url, "\n"))
   }


### PR DESCRIPTION
When deploying content, rsconnect emits to both `stderr` and `stdout`. RStudio displays this content by polling every 100ms for each and displaying the content (if any) emitted to each stream, in turn. If, during this 100ms interval, content was emitted to *both* streams, the output may not appear in the order it was emitted. 

We have a bug on the RStudio side to fix this but it's likely going to be nontrivial; in the meantime, this small change ensures that the failure line is always the last one emitted. 