### PR TITLE
Write deployment record even for failed deployments

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -214,27 +214,8 @@ deployApp <- function(appDir = getwd(),
     bundle <- application$deployment$bundle
   }
 
-  # wait for the deployment to complete (will raise an error if it can't)
-  displayStatus(paste0("Deploying bundle: ", bundle$id,
-                       " for ", assetTypeName, ": ", application$id,
-                       " ...\n", sep=""))
-  task <- client$deployApplication(application$id, bundle$id)
-  taskId <- if (is.null(task$task_id)) task$id else task$task_id
-  response <- client$waitForTask(taskId, quiet)
-  # wait 1/10th of a second for any queued output get picked by RStudio
-  # before emitting the final status, to ensure it's the last line the user sees
-  Sys.sleep(0.10)
-  deploymentSucceeded <- is.null(response$code) || response$code == 0
-  if (deploymentSucceeded) {
-    displayStatus(paste0(capitalize(assetTypeName), " successfully deployed ",
-                         "to ", application$url, "\n"))
-  } else {
-    displayStatus(paste0(capitalize(assetTypeName), " deployment failed ",
-                         "with error: ", response$error, "\n"))
-  }
-
-  # save the deployment info for subsequent updates; we do this even in the
-  # failure case to make it easy to try again
+  # save the deployment info for subsequent updates--we do this before
+  # attempting the deployment itself to make retry easy on failure
   saveDeployment(appPath,
                  target$appName,
                  target$account,
@@ -243,8 +224,21 @@ deployApp <- function(appDir = getwd(),
                  application$url,
                  metadata)
 
-  if (deploymentSucceeded) {
+  # wait for the deployment to complete (will raise an error if it can't)
+  displayStatus(paste0("Deploying bundle: ", bundle$id,
+                       " for ", assetTypeName, ": ", application$id,
+                       " ...\n", sep=""))
+  task <- client$deployApplication(application$id, bundle$id)
+  taskId <- if (is.null(task$task_id)) task$id else task$task_id
+  response <- client$waitForTask(taskId, quiet)
 
+  # wait 1/10th of a second for any queued output get picked by RStudio
+  # before emitting the final status, to ensure it's the last line the user sees
+  Sys.sleep(0.10)
+
+  deploymentSucceeded <- if (is.null(response$code) || response$code == 0) {
+    displayStatus(paste0(capitalize(assetTypeName), " successfully deployed ",
+                         "to ", application$url, "\n"))
     # function to browse to a URL using user-supplied browser (config or final)
     showURL <- function(url) {
       if (isTRUE(launch.browser))
@@ -265,6 +259,12 @@ deployApp <- function(appDir = getwd(),
 
     # launch the browser if requested
     showURL(application$url)
+
+    TRUE
+  } else {
+    displayStatus(paste0(capitalize(assetTypeName), " deployment failed ",
+                         "with error: ", response$error, "\n"))
+    FALSE
   }
 
   invisible(deploymentSucceeded)


### PR DESCRIPTION
This change is in response to some feedback that a failed deployment adds insult to injury by forcing you to start from scratch if you want to try again; with it, we write a deployment record even for apps that failed to deploy (as long as we created an app and bundle successfully). 