### PR TITLE
Introduce alternate method of specifying file deployment list

### DIFF
--- a/man/appDependencies.Rd
+++ b/man/appDependencies.Rd
@@ -10,9 +10,10 @@ appDependencies(appDir = getwd(), appFiles = NULL)
 \item{appDir}{Directory containing application. Defaults to current working
 directory.}
 
-\item{appFiles}{The files to bundle and deploy (only if \code{upload =
-TRUE}). Can be \code{NULL}, in which case all the files in the directory
-containing the application are bundled.}
+\item{appFiles}{The files and directories to bundle and deploy (only if
+\code{upload = TRUE}). Can be \code{NULL}, in which case all the files in
+the directory containing the application are bundled. Takes precedence over
+\code{appFileManifest} if both are supplied.}
 }
 \value{
 Returns a data frame listing the package

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -4,9 +4,9 @@
 \alias{deployApp}
 \title{Deploy an Application}
 \usage{
-deployApp(appDir = getwd(), appFiles = NULL, appPrimaryDoc = NULL,
-  appSourceDoc = NULL, appName = NULL, contentCategory = NULL,
-  account = NULL, server = NULL, upload = TRUE,
+deployApp(appDir = getwd(), appFiles = NULL, appFileManifest = NULL,
+  appPrimaryDoc = NULL, appSourceDoc = NULL, appName = NULL,
+  contentCategory = NULL, account = NULL, server = NULL, upload = TRUE,
   launch.browser = getOption("rsconnect.launch.browser", interactive()),
   quiet = FALSE, lint = TRUE, metadata = list())
 }
@@ -14,9 +14,14 @@ deployApp(appDir = getwd(), appFiles = NULL, appPrimaryDoc = NULL,
 \item{appDir}{Directory containing application. Defaults to current working
 directory.}
 
-\item{appFiles}{The files to bundle and deploy (only if \code{upload =
-TRUE}). Can be \code{NULL}, in which case all the files in the directory
-containing the application are bundled.}
+\item{appFiles}{The files and directories to bundle and deploy (only if
+\code{upload = TRUE}). Can be \code{NULL}, in which case all the files in
+the directory containing the application are bundled. Takes precedence over
+\code{appFileManifest} if both are supplied.}
+
+\item{appFileManifest}{An alternate way to specify the files to be deployed;
+a file containing the names of the files, one per line, relative to the
+\code{appDir}.}
 
 \item{appPrimaryDoc}{If the application contains more than one document, this
 parameter indicates the primary one, as a path relative to \code{appDir}.


### PR DESCRIPTION
When not all files are to be deployed, specifying the list of files via `appFiles` can be cumbersome if there are a large number of files. 

This change makes it possible to supply the list of files to deploy in a file supplied in a new `appFileManifest` parameter to `deployApp`.

- For IDE users, this will make it possible to deploy large numbers of files without exceeding the command length limit.
- For non-IDE users, this will make it possible to create a list of files to deploy once and re-use it.
