### PR TITLE
allow 'packrat/src' directory in deployments

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -73,12 +73,18 @@ maxDirectoryList <- function(dir, parent, totalSize) {
     for (subdir in subdirs) {
 
       # ignore known directories from the root
-      if (nchar(parent) == 0 && subdir %in% c(
-           "rsconnect", "packrat", ".svn", ".git", ".Rproj.user"))
+      ignoredSubdirs <- c("rsconnect", ".svn", ".git", ".Rproj.user")
+      if (nchar(parent) == 0 && subdir %in% ignoredSubdirs)
         next
 
       # ignore knitr _cache directories
       if (isKnitrCacheDir(subdir, contents))
+        next
+
+      # if this is a packrat sub-directory, ignore all other files
+      # and directories except for the 'src' directory
+      if (identical(basename(dir), "packrat") &&
+          !identical(subdir, "src"))
         next
 
       # get the list of files in the subdirectory

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -59,6 +59,11 @@ maxDirectoryList <- function(dir, parent, totalSize) {
     contents <- contents[!grepl(glob2rx(".Rhistory"), contents)]
   }
 
+  # within the packrat directory, only include 'src' folder
+  if (identical(basename(dir), "packrat")) {
+    contents <- contents[contents == "src"]
+  }
+
   # sum the size of the files in the directory
   info <- file.info(file.path(dir, contents))
   size <- sum(info$size)
@@ -79,12 +84,6 @@ maxDirectoryList <- function(dir, parent, totalSize) {
 
       # ignore knitr _cache directories
       if (isKnitrCacheDir(subdir, contents))
-        next
-
-      # if this is a packrat sub-directory, ignore all other files
-      # and directories except for the 'src' directory
-      if (identical(basename(dir), "packrat") &&
-          !identical(subdir, "src"))
         next
 
       # get the list of files in the subdirectory


### PR DESCRIPTION
This PR will allow the `packrat/src` directory to be included in deployments. Other subdirectories in the `packrat` folder are still screened out.

@jmcphers, can you review? Note that we don't want to merge this PR until the associated work in https://github.com/rstudio/packrat/pull/350 as well as some work on the Connect side is done as well.