### PR TITLE
Implement sendEmail option for addAuthorizedUser

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -40,11 +40,13 @@ cleanupPasswordFile <- function(appDir) {
 #'   system then this parameter can be omitted.
 #' @param server Server name. Required only if you use the same account name on
 #'   multiple servers.
+#' @param sendEmail Send and email letting the user know the application
+#'   has been shared with them.
 #' @seealso \code{\link{removeAuthorizedUser}} and \code{\link{showUsers}}
 #' @note This function works only for ShinyApps servers.
 #' @export
 addAuthorizedUser <- function(email, appDir=getwd(), appName=NULL,
-                              account = NULL, sendEmail=TRUE, server=NULL) {
+                              account = NULL, server=NULL, sendEmail=NULL) {
 
   # resolve account
   accountDetails <- accountInfo(resolveAccount(account, server), server)
@@ -59,7 +61,7 @@ addAuthorizedUser <- function(email, appDir=getwd(), appName=NULL,
 
   # fetch authoriztion list
   api <- clientForAccount(accountDetails)
-  api$inviteApplicationUser(application$id, validateEmail(email))
+  api$inviteApplicationUser(application$id, validateEmail(email), sendEmail)
 
   message(paste("Added:", email, "to application", sep=" "))
 

--- a/R/lucid.R
+++ b/R/lucid.R
@@ -108,11 +108,16 @@ lucidClient <- function(service, authInfo) {
       handleResponse(POST_JSON(service, authInfo, path, list()))
     },
 
-    inviteApplicationUser = function(applicationId, email) {
+    inviteApplicationUser = function(applicationId, email,
+                                     invite_email=NULL, invite_email_message=NULL) {
       path <- paste("/applications/", applicationId, "/authorization/users",
                     sep="")
       json <- list()
       json$email <- email
+      if (!is.null(invite_email))
+        json$invite_email=invite_email
+      if (!is.null(invite_email_message))
+        json$invite_email_message=invite_email_message
       handleResponse(POST_JSON(service, authInfo, path, json))
     },
 


### PR DESCRIPTION
You can now choose not to automatically have an email sent when adding users to apps hosted on shinyapps.io. This is because some users prefer to send their own messages. Using `addAuthorizedUser(..., sendEmail=FALSE)` to do this. If the user does not have an account you can use  `showInvited()` to retrieve the invite link and send it to them via whatever means suites you (a.k.a carrier pigeon, smoke signals, telepathy, vulcan mind-meld, etc.). 