### PR TITLE
Save application ID; enable app lookup by ID

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -123,6 +123,11 @@ connectClient <- function(service, authInfo) {
         "/applications/", applicationId, "/config", sep="")))
     },
 
+    getApplication = function(applicationId) {
+      handleResponse(GET(service, authInfo, paste0("/applications/",
+                                                   applicationId)))
+    },
+
     ## Tasks API
 
     listTasks = function() {

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -408,6 +408,13 @@ getAppByName <- function(client, accountInfo, name) {
   if (length(app)) app[[1]] else NULL
 }
 
+# get the record for the application with the given ID in the given account
+getAppById <- function(id, account = NULL, server = NULL) {
+  accountDetails <- accountInfo(resolveAccount(account, server), server)
+  client <- clientForAccount(accountDetails)
+  client$getApplication(id)
+}
+
 applicationForTarget <- function(client, accountInfo, target) {
 
   # list the existing applications for this account and see if we

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -220,6 +220,7 @@ deployApp <- function(appDir = getwd(),
                  target$appName,
                  target$account,
                  accountDetails$server,
+                 application$id,
                  bundle$id,
                  application$url,
                  metadata)

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -1,9 +1,9 @@
 
 
-saveDeployment <- function(appPath, name, account, server, bundleId, url,
+saveDeployment <- function(appPath, name, account, server, appId, bundleId, url,
                            metadata) {
 
-  deployment <- deploymentRecord(name, account, server, bundleId, url,
+  deployment <- deploymentRecord(name, account, server, appId, bundleId, url,
                                  when = as.numeric(Sys.time()),
                                  metadata)
   write.dcf(deployment, deploymentFile(appPath, name, account, server))
@@ -96,6 +96,7 @@ deployments <- function(appPath, nameFilter = NULL, accountFilter = NULL,
   deploymentRecs <- deploymentRecord(name = character(),
                                      account = character(),
                                      server = character(),
+                                     appId = character(),
                                      bundleId = character(),
                                      url = character(),
                                      when = numeric())
@@ -164,13 +165,14 @@ deploymentFile <- function(appPath, name, account, server) {
   file.path(accountDir, paste0(name, ".dcf"))
 }
 
-deploymentRecord <- function(name, account, server, bundleId, url, when,
+deploymentRecord <- function(name, account, server, appId, bundleId, url, when,
                              metadata = list()) {
   # compose the standard set of fields and append any requested
   as.data.frame(c(
       list(name = name,
            account = account,
            server = server,
+           appId = appId,
            bundleId = bundleId,
            url = url,
            when = when),

--- a/R/lucid.R
+++ b/R/lucid.R
@@ -45,7 +45,7 @@ lucidClient <- function(service, authInfo) {
 
     getApplication = function(applicationId) {
       path <- paste("/applications/", applicationId, sep="")
-      handleResponse(GET(authInfo, path))
+      handleResponse(GET(service, authInfo, path))
     },
 
     getLogs = function(applicationId, entries = 50, streaming = FALSE,

--- a/R/rpubs.R
+++ b/R/rpubs.R
@@ -151,7 +151,7 @@ rpubsUpload <- function(title,
     recordName <- ifelse(is.null(title) || nchar(title) == 0,
                          basename(recordSource), title)
 
-    rpubsRec <- deploymentRecord(recordName, "rpubs", "rpubs.com", id, url,
+    rpubsRec <- deploymentRecord(recordName, "rpubs", "rpubs.com", id, id, url,
                                  as.numeric(Sys.time()))
     rpubsRecFile <- deploymentFile(recordSource, recordName, "rpubs",
                                    "rpubs.com")


### PR DESCRIPTION
This change does two things:

- Stores an application's ID in `rsconnect` client storage (deployment record)
- Makes it possible to look up an application by its ID 

The goal of this change is to improve performance for the cases where we need application details given the application's deployment record; today, RStudio does this by getting every application in an account and then matching client-side based on the app name, but this can be quite slow when an account has many applications (noted by @fereshtehRS). 