### PR TITLE
attempt to discover + use .Rproj file for encoding

### DIFF
--- a/R/lint-framework.R
+++ b/R/lint-framework.R
@@ -142,8 +142,8 @@ lint <- function(project, files = NULL, appPrimaryDoc = NULL) {
   }))
 
   # Read in the files
-  # TODO: perform this task more lazily?
-  projectContent <- suppressWarnings(lapply(projectFilesToLint, readLines))
+  encoding <- activeEncoding(project)
+  projectContent <- suppressWarnings(lapply(projectFilesToLint, readLines, encoding = encoding))
   names(projectContent) <- projectFilesToLint
   lintResults <- vector("list", length(linters))
   names(lintResults) <- names(linters)

--- a/R/utils.R
+++ b/R/utils.R
@@ -166,4 +166,20 @@ capitalize <- function(x) {
     paste0(toupper(substr(x, 1, 1)), substring(x, 2))
 }
 
+activeEncoding <- function(project = getwd()) {
+  defaultEncoding <- getOption("encoding")
 
+  # attempt to locate .Rproj file
+  files <- list.files(project, full.names = TRUE)
+  rprojFile <- grep("\\.Rproj$", files, value = TRUE)
+  if (length(rprojFile) != 1)
+    return(defaultEncoding)
+
+  # read the file
+  contents <- readLines(rprojFile, warn = FALSE, encoding = "UTF-8")
+  encodingLine <- grep("^Encoding:", contents, value = TRUE)
+  if (length(encodingLine) != 1)
+    return(defaultEncoding)
+
+  sub("^Encoding:\\s*", "", encodingLine)
+}


### PR DESCRIPTION
This PR attempts to discover + read the project `.Rproj` file when determining the encoding to use when reading files for the linter. This should help Windows users who are defaulting to UTF-8 for their projects.