### PR TITLE
Use server name computed from account details (fixes #202)

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -464,7 +464,8 @@ deploymentTarget <- function(appPath, appName, appTitle, appId, account,
   # both appName and account explicitly specified
   if (!is.null(appName) && !is.null(account)) {
     accountDetails <- accountInfo(account, server)
-    createDeploymentTarget(appName, appTitle, appId, accountDetails$username, account, server)
+    createDeploymentTarget(appName, appTitle, appId, accountDetails$username,
+                           account, accountDetails$server)
   }
 
   # just appName specified


### PR DESCRIPTION
This change fixes an error which can arise when deploying applications in the following situation:

- deployment occurs using the R console (not the RStudio UI);
- the application name to deploy is specified;
- the account name is specified; AND
- the server name is not specified.

In this case, the computed server name is not correctly passed to `createDeploymentTarget`, resulting in an error; the fix is to use the computed server name based on the locally stored account information.