### PR TITLE
Increase max bundle size, and add file count throttle

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -64,6 +64,11 @@ maxDirectoryList <- function(dir, parent, totalSize) {
       # abort if we've reached the maximum size
       if (totalSize > getOption("rsconnect.max.bundle.size"))
         break
+
+      # abort if we've reached the maximum number of files
+      if ((length(contents) + length(subdirContents)) >
+          getOption("rsconnect.max.bundle.files"))
+        break
     }
   }
 
@@ -90,6 +95,9 @@ maxDirectoryList <- function(dir, parent, totalSize) {
 #' \item{If the total size of the files exceeds the maximum bundle size, no
 #'    more files are listed. The maximum bundle size is controlled by the
 #'    \code{rsconnect.max.bundle.size} option.}
+#' \item{If the total size number of files exceeds the maximum number to be
+#'    bundled, no more files are listed. The maximum number of files in the
+#'    bundle is controlled by the \code{rsconnect.max.bundle.files} option.}
 #' \item{Certain files and folders that don't need to be bundled, such as
 #'    those containing internal version control and RStudio state, are
 #'    excluded.}
@@ -110,11 +118,17 @@ listBundleFiles <- function(appDir) {
 bundleFiles <- function(appDir) {
   files <- listBundleFiles(appDir)
   if (files$totalSize > getOption("rsconnect.max.bundle.size")) {
-    stop("The directory", appDir, "cannot be deployed because it is too",
+    stop("The directory", appDir, "cannot be deployed because it is too ",
          "large (the maximum size is", getOption("rsconnect.max.bundle.size"),
-         "bytes). Remove some files or adjust the rsconnect.max.bundle.size",
+         "bytes). Remove some files or adjust the rsconnect.max.bundle.size ",
          "option.")
+  } else if (length(files$contents) > getOption("rsconnect.max.bundle.files")) {
+    stop("The directory", appDir, "cannot be deployed because it contains ",
+         "too many files (the maximum number of files is ",
+         getOption("rsconnect.max.bundle.files"), "). Remove some files or ",
+         "adjust the rsconnect.max.bundle.files option.")
   }
+
   files$contents
 }
 

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -1,5 +1,8 @@
 .onLoad <- function(libname, pkgname) {
   if (is.null(getOption("rsconnect.max.bundle.size"))) {
-    options(rsconnect.max.bundle.size = 1048576000)
+    options(rsconnect.max.bundle.size = 3145728000)
+  }
+  if (is.null(getOption("rsconnect.max.bundle.files"))) {
+    options(rsconnect.max.bundle.files = 10000)
   }
 }

--- a/man/listBundleFiles.Rd
+++ b/man/listBundleFiles.Rd
@@ -29,6 +29,9 @@ listing from \code{\link{list.files}}, with the following constraints:
 \item{If the total size of the files exceeds the maximum bundle size, no
    more files are listed. The maximum bundle size is controlled by the
    \code{rsconnect.max.bundle.size} option.}
+\item{If the total size number of files exceeds the maximum number to be
+   bundled, no more files are listed. The maximum number of files in the
+   bundle is controlled by the \code{rsconnect.max.bundle.files} option.}
 \item{Certain files and folders that don't need to be bundled, such as
    those containing internal version control and RStudio state, are
    excluded.}

--- a/man/options.Rd
+++ b/man/options.Rd
@@ -24,7 +24,8 @@ Supported global options include:
    \item{\code{rsconnect.launch.browser}}{When \code{TRUE}, automatically launch a browser to view applications after they are deployed}
    \item{\code{rsconnect.locale.cache}}{When \code{FALSE}, disable the detected locale cache (Windows only). }
    \item{\code{rsconnect.locale}}{Override the detected locale. }
-   \item{\code{rsconnect.max.bundle.size}}{The maximum size, in bytes, for deployed content. If not set, defaults to 1 GB.}
+   \item{\code{rsconnect.max.bundle.size}}{The maximum size, in bytes, for deployed content. If not set, defaults to 3 GB.}
+   \item{\code{rsconnect.max.bundle.files}}{The maximum number of files to deploy. If not set, defaults to 10,000.}
 }
 }
 


### PR DESCRIPTION
Currently, the maximum bundle size has two conflated responsibilities:

1) Prevent the intentional deployment of bundles that are too large for the server to accept. 

2) Prevent the accidental deployment of enormous directories (which will take a very long time to bundle) by bailing out early while counting the files in the directory.

However, the max bundle size is currently set at 1GB, which is too low for some shinyapps accounts. Therefore this change attempts to separate the concerns a little, by doing the following:

1) Increasing the deployment cap to 3GB, the highest currently supported bundle size

2) Improving the UX when deploying oversized directories by capping the number of files at 10,000 -- this is fast enough to terminate enumeration in a reasonable time

Note that after this change we will be perfectly willing to publish e.g. a 2GB bundle to a basic shinyapps.io account, where it will be summarily rejected by the server. I think that it's okay to let the server be ultimately responsible for enforcing max bundle sizes as otherwise we'll have to keep the package in sync with rules that could vary from server to server (and with time as we adjust thresholds on our hosted products), or introduce additional complexity to read and apply the rules from the server. 