### PR TITLE
Time out more quickly when validating server URL

### DIFF
--- a/R/ide.R
+++ b/R/ide.R
@@ -16,8 +16,11 @@ validateServerUrl <- function(url) {
   response <- NULL
   errMessage <- ""
   tryCatch({
+    # this shouldn't take more than 10 seconds since it does no work (i.e we
+    # should just be waiting for the network), so timeout quickly to avoid
+    # hanging when the server doesn't accept the connection
     response <- handleResponse(
-      GET(parseHttpUrl(url), NULL, "/server_settings"))
+      GET(parseHttpUrl(url), NULL, "/server_settings", timeout = 10))
   }, error = function(e) {
     errMessage <<- e$message
   })


### PR DESCRIPTION
There's been some feedback that it takes too long to recover when we attempt to validate a server URL that's invalid (i.e. it hangs for a long time waiting for a connection). This change sets up a mechanism by which any HTTP request can specify a timeout, and sets the timeout to 10 seconds during server URL validation. 