### PR TITLE
Use a long max width for DCF lines (avoid unnecessary URL wrapping)

### DIFF
--- a/R/deployments.R
+++ b/R/deployments.R
@@ -3,10 +3,14 @@
 saveDeployment <- function(appPath, name, account, server, appId, bundleId, url,
                            metadata) {
 
+  # create the record to write to disk
   deployment <- deploymentRecord(name, account, server, appId, bundleId, url,
                                  when = as.numeric(Sys.time()),
                                  metadata)
-  write.dcf(deployment, deploymentFile(appPath, name, account, server))
+
+  # use a long width so URLs don't line-wrap
+  write.dcf(deployment, deploymentFile(appPath, name, account, server),
+            width = 4096)
 
   # also save to global history
   addToDeploymentHistory(appPath, deployment)
@@ -199,7 +203,7 @@ addToDeploymentHistory <- function(appPath, deploymentRecord) {
   deploymentRecord$appPath <- appPath
 
   # write new history file
-  write.dcf(deploymentRecord, newHistory)
+  write.dcf(deploymentRecord, newHistory, width = 4096)
   cat("\n", file = newHistory, append = TRUE)
 
   # append existing history to new history

--- a/R/rpubs.R
+++ b/R/rpubs.R
@@ -155,7 +155,7 @@ rpubsUpload <- function(title,
                                  as.numeric(Sys.time()))
     rpubsRecFile <- deploymentFile(recordSource, recordName, "rpubs",
                                    "rpubs.com")
-    write.dcf(rpubsRec, rpubsRecFile)
+    write.dcf(rpubsRec, rpubsRecFile, width = 4096)
 
     # record in global history
     if (!is.null(originalDoc) && nzchar(originalDoc))


### PR DESCRIPTION
This change fixes a small issue in which RPubs deployment records are wrapped unnecessarily.

Before:

    name: Document
    account: rpubs
    server: rpubs.com
    appId:
            https://api.rpubs.com/api/v1/document/134271/d53ab072f32b49898ffc04b545aebcc7
    bundleId:
            https://api.rpubs.com/api/v1/document/134271/d53ab072f32b49898ffc04b545aebcc7
    url:
            http://rpubs.com/publish/claim/134271/b72f788583d244ac90840d3e4d700c74
    when: 1449808954.09515

After:

    name: Document
    account: rpubs
    server: rpubs.com
    appId: https://api.rpubs.com/api/v1/document/134272/744a99fe94c649f1826d1c125326b7d8
    bundleId: https://api.rpubs.com/api/v1/document/134272/744a99fe94c649f1826d1c125326b7d8
    url: http://rpubs.com/publish/claim/134272/8f08bbe6c5d84393bdb200c8fe758477
    when: 1449809043.64934


