### PR TITLE
improve error reporting for overly-large bundles

### DIFF
--- a/R/http.R
+++ b/R/http.R
@@ -367,6 +367,15 @@ httpRCurl <- function(protocol,
           "Try setting 'options(rsconnect.http = \"curl\")' and re-deploying your application."
         }
 
+        # inform user of 'rsconnectOption' help page
+        prescription <- paste(sep = "\n",
+          prescription,
+          paste(
+            "Check the `?rsconnectOptions` help page for more information on how",
+            "HTTP communications can be configured."
+          )
+        )
+
         # attempt to provide file size in output as well
         fileInfo <- if (!is.null(file) && file.exists(file)) {
           fmt <- "(File %s is %s in size)"

--- a/R/http.R
+++ b/R/http.R
@@ -361,8 +361,11 @@ httpRCurl <- function(protocol,
 
         msg <- "Deployment failed due to overly-large bundle."
 
-        prescription <- if (!identical(getOption("rsconnect.http"), "curl"))
+        # request use of system curl if available
+        tryCurl <- !identical(getOption("rsconnect.http"), "curl") && nzchar(Sys.which("curl"))
+        prescription <- if (tryCurl) {
           "Try setting 'options(rsconnect.http = \"curl\")' and re-deploying your application."
+        }
 
         # attempt to provide file size in output as well
         fileInfo <- if (!is.null(file) && file.exists(file)) {


### PR DESCRIPTION
This PR attempts to detect errors due to overly large bundles, and provide a prescription in the case where users are not using `curl` for deployment.

Should add some tests before merge.
