### PR TITLE
Use packrat to generate shinyapps.io manifests

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -27,17 +27,11 @@ bundleFiles <- function(appDir) {
   files
 }
 
-bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
-                      contentCategory, accountInfo) {
-
+bundleAppDir <- function(appDir, appFiles) {
   # create a directory to stage the application bundle in
   bundleDir <- tempfile()
   dir.create(bundleDir, recursive = TRUE)
   on.exit(unlink(bundleDir), add = TRUE)
-
-  # infer the mode of the application from its layout
-  appMode <- inferAppMode(appDir, appFiles)
-  hasParameters <- appHasParameters(appDir, appFiles)
 
   # copy the files into the bundle dir
   for (file in appFiles) {
@@ -47,6 +41,18 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
       dir.create(dirname(to), recursive = TRUE)
     file.copy(from, to)
   }
+  bundleDir
+}
+
+bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
+                      contentCategory, accountInfo) {
+
+  # infer the mode of the application from its layout
+  appMode <- inferAppMode(appDir, appFiles)
+  hasParameters <- appHasParameters(appDir, appFiles)
+
+  # copy files to bundle dir to stage
+  bundleDir <- bundleAppDir(appDir, appFiles)
 
   # get application users (for non-document deployments)
   users <- NULL

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -48,13 +48,6 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
     file.copy(from, to)
   }
 
