### PR TITLE
retain global deployment history

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rsconnect
 Type: Package
 Title: Deployment Interface for Shiny Applications
-Version: 0.4.1.9
+Version: 0.4.1.10
 Date: 2015-11-03
 Author: JJ Allaire
 Maintainer: JJ Allaire <jj@rstudio.com>

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -7,6 +7,10 @@ saveDeployment <- function(appPath, name, account, server, appId, bundleId, url,
                                  when = as.numeric(Sys.time()),
                                  metadata)
   write.dcf(deployment, deploymentFile(appPath, name, account, server))
+
+  # also save to global history
+  addToDeploymentHistory(appPath, deployment)
+
   invisible(NULL)
 }
 
@@ -179,3 +183,33 @@ deploymentRecord <- function(name, account, server, appId, bundleId, url, when,
       metadata),
     stringsAsFactors = FALSE)
 }
+
+
+deploymentHistoryDir <- function() {
+  rsconnectConfigDir("deployments")
+}
+
+addToDeploymentHistory <- function(appPath, deploymentRecord) {
+
+  # path to deployments files
+  history <- file.path(deploymentHistoryDir(), "history.dcf")
+  newHistory <- file.path(deploymentHistoryDir(), "history.new.dcf")
+
+  # add the appPath to the deploymentRecord
+  deploymentRecord$appPath <- appPath
+
+  # write new history file
+  write.dcf(deploymentRecord, newHistory)
+  cat("\n", file = newHistory, append = TRUE)
+
+  # append existing history to new history
+  if (file.exists(history))
+    file.append(newHistory, history)
+
+  # overwrite with new history
+  file.rename(newHistory, history)
+}
+
+
+
+

--- a/R/rpubs.R
+++ b/R/rpubs.R
@@ -157,6 +157,10 @@ rpubsUpload <- function(title,
                                    "rpubs.com")
     write.dcf(rpubsRec, rpubsRecFile)
 
+    # record in global history
+    if (!is.null(originalDoc) && nzchar(originalDoc))
+      addToDeploymentHistory(originalDoc, rpubsRec)
+
     # return the publish information
     return(list(id = id,
                  continueUrl = url))


### PR DESCRIPTION
We now record all deployments in a centralized deployments/history.dcf file. This is done so that front ends can show a view of all recent / previously published content.

Note that we record the data in a single file that is arranged in reverse chronological order (this is so that a front end interested in e.g. only the last 30 deployments could read that far and stop).

There is no limit to the size of the file but note that 4 deployments take about 1K of space so a 1MB file would cover ~ 4000 deployments.

@jmcphers 