### PR TITLE
Roll back plumber version to 0.3.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Suggests:
     knitr,
     testthat,
     rmarkdown (>= 1.1),
-    plumber (>= 0.3.3)
+    plumber (>= 0.3.2)
 Enhances: BiocInstaller
 License: GPL-2
 RoxygenNote: 6.0.1

--- a/R/deployAPI.R
+++ b/R/deployAPI.R
@@ -13,8 +13,8 @@
 deployAPI <- function(api,
                       ...) {
   if (!requireNamespace("plumber") ||
-      packageVersion("plumber") < "0.3.3") {
-    stop("Version 0.3.3 or later of the plumber package is required to ",
+      packageVersion("plumber") < "0.3.2") {
+    stop("Version 0.3.2 or later of the plumber package is required to ",
          "deploy plumber APIs.")
   }
   if (!file.exists(api)) {


### PR DESCRIPTION
0.3.3 isn't on CRAN yet, which causes packrat issues.