### PR TITLE
Fix a previous regression. The last PR that pulled out the config url…

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -315,34 +315,18 @@ deployApp <- function(appDir = getwd(),
   # before emitting the final status, to ensure it's the last line the user sees
   Sys.sleep(0.10)
 
-  # function to browse to a URL using user-supplied browser (config or final)
-  showURL <- function(url) {
-    if (isTRUE(launch.browser))
-      utils::browseURL(url)
-    else if (is.function(launch.browser))
-      launch.browser(url)
-  }
-
   deploymentSucceeded <- if (is.null(response$code) || response$code == 0) {
     displayStatus(paste0(capitalize(assetTypeName), " successfully deployed ",
                          "to ", application$url, "\n"))
-
-    # if this client supports config, see if the app needs it
-    openConfigURL(client, application, showURL, quiet)
-
-    # launch the browser if requested
-    showURL(application$url)
-
     TRUE
   } else {
     displayStatus(paste0(capitalize(assetTypeName), " deployment failed ",
                          "with error: ", response$error, "\n"))
-
-    # a client can still require config with some deployment failures
-    openConfigURL(client, application, showURL, quiet)
-
     FALSE
   }
+
+  if (!quiet)
+    openURL(client, application, launch.browser, deploymentSucceeded)
 
   if (verbose) {
     cat("----- Deployment log finished at ", as.character(Sys.time()), " -----\n")
@@ -528,17 +512,28 @@ applicationForTarget <- function(client, accountInfo, target) {
   app
 }
 
-## Check if client requires configuration, and if so, open to URL
-openConfigURL <- function(client, application, showURL = utils::browseURL, quiet = FALSE) {
-  if (!quiet && !is.null(client$configureApplication)) {
-    config <- client$configureApplication(application$id)
-    # Open app in Dashboard for publishing or further configuration.
-    # Preserve compatibility with older versions of connect by checking
-    # to see if config$config_url is set.
-    if (!(is.null(config$config_url) || config$config_url == '')) {
-      showURL(config$config_url)
-      return(invisible(TRUE))
-    }
+
+openURL <- function(client, application, launch.browser, deploymentSucceeded) {
+
+  # function to browse to a URL using user-supplied browser (config or final)
+  showURL <- function(url) {
+    if (isTRUE(launch.browser))
+      utils::browseURL(url)
+    else if (is.function(launch.browser))
+      launch.browser(url)
   }
+
+  # Check to see if we should open config url or app url
+  if (!is.null(client$configureApplication)) {
+    config <- client$configureApplication(application$id)
+    if (!(is.null(config$config_url) || config$config_url == '')) {
+      # Connect should always end up here, even on deployment failures
+      showURL(config$config_url)
+    }
+  } else if (deploymentSucceeded) {
+    # shinyapps.io should land here if things succeeded
+    showURL(application$url)
+  }
+    # or open no url if things failed
 }
 


### PR DESCRIPTION
The last PR that pulled out the config url check inadvertently removed a early return. The result: successful, first-time deployments would open the config page and then immediately open the content page. (This resulted in an error since the content was never published). This PR refactors the code to make the logic more clear and the code simpler. For Connect deployments, always open the config page (for successful deployments - per PR #147 - and for failures, per PR #167). For the lucid client, open the app url if deployment worked.