### PR TITLE
Manually cast rbind args to factorless data.frame

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rsconnect
 Type: Package
 Title: Deployment Interface for R Markdown Documents and Shiny Applications
-Version: 0.8.2
+Version: 0.8.3
 Author: JJ Allaire
 Maintainer: JJ Allaire <jj@rstudio.com>
 Description: Programmatic deployment interface for 'RPubs', 'shinyapps.io', and

--- a/R/http.R
+++ b/R/http.R
@@ -92,7 +92,7 @@ storeCookies <- function(requestURL, cookieHeaders){
     hostCookies <<- hostCookies[!(co$name == hostCookies$name & co$path == hostCookies$path),]
 
     # append this new cookie on
-    hostCookies <<- rbind(co, hostCookies, stringsAsFactors=FALSE)
+    hostCookies <<- rbind(as.data.frame(co, stringsAsFactors=FALSE), hostCookies)
   })
 
   # Save this host's cookies into the cookies store.


### PR DESCRIPTION
This actually was covered in our automated tests but I hadn't executed in old versions of R so I didn't catch this :(. The HTTP tests now pass in R3.2.1 (but be aware that some of the bundle tests do still fail in that older version. I can open a separate ticket if that's unexpected).

R 3.2.1 (at least) doesn't support stringsAsFactors in rbind, so you have to create the
factorless data.frame yourself then pass that into rbind if you want to get out of SAF.

Unfortunately our StringsAsFactors call was being interpreted as another row that might
be rbound.