### PR TITLE
permit fallback to CRAN during snapshot

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -597,6 +597,7 @@ performPackratSnapshot <- function(bundleDir) {
   suppressMessages(
     packrat::.snapshotImpl(project = bundleDir,
                            snapshot.sources = FALSE,
+                           fallback.ok = TRUE,
                            verbose = FALSE)
   )
 


### PR DESCRIPTION
This PR relaxes the requirement that packages installed from sources will cause a Packrat snapshot to fail. Now, if a user attempts to deploy an application that makes use of a package installed from sources, Packrat will accept the snapshot, and warn the user that Packrat will attempt to restore that package from CRAN for future restores.

Note that the restore behavior can still be overridden based on active Packrat options (e.g. `external.packages` or `ignored.packages`), so the primary effect here is just to ensure that snapshots that users make with packages installed from sources succeed; it's still possible that attempts to deploy / run their application could fail if the user has not synchronized their under-development package with their local CRAN-like repository (or whatever mechanism they're using to get packages installed on the Connect side).

If this PR is taken, it should likely be taken in tandem with a bump in the Packrat version: https://github.com/rstudio/packrat/commit/d4b591e11f2e43b4b18ba8ef48635f5f6f809805