### PR TITLE
Changes to rsconnect to use the new lucid endpoints.

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -280,42 +280,18 @@ deployApp <- function(appDir = getwd(),
                      application$id), {
       bundlePath <- bundleApp(target$appName, appDir, appFiles,
                               appPrimaryDoc, assetTypeName, contentCategory)
-      cat("doing upload", "\n")
-      if(!is.null(client$clientName) && client$clientName() == "lucid"){
-        cat("lucid: ", bundlePath, "\n")
+
+      if(!isShinyapps(accountDetails)){
 
         # Step 1. Create presigned URL and register pending bundle.
         bundleSize <- file.info(bundlePath)$size
 
         # Generate a hex-encoded md5 hash.
         checkSum <- digest::digest(bundlePath, 'md5', file=TRUE)
-        bundle <- client$generatePresignedLink(application$id, "application/x-tar", bundleSize, checkSum)
+        bundle <- client$createBundle(application$id, "application/x-tar", bundleSize, checkSum)
 
         # Step 2. Upload Bundle to presigned URL
-        presigned_service <- parseHttpUrl(bundle$presigned_url)
-
-        headers <- list()
-        headers$`Content-Type` <-  'application/x-tar'
-        headers$`Content-Length` <-  bundleSize
-
-        # AWS requires a base64 encoded hash
-        headers$`Content-MD5` <-  bundle$presigned_checksum
-
-        # AWS seems very sensitive to additional headers (likely becauseit was not included and signed
-        # for when the presigned link was created). So the lower level library is used here.
-        http <- httpFunction()
-        response <- http(
-             presigned_service$protocol,
-             presigned_service$host,
-             presigned_service$port,
-             "PUT",
-             presigned_service$path,
-             headers,
-             'application/x-tar',
-             bundlePath
-        )
-
-        if(response$status != 200){
+        if(lucid::uploadBundle(bundle, bundleSize, bundlePath)){
           stop("Could not upload file.")
         }
 
@@ -327,9 +303,8 @@ deployApp <- function(appDir = getwd(),
 
         # Step 4. Retrieve updated bundle post status change - which is required in subsequent
         # areas of the code below.
-        bundle <- client$getBundleById(bundle$id)
+        bundle <- client$getBundle(bundle$id)
 
-        cat("Bundle done", "\n")
       }else{
         cat("connect path")
         bundle <- client$uploadApplication(application$id, bundlePath)

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -281,7 +281,7 @@ deployApp <- function(appDir = getwd(),
       bundlePath <- bundleApp(target$appName, appDir, appFiles,
                               appPrimaryDoc, assetTypeName, contentCategory)
 
-      if (!isShinyapps(accountDetails)) {
+      if (isShinyapps(accountDetails)) {
 
         # Step 1. Create presigned URL and register pending bundle.
         bundleSize <- file.info(bundlePath)$size
@@ -291,7 +291,7 @@ deployApp <- function(appDir = getwd(),
         bundle <- client$createBundle(application$id, "application/x-tar", bundleSize, checkSum)
 
         # Step 2. Upload Bundle to presigned URL
-        if (lucid::uploadBundle(bundle, bundleSize, bundlePath)) {
+        if (uploadBundle(bundle, bundleSize, bundlePath)) {
           stop("Could not upload file.")
         }
 
@@ -306,7 +306,6 @@ deployApp <- function(appDir = getwd(),
         bundle <- client$getBundle(bundle$id)
 
       } else {
-        cat("connect path")
         bundle <- client$uploadApplication(application$id, bundlePath)
       }
     })

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -291,7 +291,7 @@ deployApp <- function(appDir = getwd(),
         bundle <- client$createBundle(application$id, "application/x-tar", bundleSize, checkSum)
 
         # Step 2. Upload Bundle to presigned URL
-        if (uploadBundle(bundle, bundleSize, bundlePath)) {
+        if (!uploadBundle(bundle, bundleSize, bundlePath)) {
           stop("Could not upload file.")
         }
 

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -298,7 +298,8 @@ deployApp <- function(appDir = getwd(),
         # Step 3. Upload revise bundle status.
         response <- client$updateBundleStatus(bundle$id, status="ready")
         if (response$status != 303) {
-          stop("Errors updating bundle status.")
+          err <- handleResponse(response)
+          stop(paste("Errors updating bundle status:", response$status, "-" , err$error, sep=" "))
         }
 
         # Step 4. Retrieve updated bundle post status change - which is required in subsequent

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -297,10 +297,6 @@ deployApp <- function(appDir = getwd(),
 
         # Step 3. Upload revise bundle status.
         response <- client$updateBundleStatus(bundle$id, status="ready")
-        if (response$status != 303) {
-          err <- handleResponse(response)
-          stop(paste("Errors updating bundle status:", response$status, "-" , err$error, sep=" "))
-        }
 
         # Step 4. Retrieve updated bundle post status change - which is required in subsequent
         # areas of the code below.

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -281,7 +281,7 @@ deployApp <- function(appDir = getwd(),
       bundlePath <- bundleApp(target$appName, appDir, appFiles,
                               appPrimaryDoc, assetTypeName, contentCategory)
 
-      if(!isShinyapps(accountDetails)){
+      if (!isShinyapps(accountDetails)) {
 
         # Step 1. Create presigned URL and register pending bundle.
         bundleSize <- file.info(bundlePath)$size
@@ -291,13 +291,13 @@ deployApp <- function(appDir = getwd(),
         bundle <- client$createBundle(application$id, "application/x-tar", bundleSize, checkSum)
 
         # Step 2. Upload Bundle to presigned URL
-        if(lucid::uploadBundle(bundle, bundleSize, bundlePath)){
+        if (lucid::uploadBundle(bundle, bundleSize, bundlePath)) {
           stop("Could not upload file.")
         }
 
         # Step 3. Upload revise bundle status.
         response <- client$updateBundleStatus(bundle$id, status="ready")
-        if(response$status != 303){
+        if (response$status != 303) {
           stop("Errors updating bundle status.")
         }
 
@@ -305,7 +305,7 @@ deployApp <- function(appDir = getwd(),
         # areas of the code below.
         bundle <- client$getBundle(bundle$id)
 
-      }else{
+      } else {
         cat("connect path")
         bundle <- client$uploadApplication(application$id, bundlePath)
       }

--- a/R/lucid.R
+++ b/R/lucid.R
@@ -320,7 +320,7 @@ uploadBundle <- function(bundle, bundleSize, bundlePath){
     "PUT",
     presigned_service$path,
     headers,
-    'application/x-tar',
+    headers$`Content-Type`,
     bundlePath
   )
 

--- a/R/lucid.R
+++ b/R/lucid.R
@@ -43,7 +43,7 @@ lucidClient <- function(service, authInfo) {
       path <- paste("/bundles/", bundleId, "/status", sep="")
       json <- list()
       json$status = status
-      POST_JSON(service, authInfo, path, json)
+      handleResponse(POST_JSON(service, authInfo, path, json))
     },
 
     createBundle = function(application, content_type, content_length, checksum) {

--- a/R/lucid.R
+++ b/R/lucid.R
@@ -5,6 +5,10 @@ lucidClient <- function(service, authInfo) {
 
   list(
 
+    clientName = function(){
+      "lucid"
+    },
+
     status = function() {
       handleResponse(GET(service, authInfo,  "/internal/status"))
     },
@@ -32,6 +36,27 @@ lucidClient <- function(service, authInfo) {
       if (is.null(interval))
         query$interval = interval
       handleResponse(GET(service, authInfo, path, queryString(query)))
+    },
+
+    getBundleById = function(bundleId){
+      path <- paste("/bundles/", bundleId, sep="")
+      handleResponse(GET(service, authInfo, path))
+    },
+
+    updateBundleStatus = function(bundleId, status) {
+      path <- paste("/bundles/", bundleId, "/status", sep="")
+      json <- list()
+      json$status = status
+      POST_JSON(service, authInfo, path, json)
+    },
+
+    generatePresignedLink = function(application, content_type, content_length, checksum) {
+      json <- list()
+      json$application = application
+      json$content_type = content_type
+      json$content_length = content_length
+      json$checksum = checksum
+      handleResponse(POST_JSON(service, authInfo, "/bundles", json))
     },
 
    listApplications = function(accountId, filters = list()) {

--- a/R/lucid.R
+++ b/R/lucid.R
@@ -324,5 +324,5 @@ uploadBundle <- function(bundle, bundleSize, bundlePath){
     bundlePath
   )
 
-  response$status != 200
+  response$status == 200
 }

--- a/R/lucid.R
+++ b/R/lucid.R
@@ -324,6 +324,5 @@ uploadBundle <- function(bundle, bundleSize, bundlePath){
     bundlePath
   )
 
-  response$status == 200
-
+  response$status != 200
 }


### PR DESCRIPTION
Changes to use the new presigned-url bundle upload feature. Instead of uploading a file through the lucid application is will upload the file directly to AWS S3 using a pre-authorized path. 