### PR TITLE
always use internal tar (#150)

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -192,7 +192,7 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
   prevDir <- setwd(bundleDir)
   on.exit(setwd(prevDir), add = TRUE)
   bundlePath <- tempfile("rsconnect-bundle", fileext = ".tar.gz")
-  utils::tar(bundlePath, files = ".", compression = "gzip")
+  utils::tar(bundlePath, files = ".", compression = "gzip", tar = "internal")
   bundlePath
 }
 

--- a/R/rpubs.R
+++ b/R/rpubs.R
@@ -90,7 +90,7 @@ rpubsUpload <- function(title,
 
     # create the tarball
     tarfile <- tempfile("package", fileext = ".tar.gz")
-    utils::tar(tarfile, files = ".", compression = "gzip")
+    utils::tar(tarfile, files = ".", compression = "gzip", tar = "internal")
 
     # return the full path to the tarball
     return(tarfile)


### PR DESCRIPTION
This PR should hopefully resolve an issue where attempts to `tar()` using the system `tar` program on Windows could produce incorrect filenames.