### PR TITLE
Emit X-Auth-Token HTTP header in every request to RStudio Connect

### DIFF
--- a/R/http.R
+++ b/R/http.R
@@ -764,6 +764,8 @@ httpRequestWithBody <- function(service,
   if (!is.null(authInfo$secret) || !is.null(authInfo$private_key)) {
     sigHeaders <- signatureHeaders(authInfo, method, url, file)
     headers <- append(headers, sigHeaders)
+  } else {
+    headers <- append(headers, bogusSignatureHeaders())
   }
 
   # perform request
@@ -804,6 +806,8 @@ httpRequest <- function(service,
       !identical(names(authInfo), "certificate")) {
     sigHeaders <- signatureHeaders(authInfo, method, url, NULL)
     headers <- append(headers, sigHeaders)
+  } else {
+    headers <- append(headers, bogusSignatureHeaders())
   }
 
   # perform GET
@@ -857,6 +861,10 @@ queryString <- function (elements) {
     result <- ""
   }
   return(result)
+}
+
+bogusSignatureHeaders <- function() {
+  list(`X-Auth-Token` = 'anonymous-access') # The value doesn't actually matter here, but the header needs to be set.
 }
 
 signatureHeaders <- function(authInfo, method, path, file) {


### PR DESCRIPTION
Connected to #216 

The fake X-Auth-Token is provided to allow anonymous access through a properly configured SSO proxy.

To take advantage of this functionality, the proxy should permit any request that provides `X-Auth-Token` to pass through to Connect.

`deployApp` tested on a local copy of Connect running master branch, proxy auth.