### PR TITLE
Improve diagnostic output during deployment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rsconnect
 Type: Package
 Title: Deployment Interface for R Markdown Documents and Shiny Applications
-Version: 0.4.5
+Version: 0.4.6
 Date: 2016-05-02
 Author: JJ Allaire
 Maintainer: JJ Allaire <jj@rstudio.com>

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -470,7 +470,22 @@ addPackratSnapshot <- function(bundleDir, implicit_dependencies = c()) {
   }
 
   # generate the packrat snapshot
-  performPackratSnapshot(bundleDir)
+  tryCatch({
+    performPackratSnapshot(bundleDir)
+  }, error = function(e) {
+    # if an error occurs while generating the snapshot, add a header to the
+    # message for improved attribution
+    e$msg <- paste0("----- Error snapshotting dependencies (Packrat) -----\n",
+                    e$msg)
+
+    # print a traceback if enabled
+    if (isTRUE(getOption("rsconnect.error.trace"))) {
+      traceback(3, sys.calls())
+    }
+
+    # rethrow error so we still halt deployment
+    stop(e)
+  })
 
   # if we emitted a temporary dependency file for packrat's benefit, remove it
   # now so it isn't included in the bundle sent to the server

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -92,6 +92,18 @@ deployApp <- function(appDir = getwd(),
   if (!isStringParam(appDir))
     stop(stringParamErrorMessage("appDir"))
 
+  # install error handler if requested
+  if (isTRUE(getOption("rsconnect.error.trace"))) {
+    errOption <- getOption("error")
+    options(error = function(e) {
+      cat("----- Deployment error -----\n", file = stderr())
+      cat(geterrmessage(), file = stderr())
+      cat("----- Error stack trace -----\n", file = stderr())
+      traceback(3, sys.calls())
+    })
+    on.exit(options(error = errOption), add = TRUE)
+  }
+
   # normalize appDir path and ensure it exists
   appDir <- normalizePath(appDir, mustWork = FALSE)
   if (!file.exists(appDir)) {

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -87,7 +87,7 @@ deployApp <- function(appDir = getwd(),
                       upload = TRUE,
                       launch.browser = getOption("rsconnect.launch.browser",
                                                  interactive()),
-                      logLevel = c("verbose", "normal", "quiet", "verbose"),
+                      logLevel = c("normal", "quiet", "verbose"),
                       lint = TRUE,
                       metadata = list()) {
 

--- a/R/deploySite.R
+++ b/R/deploySite.R
@@ -23,7 +23,7 @@ deploySite <- function(siteDir = getwd(),
                        server = NULL,
                        render = c("none", "local", "server"),
                        launch.browser = getOption("rsconnect.launch.browser", interactive()),
-                       quiet = FALSE,
+                       logLevel = c("quiet", "normal", "verbose"),
                        lint = FALSE,
                        metadata = list()) {
 
@@ -60,7 +60,7 @@ deploySite <- function(siteDir = getwd(),
     siteGenerator$render(input_file = NULL,
                          output_format = NULL,
                          envir = new.env(),
-                         quiet = quiet,
+                         quiet = identical(match.arg(logLevel), "quiet"),
                          encoding = getOption("encoding"))
   }
 
@@ -94,7 +94,7 @@ deploySite <- function(siteDir = getwd(),
             account = account,
             server = server,
             launch.browser = launch.browser,
-            quiet = quiet,
+            logLevel = logLevel,
             lint = lint,
             metadata = metadata)
 }

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -9,7 +9,8 @@ deployApp(appDir = getwd(), appFiles = NULL, appFileManifest = NULL,
   appTitle = NULL, contentCategory = NULL, account = NULL,
   server = NULL, upload = TRUE,
   launch.browser = getOption("rsconnect.launch.browser", interactive()),
-  quiet = FALSE, lint = TRUE, metadata = list())
+  logLevel = c("normal", "quiet", "verbose"), lint = TRUE,
+  metadata = list())
 }
 \arguments{
 \item{appDir}{Directory containing application. Defaults to current working
@@ -61,8 +62,10 @@ re-deployed using the last version that was uploaded.}
 launched automatically after the app is started. Defaults to \code{TRUE} in
 interactive sessions only.}
 
-\item{quiet}{Request that no status information be printed to the console
-during the deployment.}
+\item{logLevel}{One of \code{"quiet"}, \code{"normal"} or \code{"verbose"};
+indicates how much logging to the console is to be performed. At
+\code{"quiet"} reports no information; at \code{"verbose"}, a full
+diagnostic log is captured.}
 
 \item{lint}{Lint the project before initiating deployment, to identify
 potentially problematic code?}

--- a/man/deploySite.Rd
+++ b/man/deploySite.Rd
@@ -7,7 +7,8 @@
 deploySite(siteDir = getwd(), siteName = NULL, account = NULL,
   server = NULL, render = c("none", "local", "server"),
   launch.browser = getOption("rsconnect.launch.browser", interactive()),
-  quiet = FALSE, lint = FALSE, metadata = list())
+  logLevel = c("quiet", "normal", "verbose"), lint = FALSE,
+  metadata = list())
 }
 \arguments{
 \item{siteDir}{Directory containing website. Defaults to current
@@ -36,8 +37,10 @@ uploaded to the server.}
 launched automatically after the app is started. Defaults to \code{TRUE} in
 interactive sessions only.}
 
