### PR TITLE
Add session-long support for cookies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rsconnect
 Type: Package
 Title: Deployment Interface for R Markdown Documents and Shiny Applications
-Version: 0.8
+Version: 0.8.1
 Author: JJ Allaire
 Maintainer: JJ Allaire <jj@rstudio.com>
 Description: Programmatic deployment interface for 'RPubs', 'shinyapps.io', and

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -267,6 +267,18 @@ deployApp <- function(appDir = getwd(),
   accountDetails <- accountInfo(target$account, target$server)
   client <- clientForAccount(accountDetails)
 
+  if(verbose){
+    urlstr <- serverInfo(accountDetails$server)$url
+    url <- parseHttpUrl(urlstr)
+    cat("Cookies:", "\n")
+    host <- getCookieHost(url)
+    if (exists(host, .cookieStore)){
+      print(get(host, envir=.cookieStore))
+    } else {
+      print("None")
+    }
+  }
+
   # get the application to deploy (creates a new app on demand)
   withStatus(paste0("Preparing to deploy ", assetTypeName), {
     application <- applicationForTarget(client, accountDetails, target)

--- a/R/http.R
+++ b/R/http.R
@@ -61,13 +61,10 @@ getCookieHost <- function(requestURL){
 # Parse out the raw headers provided and insert them into the cookieStore
 # NOTE: Domain attribute is currently ignored
 # @param requestURL the parsed URL as returned from `parseHttpUrl`
-# @param cookieHeaders a vector of characters strings representing the raw
+# @param cookieHeaders a list of characters strings representing the raw
 #   Set-Cookie header value with the "Set-Cookie: " prefix omitted
 storeCookies <- function(requestURL, cookieHeaders){
-  cookies <- lapply(cookieHeaders, function(co){ parseCookieHeader(requestURL, co) })
-
-  # Flatten out since some headers might contain multiple cookies
-  cookies <- unlist(cookies, recursive=FALSE)
+  cookies <- lapply(cookieHeaders, function(co){ parseCookie(requestURL, co) })
 
   # Filter out invalid cookies (which would return as NULL)
   cookies <- Filter(Negate(is.null), cookies)
@@ -105,20 +102,8 @@ storeCookies <- function(requestURL, cookieHeaders){
 # Parse out an individual cookie
 # @param requestURL the parsed URL as returned from `parseHttpUrl`
 # @param cookieHeader the raw text contents of the Set-Cookie header with the
-#   header name omitted. May contain multiple comma-separated cookies
-parseCookieHeader <- function(requestURL, cookieHeader){
-  cookieStrs <- strsplit(cookieHeader, ",", fixed=TRUE)[[1]]
-  # Trim whitespace
-  cookieStrs <- gsub("^\\s*|\\s*$", "", cookieStrs)
-
-  lapply(cookieStrs, function(co){ parseSingleCookie(requestURL, co) })
-}
-
-# Parse out an individual cookie
-# @param requestURL the parsed URL as returned from `parseHttpUrl`
-# @param cookieHeader the raw text contents of the Set-Cookie header with the
 #   header name omitted.
-parseSingleCookie <- function(requestURL, cookieHeader){
+parseCookie <- function(requestURL, cookieHeader){
   keyval <- regmatches(cookieHeader, regexec(
     "^(\\w+)\\s*=\\s*([^;]*)(;|$)", cookieHeader, ignore.case=TRUE))[[1]]
   if (length(keyval) == 0){

--- a/R/http.R
+++ b/R/http.R
@@ -18,6 +18,7 @@ getCookieHost <- function(requestURL){
     # Erring on the side of not sending the cookies to the wrong services
     host <- paste(host, port, sep=":")
   }
+  host
 }
 
 # Parse out the raw headers provided and insert them into the cookieStore

--- a/R/http.R
+++ b/R/http.R
@@ -21,7 +21,6 @@ getCookieHost <- function(requestURL){
 }
 
 # Parse out the raw headers provided and insert them into the cookieStore
-# FIXME: secure flag
 # NOTE: Domain attribute is currently ignored
 # @param requestURL the parsed URL as returned from `parseHttpUrl`
 # @param cookieHeaders a vector of characters strings representing the raw

--- a/R/http.R
+++ b/R/http.R
@@ -120,7 +120,7 @@ parseCookieHeader <- function(requestURL, cookieHeader){
 #   header name omitted.
 parseSingleCookie <- function(requestURL, cookieHeader){
   keyval <- regmatches(cookieHeader, regexec(
-    "^(\\w+)\\s*=\\s*([^;]*)(;|\\z)", cookieHeader, perl=TRUE, ignore.case=TRUE))[[1]]
+    "^(\\w+)\\s*=\\s*([^;]*)(;|$)", cookieHeader, ignore.case=TRUE))[[1]]
   if (length(keyval) == 0){
     # Invalid cookie format.
     warning("Unable to parse set-cookie header: ", cookieHeader)
@@ -131,7 +131,7 @@ parseSingleCookie <- function(requestURL, cookieHeader){
 
   # Path
   path <- regmatches(cookieHeader, regexec(
-    "^.*\\sPath\\s*=\\s*([^;]+)(;|\\z).*$", cookieHeader, perl=TRUE, ignore.case=TRUE))[[1]]
+    "^.*\\sPath\\s*=\\s*([^;]+)(;|$).*$", cookieHeader, ignore.case=TRUE))[[1]]
   if (length(path) == 0){
     path <- "/"
   } else {
@@ -145,7 +145,7 @@ parseSingleCookie <- function(requestURL, cookieHeader){
 
   # MaxAge
   maxage <- regmatches(cookieHeader, regexec(
-    "^.*\\sMax-Age\\s*=\\s*(-?\\d+)(;|\\z).*$", cookieHeader, perl = TRUE, ignore.case=TRUE))[[1]]
+    "^.*\\sMax-Age\\s*=\\s*(-?\\d+)(;|$).*$", cookieHeader, ignore.case=TRUE))[[1]]
   # If no maxage specified, then this is a session cookie, which means that
   # (since our cookies only survive for a single session anyways...) we should
   # keep this cookie around as long as we're alive.
@@ -156,7 +156,7 @@ parseSingleCookie <- function(requestURL, cookieHeader){
   }
 
   # Secure
-  secure <- grepl(";\\s+Secure(;|\\z)", cookieHeader, perl=TRUE, ignore.case=TRUE)
+  secure <- grepl(";\\s+Secure(;|$)", cookieHeader, ignore.case=TRUE)
 
   list(name=key,
        value=val,

--- a/R/http.R
+++ b/R/http.R
@@ -70,7 +70,10 @@ storeCookies <- function(requestURL, cookieHeaders){
 # @param cookieHeader the raw text contents of the Set-Cookie header with the
 #   header name omitted. May contain multiple comma-separated cookies
 parseCookieHeader <- function(requestURL, cookieHeader){
-  cookieStrs <- trimws(strsplit(cookieHeader, ",", fixed=TRUE)[[1]])
+  cookieStrs <- strsplit(cookieHeader, ",", fixed=TRUE)[[1]]
+  # Trim whitespace
+  cookieStrs <- gsub("^\\s*|\\s*$", "", cookieStrs)
+
   lapply(cookieStrs, function(co){ parseSingleCookie(requestURL, co) })
 }
 

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -75,7 +75,7 @@ record. These fields will be returned on subsequent calls to
 \code{\link{deployments}}.}
 }
 \description{
-Deploy a Shiny application, an R Markdown
+Deploy a \link[shiny:shiny-package]{shiny} application, an R Markdown
 document, or HTML content to a server.
 }
 \examples{

--- a/tests/testthat/test-http.R
+++ b/tests/testthat/test-http.R
@@ -1,0 +1,143 @@
+context("http")
+
+test_that("URL parsing works", {
+  p <- parseHttpUrl("http://yahoo.com")
+  expect_equal(p$protocol, "http")
+  expect_equal(p$host, "yahoo.com")
+  expect_equal(p$port, "")
+  expect_equal(p$path, "") #TODO: bug? Should default to /?
+
+  p <- parseHttpUrl("https://rstudio.com/about")
+  expect_equal(p$protocol, "https")
+  expect_equal(p$host, "rstudio.com")
+  expect_equal(p$port, "")
+  expect_equal(p$path, "/about")
+
+  p <- parseHttpUrl("http://127.0.0.1:3939/stuff/here/?who-knows")
+  expect_equal(p$protocol, "http")
+  expect_equal(p$host, "127.0.0.1")
+  expect_equal(p$port, "3939")
+  expect_equal(p$path, "/stuff/here/?who-knows") #TODO: bug?
+})
+
+test_that("Parsing cookies works", {
+  parsedUrl <- parseHttpUrl("http://rstudio.com/test/stuff")
+  # Note that the Expires field is ignored
+  cookie <- parseCookie(parsedUrl, "mycookie=myvalue; Path=/; Expires=Sat, 24 Jun 2017 16:16:05 GMT; Max-Age=3600; HttpOnly")
+  expect_equal(cookie$name, "mycookie")
+  expect_equal(cookie$value, "myvalue")
+  expect_true(cookie$expires > Sys.time() + 3595)
+  expect_true(cookie$expires < Sys.time() + 3605)
+  expect_equal(cookie$path, "/")
+
+  # Max-Age with no semicolon, non-root path
+  cookie <- parseCookie(parsedUrl, "mycookie2=myvalue2; Path=/test; Max-Age=3600")
+  expect_equal(cookie$name, "mycookie2")
+  expect_equal(cookie$value, "myvalue2")
+  expect_true(cookie$expires > Sys.time() + 3595)
+  expect_true(cookie$expires < Sys.time() + 3605)
+  expect_equal(cookie$path, "/test")
+
+  # Path with no semicolon, no max age
+  cookie <- parseCookie(parsedUrl, "mycookie2=myvalue2; Path=/test")
+  expect_equal(cookie$name, "mycookie2")
+  expect_equal(cookie$value, "myvalue2")
+  expect_null(cookie$expires)
+  expect_equal(cookie$path, "/test")
+
+  # No path, value with no semicolon
+  cookie <- parseCookie(parsedUrl, "mycookie2=myvalue2")
+  expect_equal(cookie$name, "mycookie2")
+  expect_equal(cookie$value, "myvalue2")
+  expect_null(cookie$expires)
+  expect_equal(cookie$path, "/")
+
+  # Full cookie with spaces around =s
+  cookie <- parseCookie(parsedUrl, "mycookie = myvalue; Path = /; Expires = Sat, 24 Jun 2017 16:16:05 GMT; Max-Age = 3600; HttpOnly")
+  expect_equal(cookie$name, "mycookie")
+  expect_equal(cookie$value, "myvalue")
+  expect_true(cookie$expires > Sys.time() + 3595)
+  expect_true(cookie$expires < Sys.time() + 3605)
+  expect_equal(cookie$path, "/")
+
+  # Value-less cookie
+  cookie <- parseCookie(parsedUrl, "mycookie=; Path = /")
+  expect_equal(cookie$name, "mycookie")
+  expect_equal(cookie$value, "")
+  expect_equal(cookie$path, "/")
+})
+
+test_that("Invalid cookies fail parsing", {
+  # Invalid path, doesn't match request's path
+  parsedUrl <- parseHttpUrl("http://rstudio.com/test/stuff")
+  expect_warning({cookie <- parseCookie(parsedUrl, "mycookie=myvalue; Path=/something/else")},
+                 "Invalid path set for cookie")
+  expect_null(cookie)
+
+  # Invalid key/val format
+  expect_warning({cookie <- parseCookie(parsedUrl, "mycookie;")},
+                 "Unable to parse set-cookie ")
+  expect_null(cookie)
+})
+
+clearCookieStore <- function(){
+  if (exists("fakedomain:123", .cookieStore)){
+    rm("fakedomain:123", envir=.cookieStore)
+  }
+}
+
+test_that("cookies can be stored", {
+  clearCookieStore()
+
+  parsedUrl <- parseHttpUrl("http://fakedomain:123/test/stuff")
+  expect_warning({
+    storeCookies(parsedUrl, c(
+      "mycookie=myvalue; Path=/; Max-Age=3600; HttpOnly",
+      "anotherCookie=what; Path=/test; Max-Age=100",
+      "wrongpath=huh; Path=/uhoh; Max-Age=100")
+    )
+  }, "Invalid path set for cookie")
+  cookies <- get("fakedomain:123", envir=.cookieStore)
+  expect_equal(nrow(cookies), 2)
+
+  # Check the first cookie
+  co <- cookies[cookies$name=="mycookie",]
+  expect_equal(co$name, "mycookie")
+  expect_equal(co$value, "myvalue")
+  expect_true(co$expires > Sys.time() + 3595)
+  expect_true(co$expires < Sys.time() + 3605)
+  expect_equal(co$path, "/")
+
+  # And the other
+  co <- cookies[cookies$name=="anotherCookie",]
+  expect_equal(co$name, "anotherCookie")
+  expect_equal(co$value, "what")
+  expect_true(co$expires > Sys.time() + 95)
+  expect_true(co$expires < Sys.time() + 105)
+  expect_equal(co$path, "/test")
+})
+
+
+test_that("duplicate cookies overwrite one another", {
+  clearCookieStore()
+
+  parsedUrl <- parseHttpUrl("http://fakedomain:123/test/stuff")
+  storeCookies(parsedUrl, "mycookie=myvalue; Path=/; Max-Age=3600")
+  cookies <- get("fakedomain:123", envir=.cookieStore)
+  expect_equal(nrow(cookies), 1)
+
+  # Add another valid cookie, same domain, same name, different path
+  storeCookies(parsedUrl, "mycookie=myvalue; Path=/test; Max-Age=3600")
+  cookies <- get("fakedomain:123", envir=.cookieStore)
+  expect_equal(nrow(cookies), 2)
+
+  # Duplicate cookie should overwrite
+  storeCookies(parsedUrl, "mycookie=myvalue; Path=/test; Max-Age=99")
+  cookies <- get("fakedomain:123", envir=.cookieStore)
+  expect_equal(nrow(cookies), 2)
+
+  # Confirm that the stored cookie is the more recent one.
+  co <- cookies[cookies$path=="/test",]
+  expect_true(co$expires > Sys.time() + 94)
+  expect_true(co$expires < Sys.time() + 104)
+})

--- a/tests/testthat/test-http.R
+++ b/tests/testthat/test-http.R
@@ -269,3 +269,10 @@ test_that("Expired cookies are removed", {
   cookies <- get("fakedomain:123", envir=.cookieStore)
   expect_equal(nrow(cookies), 1)
 })
+
+test_that("getCookieHost works", {
+  expect_equal(getCookieHost(parseHttpUrl("http://rstudio.com")), "rstudio.com")
+  expect_equal(getCookieHost(parseHttpUrl("http://rstudio.com:3939")), "rstudio.com:3939")
+  expect_equal(getCookieHost(parseHttpUrl("http://127.0.0.1")), "127.0.0.1")
+  expect_equal(getCookieHost(parseHttpUrl("http://127.0.0.1:3939")), "127.0.0.1:3939")
+})

--- a/tests/testthat/test-http.R
+++ b/tests/testthat/test-http.R
@@ -276,3 +276,50 @@ test_that("getCookieHost works", {
   expect_equal(getCookieHost(parseHttpUrl("http://127.0.0.1")), "127.0.0.1")
   expect_equal(getCookieHost(parseHttpUrl("http://127.0.0.1:3939")), "127.0.0.1:3939")
 })
+
+test_that("getting and clearing cookies works", {
+  clearCookieStore()
+
+  all <- getCookies()
+  expect_null(all)
+
+  # Add a few cookies
+  domain1 <- parseHttpUrl("http://domain1/test/stuff")
+  storeCookies(domain1, "c1=v1")
+  storeCookies(domain1, "c2=v2")
+
+  domain2 <- parseHttpUrl("http://domain2:3939/test/stuff")
+  storeCookies(domain2, "c3=v3")
+
+  d1c <- getCookies("domain1")
+  expect_equal(nrow(d1c), 2)
+  expect_equal(d1c$host[1], "domain1")
+
+  d2c <- getCookies("domain2")
+  expect_null(d2c)
+  d2c <- getCookies("domain2", 3939)
+  expect_equal(nrow(d2c), 1)
+  expect_equal(d2c$host[1], "domain2:3939")
+
+  all <- getCookies()
+  expect_equal(nrow(all), 3)
+
+  # Delete cookies from one domain
+  clearCookies("domain2", 3939)
+
+  d2c <- getCookies("domain2", 3939)
+  expect_null(d2c)
+
+  all <- getCookies()
+  expect_equal(nrow(all), 2)
+
+  # Clear all cookies
+  clearCookies()
+
+  d1c <- getCookies("domain1")
+  expect_null(d1c)
+
+  all <- getCookies()
+  expect_null(all)
+
+})


### PR DESCRIPTION
Enables all three HTTP modes in rsconnect to support cookies. This is important for RSC in HA environments where the load balancer will set a cookie to ensure session stickiness.

Largely based off of [this RFC](http://www.ietf.org/rfc/rfc2109.txt). Intentional deviations or omissions from the RFC are called out in the code (e.g. the inclusion of the port in the hostname for domains, no support for the `domain` field on cookies). 

Happy to take input on the R code or if there are cleaner ways to implement portions of this. Also hoping to get eyes on the changes around `http.R:220`. I'm using an explicit equality check here in order to be case-insensitive, but that means leaving behind `identical` which makes us vulnerable to `NULL` comparisons. Based on my reading of `parseHttpHeader`, I don't think this will be a problem but I'd like for someone to confirm.