### PR TITLE
Show more detailed HTTP error information

### DIFF
--- a/R/accounts.R
+++ b/R/accounts.R
@@ -279,7 +279,7 @@ getUserFromRawToken <- function(serverUrl, token, privateKey) {
   tryCatch({
     user <- connect$currentUser()
   }, error = function(e) {
-    if (length(grep("500 -", e$message)) == 0) {
+    if (length(grep("HTTP 500", e$message)) == 0) {
       stop(e)
     }
   })

--- a/R/client.R
+++ b/R/client.R
@@ -2,7 +2,10 @@ handleResponse <- function(response, jsonFilter = NULL) {
 
   # function to report errors
   reportError <- function(msg) {
-    stop(paste(response$path, response$status, "-", msg), call. = FALSE)
+    stop("HTTP ", response$status, "\n",
+         response$req$method, " ",  response$req$protocol, "://",
+         response$req$host, response$req$port, response$req$path, "\n",
+         msg, call. = FALSE)
   }
 
   # json responses


### PR DESCRIPTION
When an HTTP error occurs today, the error displayed includes the relative path to the endpoint, the HTTP status code returned, and the content of the error.

This change writes more detailed information about the request that caused the error, including the request method (e.g. `GET` or `POST`) and the full request URL. 