### PR TITLE
load 'BiocInstaller' eagerly

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -558,6 +558,12 @@ performPackratSnapshot <- function(bundleDir) {
   on.exit(packrat::opts$snapshot.recommended.packages(srp, persist = FALSE),
           add = TRUE)
 
+  # attempt to eagerly load the BiocInstaller package if installed, to work
+  # around an issue where attempts to load the package could fail within a
+  # 'suppressMessages()' context
+  if (length(find.package("BiocInstaller", quiet = TRUE)))
+    requireNamespace("BiocInstaller", quietly = TRUE)
+
   # generate a snapshot
   suppressMessages(
     packrat::.snapshotImpl(project = bundleDir,


### PR DESCRIPTION
This PR should resolve an issue where deployments would fail from older versions of R that do not include https support.

The overaching issue -- `packrat::snapshot()` will attempt to invoke `BiocInstaller::biocinstallRepos()`, thus attempting to load the package. However, this will fail when executed within a `suppressMessages()` context; the simplest way to reproduce is

```
suppressMessages(library(BiocInstaller))
```

within an older version of R without libcurl support.