### PR TITLE
Remove current user trailing slash

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -59,7 +59,7 @@ connectClient <- function(service, authInfo) {
     },
 
     currentUser = function() {
-      handleResponse(GET(service, authInfo, "/users/current/"))
+      handleResponse(GET(service, authInfo, "/users/current"))
     },
 
     ## Tokens API

--- a/R/connect.R
+++ b/R/connect.R
@@ -82,7 +82,7 @@ connectClient <- function(service, authInfo) {
       if (is.null(filters)) {
         filters <- vector()
       }
-      path <- "/applications/"
+      path <- "/applications"
       query <- paste(filterQuery(
         c("account_id", names(filters)),
         c(accountId, unname(filters))


### PR DESCRIPTION
We do a redirect in connect when a url comes in with a trailing slash. Removing it here just skips the redirect that connect does.