### PR TITLE
Modernise dependencies: use openssl pkg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,7 @@ Description: Programmatic deployment interface for 'RPubs', 'shinyapps.io', and
 Depends:
     R (>= 3.0.0)
 Imports:
-    digest,
-    PKI,
+    openssl,
     RCurl,
     RJSONIO,
     packrat (>= 0.4.8-1),

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -421,8 +421,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
   # provide checksums for all files
   filelist <- list()
   for (file in files) {
-    checksum <- list(checksum = digest::digest(file.path(appDir, file),
-                                               algo = "md5", file = TRUE))
+    checksum <- list(checksum = as.character(openssl::md5(base::file(file.path(appDir, file)))))
     filelist[[file]] <- I(checksum)
   }
 

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -320,7 +320,7 @@ deployApp <- function(appDir = getwd(),
         bundleSize <- file.info(bundlePath)$size
 
         # Generate a hex-encoded md5 hash.
-        checkSum <- digest::digest(bundlePath, 'md5', file=TRUE)
+        checkSum <- as.character(openssl::md5(bundlePath))
         bundle <- client$createBundle(application$id, "application/x-tar", bundleSize, checkSum)
 
         if (verbose)

--- a/R/rsa.R
+++ b/R/rsa.R
@@ -3,19 +3,19 @@
 # Connect service. The token's ID and public key are sent to the server, and
 # the private key is saved locally.
 generateToken <- function() {
-  key <- PKI::PKI.genRSAkey(bits = 2048L)
-  priv.der <- PKI::PKI.save.key(key, format = "DER")
-  pub.der <- PKI::PKI.save.key(key, format = "DER", private = FALSE)
+  key <- openssl::rsa_keygen(2048L)
+  priv.der <- openssl::write_der(key)
+  pub.der <- openssl::write_der(key$pubkey)
 
   # hash the public key to generate the token ID; we used to create a random
   # token ID using sample(), but this causes trouble for users who use a fixed
   # RNG seed and/or need the RNG state to remain unperturbed.
-  tokenId <- digest::digest(object = pub.der, algo = "md5")
+  tokenId <- as.character(openssl::md5(serialize(pub.der, NULL)))
 
   # form the token from the
   list(
     token = paste0("T", tokenId),
-    public_key = RCurl::base64Encode(pub.der),
-    private_key = RCurl::base64Encode(priv.der)
+    public_key = openssl::base64_encode(pub.der),
+    private_key = openssl::base64_encode(priv.der)
   )
 }


### PR DESCRIPTION
The `PKI` package does not build anymore on MacOS (See e.g. https://github.com/s-u/PKI/issues/17).  This replaces `PKI` with the `openssl` package (which also has all of the hash/hmac/base64 functions).

I am not sure what is the best way to test this package, but from what I can see there should be no side effects.

If it is useful, I will gladly try to replace RJSONIO/RCurl with `jsonlite/curl` as well.
