### PR TITLE
Open Config URL after Deployment Regardless of needs_config Flag

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -329,11 +329,9 @@ deployApp <- function(appDir = getwd(),
     # if this client supports config, see if the app needs it
     if (!quiet && !is.null(client$configureApplication)) {
       config <- client$configureApplication(application$id)
-      if (config$needs_config) {
-        # app needs config, finish deployment on the server
-        showURL(config$config_url)
-        return(invisible(TRUE))
-      }
+      # open app in Dashboard for publishing or further configuration
+      showURL(config$config_url)
+      return(invisible(TRUE))
     }
 
     # launch the browser if requested

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -332,7 +332,7 @@ deployApp <- function(appDir = getwd(),
       # Open app in Dashboard for publishing or further configuration.
       # Preserve compatibility with older versions of connect by checking
       # to see if config$config_url is set.
-      if (!(is.na(config$config_url) || config$config_url == '')) {
+      if (!(is.null(config$config_url) || config$config_url == '')) {
         showURL(config$config_url)
         return(invisible(TRUE))
       }

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -329,9 +329,13 @@ deployApp <- function(appDir = getwd(),
     # if this client supports config, see if the app needs it
     if (!quiet && !is.null(client$configureApplication)) {
       config <- client$configureApplication(application$id)
-      # open app in Dashboard for publishing or further configuration
-      showURL(config$config_url)
-      return(invisible(TRUE))
+      # Open app in Dashboard for publishing or further configuration.
+      # Preserve compatibility with older versions of connect by checking
+      # to see if config$config_url is set.
+      if (!(is.na(config$config_url) || config$config_url == '')) {
+        showURL(config$config_url)
+        return(invisible(TRUE))
+      }
     }
 
     # launch the browser if requested


### PR DESCRIPTION
See rstudio/connect#4306 and rstudio/connect#4230. We've decided to redirect users to the Dashboard URL on both initial deployments and subsequent updates. 

Connect (as of rstudio/connect#4306) will return the `config_url` regardless of whether `needs_config` is `TRUE`. Compatibility with older Connect versions is preserved by testing to see if a `config_url` is returned.
