### PR TITLE
long-polling for connect task requests

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -160,7 +160,7 @@ connectClient <- function(service, authInfo) {
     waitForTask = function(taskId, quiet) {
       start <- 0
       while (TRUE) {
-        path <- paste0(file.path("/tasks", taskId), "?first_status=", start)
+        path <- paste0(file.path("/tasks", taskId), "?first_status=", start, "&wait_time=5")
         response <- handleResponse(GET(service, authInfo, path))
         if (length(response$status) > 0) {
           lapply(response$status, message)
@@ -169,7 +169,6 @@ connectClient <- function(service, authInfo) {
         if (response$finished) {
           return(response)
         }
-        Sys.sleep(1)
       }
     }
 


### PR DESCRIPTION
Long-polling was added to Connect in the 1.2.0 release. This change substantially decreases the number of requests made by rsconnect against Connect when looking for new task output.

Hold on merging for now; need to test the behavior against older Connect releases. 

Two open questions:
* Might need to retain the `Sys.sleep` to avoid fast-polling prior to 1.2.0.
* Are we comfortable waiting up to five seconds (or until task completion) to receive the next batch of output? Might need to adjust the Connect long-poll behavior when data is already available.