### PR TITLE
Make server URL validation more robust

### DIFF
--- a/R/ide.R
+++ b/R/ide.R
@@ -5,25 +5,76 @@
 # (which does not require authentication). returns a list containing (valid =
 # TRUE) and server settings, or a list containing (valid = FALSE) and an error
 # message.
+#
+# the URL may be specified with or without the protocol and port; this function
+# will try both http and https and follow any redirects given by the server.
 validateServerUrl <- function(url) {
-  # if no protocol specified, guess HTTP (TODO: unfortunately guessing the wrong
-  # protocol results in a hung request; is there a way we can test for HTTPS
-  # support without hanging if it doesn't exist?)
-  if (!grepl("://", url, fixed = TRUE))
-    url <- paste0("http://", url)
+  tryAllProtocols <- TRUE
 
+  if (!grepl("://", url, fixed = TRUE))
+  {
+    if (grepl(":3939", url, fixed = TRUE)) {
+      # assume http for default (local) connect installations
+      url <- paste0("http://", url)
+    } else {
+      # assume https elsewhere
+      url <- paste0("https://", url)
+    }
+  }
+
+  # if the URL ends with a port number, don't try http/https on the same port
+  if (grepl(":\\d+/?$", url)) {
+    tryAllProtocols <- FALSE
+  }
+
+  settingsEndpoint <- "/server_settings"
   url <- ensureConnectServerUrl(url)
+
+  # begin trying URLs to discover the correct one
   response <- NULL
   errMessage <- ""
-  tryCatch({
-    # this shouldn't take more than 10 seconds since it does no work (i.e we
-    # should just be waiting for the network), so timeout quickly to avoid
-    # hanging when the server doesn't accept the connection
-    response <- handleResponse(
-      GET(parseHttpUrl(url), NULL, "/server_settings", timeout = 10))
-  }, error = function(e) {
-    errMessage <<- e$message
-  })
+  retry <- TRUE
+  while (retry) {
+    tryCatch({
+      # this shouldn't take more than 5 seconds since it does no work (i.e we
+      # should just be waiting for the network), so timeout quickly to avoid
+      # hanging when the server doesn't accept the connection
+      httpResponse <- GET(parseHttpUrl(url), NULL, settingsEndpoint,
+                          timeout = 5)
+
+      # check for redirect
+      if (httpResponse$status == 307 &&
+          !is.null(httpResponse$location)) {
+
+        # we were served a redirect; try again with the new URL
+        url <- httpResponse$location
+        if (substring(url, (nchar(url) - nchar(settingsEndpoint)) + 1)   ==
+            settingsEndpoint) {
+          # chop /server_settings from the redirect path to get the raw API path
+          url <- substring(url, 1, nchar(url) - nchar(settingsEndpoint))
+        }
+        next
+      }
+      response <- handleResponse(httpResponse)
+
+      # got a real response; stop trying now
+      retry <- FALSE
+    }, error = function(e) {
+      if (inherits(e, "OPERATION_TIMEDOUT") && tryAllProtocols) {
+        # if the operation timed out on one protocol, try the other one (note
+        # that we don't do this if a port is specified)
+        if (substring(url, 1, 7) == "http://") {
+          url <<- paste0("https://", substring(url, 8))
+        } else if (substring(url, 1, 8) == "https://") {
+          url <<- paste0("http://", substring(url, 9))
+        }
+        tryAllProtocols <<- FALSE
+        return()
+      }
+      errMessage <<- e$message
+      retry <<- FALSE
+    })
+  }
   if (is.null(response)) {
     list(
       valid = FALSE,


### PR DESCRIPTION
This change addresses some ongoing confusion about whether to use http or https in the IDE's server URL textbox, and how to specify it if so, by accepting a wider variety of inputs and trying URL variations with short timeouts so that even some incorrectly specified URLs can be used. The two major changes are:

- It is no longer necessary to specify http or https on the URL. If you do specify it, we'll try the protocol you named first, but also try the other one if it fails.
- If the server returns a redirect on the URL, we'll try again at the redirected URL. 

Once this is in, the IDE will lose the http/https checkbox, and let the user just type the server URL freehand (with a cue suggesting the right format). 