-  if (!isShinyapps(accountInfo)) {
-    # infer package dependencies for non-static content deployment
-    if (appMode != "static") {
-      addPackratSnapshot(bundleDir, inferDependencies(appMode, hasParameters))
-    }
-  }
-
   # get application users (for non-document deployments)
   users <- NULL
   if (is.null(appPrimaryDoc)) {
@@ -186,45 +179,41 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters, a
   # potential error messages
   msg      <- NULL
 
-  # for apps which run code, discover dependencies
+  # infer package dependencies for non-static content deployment
   if (appMode != "static") {
-    for (pkg in dirDependencies(appDir)) {
 
-      # get the description
-      description <- list(description = suppressWarnings(
-        utils::packageDescription(pkg)))
+    # detect dependencies
+    deps = snapshotDependencies(appDir, inferDependencies(appMode, hasParameters))
+
+    # construct package list from dependencies
+    for (i in seq.int(nrow(deps))) {
+      name <- deps[i, "Package"]
+
+      # construct package info
+      info <- as.list(deps[i, c('Source',
+                                'Repository',
+                                'GithubUsername',
+                                'GithubRepo',
+                                'GithubRef',
+                                'GithubSha1')])
+
+      # get package description
+      # TODO: should we get description from packrat/desc folder?
+      info$description = suppressWarnings(utils::packageDescription(name))
 
       # if description is NA, application dependency may not be installed
-      if (is.na(description)) {
+      if (is.na(info$description[1])) {
         msg <- c(msg, paste0(capitalize(assetTypeName), " depends on package \"",
-                             pkg, "\" but it is not installed. Please resolve ",
+                             name, "\" but it is not installed. Please resolve ",
                              "before continuing."))
         next
       }
 
-      # get package repository (e.g. source)
-      repo <-  getRepository(description[[1]])
-
-      # validate the repository (returns an error message if there is a problem)
-      msg <- c(msg, validateRepository(pkg, repo))
-
-      # append the bioc version to any bioconductor packages
-      # TODO: resolve against actual BioC repo a package was pulled from
-      # (in case the user mixed and matched)
-      if (identical(repo, "BioC")) {
-
-        # capture Bioc repository if available
-        biocPackages = available.packages(contriburl=contrib.url(BiocInstaller::biocinstallRepos(),
-                                                                 type="source"))
-        if (pkg %in% biocPackages) {
-          description$description$biocRepo <- biocPackages[pkg, 'Repository']
-        }
-
-        description$description$biocVersion <- BiocInstaller::biocVersion()
-      }
+      # validate package source (returns an error message if there is a problem)
+      msg <- c(msg, validatePackageSource(deps[i, ]))
 
       # good to go
-      packages[[pkg]] <- description
+      packages[[name]] <- info
     }
   }
   if (length(msg)) stop(paste(formatUL(msg, '\n*'), collapse = '\n'), call. = FALSE)
@@ -290,7 +279,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters, a
   metadata$content_category <- ifelse(!is.null(contentCategory),
                                       contentCategory, NA)
   metadata$has_parameters <- hasParameters
-  
+
   # add metadata
   manifest$metadata <- metadata
 
@@ -317,51 +306,27 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters, a
   RJSONIO::toJSON(manifest, pretty = TRUE)
 }
 
-getRepository <- function(description) {
-  package <- description$Package
-  priority <- description$Priority
-  repository <- description$Repository
-  githubRepo <- description$GithubRepo
-  if (is.null(repository)) {
-    if (identical(priority, "base") || identical(priority, "recommended"))
-      repository <- "CRAN"
-    else if ("biocViews" %in% names(description))
-      repository <- "BioC"
-    else if (!is.null(githubRepo))
-      repository <- "GitHub"
-    else if (package %in% .biocExtraPackages)
-      repository <- "BioC"
-  }
-  repository
-}
-
-validateRepository <- function(pkg, repository) {
-  msg <- if (is.null(repository)) {
-    "The package was installed locally from source."
-  } else if (!(repository %in% c("CRAN", "GitHub", "BioC"))) {
-    paste(" The package was installed from an unsupported ",
-          "repository '", repository, "'.", sep = "")
+validatePackageSource <- function(pkg) {
+  msg <- NULL
+  if (!(pkg$Source %in% c("CRAN", "Bioconductor", "github"))) {
+    if (is.null(pkg$Repository)) {
+      msg <- paste("The package was installed from an unsupported ",
+                   "source '", pkg$Source, "'.", sep = "")
+    }
   }
   if (is.null(msg)) return()
-  msg <- paste(
-    "Unable to deploy package dependency '", pkg, "'\n\n", msg, " ",
-    "Only packages installed from CRAN, BioConductor and GitHub are supported.\n",
-    sep = ""
-  )
-  if (!hasRequiredDevtools()) {
-    msg <- paste(msg, "\nTo use packages from GitHub you need to install ",
-                 "them with the most recent version of devtools. ",
-                 "To ensure you have the latest version of devtools ",
-                 "use:\n\n",
-                 "install.packages('devtools'); ",
-                 "devtools::install_github('devtools')\n", sep = "")
-  }
+  msg <- paste("Unable to deploy package dependency '", pkg$Package,
+               "'\n\n", msg, " ", sep = "")
   msg
 }
 
 hasRequiredDevtools <- function() {
   "devtools" %in% .packages(all.available = TRUE) &&
     packageVersion("devtools") > "1.3"
+}
+
+snapshotLockFile <- function(appDir) {
+  file.path(appDir, "packrat", "packrat.lock")
 }
 
 addPackratSnapshot <- function(bundleDir, implicit_dependencies = c()) {
@@ -412,7 +377,7 @@ addPackratSnapshot <- function(bundleDir, implicit_dependencies = c()) {
   # The server will use this to calculate package hashes. We don't want
   # to rely on hashes calculated by our version of packrat, because the
   # server may be running a different version.
-  lockFilePath <- file.path(bundleDir, "packrat", "packrat.lock")
+  lockFilePath <- snapshotLockFile(bundleDir)
   descDir <- file.path(bundleDir, "packrat", "desc")
   tryCatch({
     dir.create(descDir)
@@ -433,6 +398,7 @@ addPackratSnapshot <- function(bundleDir, implicit_dependencies = c()) {
 
   invisible()
 }
+
 
 # given a list of mixed files and directories, explodes the directories
 # recursively into their constituent files, and returns just a list of files

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -182,13 +182,12 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters, a
     for (i in seq.int(nrow(deps))) {
       name <- deps[i, "Package"]
 
-      # construct package info
+      # get package info
       info <- as.list(deps[i, c('Source',
-                                'Repository',
-                                'GithubUsername',
-                                'GithubRepo',
-                                'GithubRef',
-                                'GithubSha1')])
+                                'Repository')])
+
+      # include github package info
+      info <- c(info, as.list(deps[i, grep('Github', colnames(deps), perl = TRUE, value = TRUE)]))
 
       # get package description
       # TODO: should we get description from packrat/desc folder?

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -344,7 +344,7 @@ addPackratSnapshot <- function(bundleDir, implicit_dependencies = c()) {
 
   # ensure we have an up-to-date packrat lockfile
   packratVersion <- packageVersion("packrat")
-  requiredVersion <- "0.4.4.20"
+  requiredVersion <- "0.4.1.19"
   if (packratVersion < requiredVersion) {
     stop("rsconnect requires version '", requiredVersion, "' of Packrat; ",
          "you have version '", packratVersion, "' installed.\n",

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -1,32 +1,3 @@
-.biocExtraPackages <- c(
-  "nlcv",
-  "org.TguttataTestingSubset.eg.db",
-  "RCurl",
-  "Rlibstree",
-  "SNPRelate",
-  "SSOAP",
-  "SVGAnnotation",
-  "XMLRPC",
-  "XMLSchema"
-)
-
-
-bundleFiles <- function(appDir) {
-  # determine the files that will be in the bundle (exclude rsconnect dir
-  # as well as common hidden files)
-  files <- list.files(appDir, recursive = TRUE, all.files = TRUE,
-                      full.names = FALSE)
-  files <- files[!grepl(glob2rx("rsconnect/*"), files)]
-  files <- files[!grepl(glob2rx(".svn/*"), files)]
-  files <- files[!grepl(glob2rx(".git/*"), files)]
-  files <- files[!grepl(glob2rx(".Rproj.user/*"), files)]
-  files <- files[!grepl(glob2rx("*.Rproj"), files)]
-  files <- files[!grepl(glob2rx(".DS_Store"), files)]
-  files <- files[!grepl(glob2rx(".gitignore"), files)]
-  files <- files[!grepl(glob2rx("packrat/*"), files)]
-  files
-}
-
 bundleAppDir <- function(appDir, appFiles) {
   # create a directory to stage the application bundle in
   bundleDir <- tempfile()
@@ -42,6 +13,22 @@ bundleAppDir <- function(appDir, appFiles) {
     file.copy(from, to)
   }
   bundleDir
+}
+
+bundleFiles <- function(appDir) {
+  # determine the files that will be in the bundle (exclude rsconnect dir
+  # as well as common hidden files)
+  files <- list.files(appDir, recursive = TRUE, all.files = TRUE,
+                      full.names = FALSE)
+  files <- files[!grepl(glob2rx("rsconnect/*"), files)]
+  files <- files[!grepl(glob2rx(".svn/*"), files)]
+  files <- files[!grepl(glob2rx(".git/*"), files)]
+  files <- files[!grepl(glob2rx(".Rproj.user/*"), files)]
+  files <- files[!grepl(glob2rx("*.Rproj"), files)]
+  files <- files[!grepl(glob2rx(".DS_Store"), files)]
+  files <- files[!grepl(glob2rx(".gitignore"), files)]
+  files <- files[!grepl(glob2rx("packrat/*"), files)]
+  files
 }
 
 bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
@@ -185,10 +172,10 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters, a
   # potential error messages
   msg      <- NULL
 
-  # infer package dependencies for non-static content deployment
+  # get package dependencies for non-static content deployment
   if (appMode != "static") {
 
-    # detect dependencies
+    # detect dependencies including inferred dependences
     deps = snapshotDependencies(appDir, inferDependencies(appMode, hasParameters))
 
     # construct package list from dependencies
@@ -357,7 +344,7 @@ addPackratSnapshot <- function(bundleDir, implicit_dependencies = c()) {
 
   # ensure we have an up-to-date packrat lockfile
   packratVersion <- packageVersion("packrat")
-  requiredVersion <- "0.4.1.19"
+  requiredVersion <- "0.4.4.20"
   if (packratVersion < requiredVersion) {
     stop("rsconnect requires version '", requiredVersion, "' of Packrat; ",
          "you have version '", packratVersion, "' installed.\n",

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -40,14 +40,17 @@
 #' }
 #' @seealso \link[rsconnect:rsconnectPackages]{Using Packages with rsconnect}
 #' @export
-appDependencies <- function(appDir = getwd()) {
-  deps <- snapshotDependencies(appDir)
-  versions <- sapply(deps, function(dep)  {
-    utils::packageDescription(dep$Package, fields="Version")
-  })
-  data.frame(package = deps,
-             version = versions,
-             row.names = c(1:length(deps$Package)),
+appDependencies <- function(appDir = getwd(), appFiles=NULL) {
+  # if the list of files wasn't specified, generate it
+  if (is.null(appFiles)) {
+    appFiles <- bundleFiles(appDir)
+  }
+  bundleDir <- bundleAppDir(appDir, appFiles)
+  deps <- snapshotDependencies(bundleDir)
+  data.frame(package = deps[,"Package"],
+             version = deps[,"Version"],
+             source = deps[,"Source"],
+             row.names = c(1:length(deps[,"Package"])),
              stringsAsFactors=FALSE)
 }
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -41,160 +41,62 @@
 #' @seealso \link[rsconnect:rsconnectPackages]{Using Packages with rsconnect}
 #' @export
 appDependencies <- function(appDir = getwd()) {
-  deps <- dirDependencies(appDir)
+  deps <- snapshotDependencies(appDir)
   versions <- sapply(deps, function(dep)  {
-    utils::packageDescription(dep, fields="Version")
+    utils::packageDescription(dep$Package, fields="Version")
   })
   data.frame(package = deps,
              version = versions,
-             row.names = c(1:length(deps)),
+             row.names = c(1:length(deps$Package)),
              stringsAsFactors=FALSE)
 }
 
-# detect all package dependencies for a directory of files
-dirDependencies <- function(dir) {
+snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
 
-  # start with the shiny package (the dependency on shiny can be implicit
-  # as the shiny package is automatically loaded prior to sourcing ui.R
-  # and server.R)
-  pkgs <- c("shiny")
+  # create a packrat "snapshot"
+  addPackratSnapshot(appDir, implicit_dependencies)
 
-  # now get the packages referred to in the source code; look in both .R
-  # and .Rmd files
-  sapply(list.files(dir, pattern="^.*[.][Rr]([Mm][Dd])?$",
-                    ignore.case=TRUE, recursive=TRUE),
-         function(file) {
-           # ignore files in the Packrat folder
-           if (!identical(substr(file, 1, 8), "packrat/"))
-             pkgs <<- append(pkgs, fileDependencies(file.path(dir, file)))
-         })
-  pkgs <- unique(pkgs)
+  # TODO: should we care about lockfile version or packrat version?
+  lockFilePath <- snapshotLockFile(appDir)
+  df <- as.data.frame(read.dcf(lockFilePath), stringsAsFactors = FALSE)
 
-  # then calculate recursive dependencies
-  installed <- installed.packages()
-  which <-  c("Depends", "Imports", "LinkingTo")
-  depsList <- tools::package_dependencies(pkgs,
-                                          installed,
-                                          which,
-                                          recursive=TRUE)
+  # get repos defined in the lockfile
+  repos <- gsub("[\r\n]", " ", df[1, 'Repos'])
+  repos <- strsplit(unlist(strsplit(repos, "\\s*,\\s*", perl = TRUE)), "=", fixed = TRUE)
+  repos <- setNames(
+    sapply(repos, "[[", 2),
+    sapply(repos, "[[", 1)
+  )
 
-  # flatten the list
-  deps <- unlist(depsList, recursive=TRUE, use.names=FALSE)
-  unique(c(pkgs, deps))
-}
+  # get Bioconductor repos if any
+  biocRepos = repos[grep('BioC', names(repos), perl=TRUE, value=TRUE)]
+  if (length(biocRepos) > 0) {
+    biocPackages = available.packages(contriburl=contrib.url(biocRepos, type="source"))
+  } else {
+    biocPackages = c()
+  }
 
-# detect all package dependencies for a source file (parses the file and then
-# recursively examines all expressions in the file)
-fileDependencies <- function(file) {
+  # get packages records defined in the lockfile
+  records <- utils::tail(df, -1)
 
-  # build a list of package dependencies to return
-  pkgs <- character()
-
-  ext <- tolower(tools::file_ext(file))
-  if (identical(ext, "rmd")) {
-    # if this is an R Markdown file, we'll need to use knitr to extract its code
-    # chunks for parsing
-    if (require(knitr, quietly = TRUE)) {
-      purled <- ""
-      purled_con <- textConnection("purled", open = "w", local = TRUE)
-      knitr::purl(file, purled_con, quiet = TRUE, documentation = 0,
-                  encoding = checkEncoding(file))
-      close(purled_con)
-      input <- textConnection(purled, open = "r")
-      # rmarkdown is an implicit dependency (it's not referenced in the Rmd source)
-      pkgs <- c(pkgs, "rmarkdown")
-
-      if (packageVersion("knitr") >= "1.10.18") {
-        file_lines = readLines(file, warn = FALSE, encoding = "UTF-8")
-        knit_params <- knitr::knit_params(file_lines, evaluate = FALSE)
-        if (length(knit_params) > 0) {
-          # shiny is an implicit dependency when using parameters, which lets us
-          # run rmarkdown::knit_params_ask.
-          pkgs <- c(pkgs, "shiny")
-          # Document parameters can optionally be expressions.
-          for (param in knit_params) {
-            if (!is.null(param$expr)) {
-              # When not evaluating, param$value is the parsed expression;
-              # param$expr is always the expression text.
-              pkgs <- append(pkgs, expressionDependencies(param$value))
-            }
-          }
-        }
+  # if the package is in a named CRAN-like repository capture it
+  tmp <- sapply(seq.int(nrow(records)), function(i) {
+    pkg <- records[i, "Package"]
+    source <- records[i, "Source"]
+    repository <- NA
+    # capture Bioconcutor repository
+    if (identical(source, "Bioconductor")) {
+      if (pkg %in% biocPackages) {
+        repository <- biocPackages[pkg, 'Repository']
       }
     } else {
-      # no knitr, return an empty list
-      warning("Could not determine dependencies for ", file,
-              " (requires knitr)")
-      return(character())
+      # capture CRAN-like repository
+      repository <- if (source %in% names(repos)) repos[[source]] else NA
     }
-  } else if (identical(ext, "r")) {
-    # if this is an R script, we can parse its output directly
-    input <- base::file(file, encoding = checkEncoding(file))
-    on.exit(close(input), add = TRUE)
-  } else {
-    # if it's not an extension we know, emit a warning
-    warning("Could not determine dependencies for ", file,
-            " (extension .", ext, " unknown)")
-    return(character())
-  }
-
-  # parse file and examine expressions
-  withCallingHandlers(
-    exprs <- parse(input, n = -1L, encoding = checkEncoding(file)),
-    error = function(e) message('\n\n* Failed to parse ', file, '\n')
-  )
-  for (i in seq_along(exprs))
-    pkgs <- append(pkgs, expressionDependencies(exprs[[i]]))
-
-  # return packages
-  unique(pkgs)
-}
-
-# detect the pacakge dependencies of an expression (adapted from
-# tools:::.check_packages_used)
-expressionDependencies <- function(e) {
-
-  # build a list of packages to return
-  pkgs <- character()
-
-  # examine calls
-  if (is.call(e) || is.expression(e)) {
-
-    # extract call
-    call <- deparse(e[[1L]])[1L]
-
-    # check for library or require and extract package argument
-    if ((call %in% c("library", "require")) && (length(e) >= 2L)) {
-      keep <- sapply(e, function(x) deparse(x)[1L] != "...")
-      mc <- match.call(get(call, baseenv()), e[keep])
-      if (!is.null(pkg <- mc$package)) {
-        # ensure that types are rational
-        if (!identical(mc$character.only, TRUE) ||
-              identical(class(pkg), "character")) {
-          pkg <- sub("^\"(.*)\"$", "\\1", deparse(pkg))
-          pkgs <- append(pkgs, pkg)
-        }
-      }
-    }
-
-    # check for :: or :::
-    else if (call %in% c("::", ":::")) {
-      pkg <- deparse(e[[2L]])
-      pkgs <- append(pkgs, pkg)
-    }
-
-    # check for uses of methods
-    else if (call %in% c("setClass", "setMethod")) {
-      pkgs <- append(pkgs, "methods")
-    }
-
-    # process subexpressions
-    for (i in seq_along(e))
-      pkgs <- append(pkgs, Recall(e[[i]]))
-  }
-
-  # return packages
-  unique(pkgs)
+    repository
+  })
+  records[, "Repository"] <- tmp
+  return(records)
 }
 
 # get source packages from CRAN


### PR DESCRIPTION
Previously content being deployed to connect used `packrat` to detect dependencies whiling still generating the manifest from code within the `rsconnect` package.  The goal of this PR is to generate the manifest using the same `packrat` snapshot that connect uses. This eliminates the need for the old dependency detection code. This also has the benefit of allowing content deployed to shinyapps.io to understand dependencies detected by `packrat` including 3rd-party CRAN-like repositories and other sources in the future.

NOTE: There is shinyapps.io server side changes that must be deployed for this to work so don't merge without checking with me.