### PR TITLE
remove the get token call

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -71,11 +71,6 @@ connectClient <- function(service, authInfo) {
                                token))
     },
 
-    getToken = function(tokenId) {
-      handleResponse(GET(service, authInfo,
-                         file.path("/tokens", tokenId)))
-    },
-
     ## Applications API
 
     listApplications = function(accountId, filters = NULL) {


### PR DESCRIPTION
I cannot find a call of this function; trying to reduce the Connect API surface.