-\item{quiet}{Request that no status information be printed to the console
-during the deployment.}
+\item{logLevel}{One of \code{"quiet"}, \code{"normal"} or \code{"verbose"};
+indicates how much logging to the console is to be performed. At
+\code{"quiet"} reports no information; at \code{"verbose"}, a full
+diagnostic log is captured.}
 
 \item{lint}{Lint the project before initiating deployment, to identify
 potentially problematic code?}

--- a/man/options.Rd
+++ b/man/options.Rd
@@ -21,6 +21,7 @@ Supported global options include:
    \item{\code{rsconnect.http.trace}}{When \code{TRUE}, trace http calls (prints the method, path, and total milliseconds for each http request)}
    \item{\code{rsconnect.http.trace.json}}{When \code{TRUE}, trace JSON content (shows JSON payloads sent to and received from the server))}
    \item{\code{rsconnect.http.verbose}}{When \code{TRUE}, print verbose output for http connections (useful only for debugging SSL certificate or http connection problems)}
+   \item{\code{rsconnect.error.trace}}{{When \code{TRUE}, print detailed stack traces for errors occurring during deployment.}}
    \item{\code{rsconnect.launch.browser}}{When \code{TRUE}, automatically launch a browser to view applications after they are deployed}
    \item{\code{rsconnect.locale.cache}}{When \code{FALSE}, disable the detected locale cache (Windows only). }
    \item{\code{rsconnect.locale}}{Override the detected locale. }


### PR DESCRIPTION
This change addresses feedback from the support team concerning error attribution in deployment failures. Deployment is a complex process involving many parts (including Packrat for bundling, lots of logic in the rsconnect package itself, and then unbundling/rendering on the server end), and when a failure occurs it's not clear exactly where it's coming from. 

Towards that end, this change bundles a number of improvements:

There is now a **verbose output mode** for deployment. In this mode, the log is annotated with extra information, including the `deployApp` call and R session information, and most tracing options are enabled for the duration of the deployment, including those that log more detailed HTTP errors, and the JSON communication between the client and server.  Note that this part of the change changes function signatures. 

There is a **new option**, `rsconnect.error.trace`. This option, when enabled, installs a custom error handler that prints stack traces when a local error occurs during deployment.  It's designed mostly to be used by the above switch, but can also be used standalone. 

Errors from **Packrat** are now explicitly marked as such, even in non-verbose mode. 

There is a planned IDE side of this change: We'll add an affordance to the IDE, probably in the publish preferences pane, to make it possible for customers (and developers) to turn on the verbose output mode for deployments originating from the IDE so they can share the diagnostic logs with the support team when that's necessary (hopefully rarely). 
