### PR TITLE
ensure Recommended packages are snapshotted

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -362,7 +362,7 @@ addPackratSnapshot <- function(bundleDir, implicit_dependencies = c()) {
 
   # ensure we have an up-to-date packrat lockfile
   packratVersion <- packageVersion("packrat")
-  requiredVersion <- "0.4.5.13"
+  requiredVersion <- "0.4.5.14"
   if (packratVersion < requiredVersion) {
     stop("rsconnect requires version '", requiredVersion, "' of Packrat; ",
          "you have version '", packratVersion, "' installed.\n",
@@ -440,7 +440,10 @@ performPackratSnapshot <- function(bundleDir) {
   setwd(bundleDir)
 
   # ensure we snapshot recommended packages
+  srp <- packrat::opts$snapshot.recommended.packages()
   packrat::opts$snapshot.recommended.packages(TRUE, persist = FALSE)
+  on.exit(packrat::opts$snapshot.recommended.packages(srp, persist = FALSE),
+          add = TRUE)
 
   # generate a snapshot
   suppressMessages(
@@ -448,5 +451,7 @@ performPackratSnapshot <- function(bundleDir) {
                            snapshot.sources = FALSE,
                            verbose = FALSE)
   )
+
+  # TRUE just to indicate success
   TRUE
 }

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -362,7 +362,7 @@ addPackratSnapshot <- function(bundleDir, implicit_dependencies = c()) {
 
   # ensure we have an up-to-date packrat lockfile
   packratVersion <- packageVersion("packrat")
-  requiredVersion <- "0.4.5.10"
+  requiredVersion <- "0.4.5.13"
   if (packratVersion < requiredVersion) {
     stop("rsconnect requires version '", requiredVersion, "' of Packrat; ",
          "you have version '", packratVersion, "' installed.\n",
@@ -440,7 +440,7 @@ performPackratSnapshot <- function(bundleDir) {
   setwd(bundleDir)
 
   # ensure we snapshot recommended packages
-  packrat::opts$snapshot.recommended.packages(TRUE)
+  packrat::opts$snapshot.recommended.packages(TRUE, persist = FALSE)
 
   # generate a snapshot
   suppressMessages(

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -362,17 +362,16 @@ addPackratSnapshot <- function(bundleDir, implicit_dependencies = c()) {
 
   # ensure we have an up-to-date packrat lockfile
   packratVersion <- packageVersion("packrat")
-  requiredVersion <- "0.4.5"
+  requiredVersion <- "0.4.5.10"
   if (packratVersion < requiredVersion) {
     stop("rsconnect requires version '", requiredVersion, "' of Packrat; ",
          "you have version '", packratVersion, "' installed.\n",
-         "Please install the latest version of Packrat from CRAN.")
+         "Please install the latest version of Packrat from GitHub with:\n- ",
+         "devtools::install_github('rstudio/packrat')")
   }
-  suppressMessages(
-    packrat::.snapshotImpl(project = bundleDir,
-                           snapshot.sources = FALSE,
-                           verbose = FALSE)
-  )
+
+  # generate the packrat snapshot
+  performPackratSnapshot(bundleDir)
 
   # if we emitted a temporary dependency file for packrat's benefit, remove it
   # now so it isn't included in the bundle sent to the server
@@ -431,4 +430,23 @@ explodeFiles <- function(dir, files) {
     }
   }
   exploded
+}
+
+performPackratSnapshot <- function(bundleDir) {
+
+  # move to the bundle directory
+  owd <- getwd()
+  on.exit(setwd(owd), add = TRUE)
+  setwd(bundleDir)
+
+  # ensure we snapshot recommended packages
+  packrat::opts$snapshot.recommended.packages(TRUE)
+
+  # generate a snapshot
+  suppressMessages(
+    packrat::.snapshotImpl(project = bundleDir,
+                           snapshot.sources = FALSE,
+                           verbose = FALSE)
+  )
+  TRUE
 }

--- a/tests/testthat/project-MASS/MASS.R
+++ b/tests/testthat/project-MASS/MASS.R
@@ -1,0 +1,1 @@
+library(MASS)

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -9,6 +9,11 @@ makeShinyBundleTempDir <- function(appName, appDir, appPrimaryDoc) {
   bundleTempDir
 }
 
+# avoid 'trying to use CRAN without setting a mirror' errors
+repos <- getOption("repos")
+options(repos = c(CRAN = "https://cran.rstudio.com"))
+on.exit(options(repos = repos), add = TRUE)
+
 test_that("simple Shiny app bundle is runnable", {
   bundleTempDir <- makeShinyBundleTempDir("simple_shiny", "shinyapp-simple",
                                           NULL)
@@ -28,4 +33,11 @@ test_that("single-file Shiny app bundle is runnable", {
                                           "single.R")
   on.exit(unlink(bundleTempDir, recursive = TRUE))
   expect_true(inherits(shiny::shinyAppDir(bundleTempDir), "shiny.appobj"))
+})
+
+test_that("recommended packages are snapshotted", {
+  bundleTempDir <- makeShinyBundleTempDir("MASS", "project-MASS", "MASS.R")
+  lockfile <- file.path(bundleTempDir, "packrat/packrat.lock")
+  deps <- packrat:::readLockFilePackages(lockfile)
+  expect_true("MASS" %in% names(deps))
 })


### PR DESCRIPTION
This PR ensures that recommended packages enter the lockfile when performing a packrat snapshot.