### PR TITLE
Allow custom message in email from rsconnect::addAuthorizedUser

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -46,7 +46,8 @@ cleanupPasswordFile <- function(appDir) {
 #' @note This function works only for ShinyApps servers.
 #' @export
 addAuthorizedUser <- function(email, appDir=getwd(), appName=NULL,
-                              account = NULL, server=NULL, sendEmail=NULL) {
+                              account = NULL, server=NULL, sendEmail=NULL,
+                              emailMessage = NULL) {
 
   # resolve account
   accountDetails <- accountInfo(resolveAccount(account, server), server)
@@ -61,7 +62,8 @@ addAuthorizedUser <- function(email, appDir=getwd(), appName=NULL,
 
   # fetch authoriztion list
   api <- clientForAccount(accountDetails)
-  api$inviteApplicationUser(application$id, validateEmail(email), sendEmail)
+  api$inviteApplicationUser(application$id, validateEmail(email), sendEmail,
+                            emailMessage)
 
   message(paste("Added:", email, "to application", sep=" "))
 

--- a/R/auth.R
+++ b/R/auth.R
@@ -42,6 +42,9 @@ cleanupPasswordFile <- function(appDir) {
 #'   multiple servers.
 #' @param sendEmail Send an email letting the user know the application
 #'   has been shared with them.
+#' @param emailMessage Optional character vector of length 1 containing a
+#'   custom message to send in email invitation. Defaults to NULL, which
+#'   will use default invitation message.
 #' @seealso \code{\link{removeAuthorizedUser}} and \code{\link{showUsers}}
 #' @note This function works only for ShinyApps servers.
 #' @export

--- a/man/addAuthorizedUser.Rd
+++ b/man/addAuthorizedUser.Rd
@@ -5,7 +5,7 @@
 \title{Add authorized user to application}
 \usage{
 addAuthorizedUser(email, appDir = getwd(), appName = NULL, account = NULL,
-  server = NULL, sendEmail = NULL)
+  server = NULL, sendEmail = NULL, emailMessage = NULL)
 }
 \arguments{
 \item{email}{Email address of user to add.}

--- a/man/addAuthorizedUser.Rd
+++ b/man/addAuthorizedUser.Rd
@@ -23,6 +23,10 @@ multiple servers.}
 
 \item{sendEmail}{Send an email letting the user know the application
 has been shared with them.}
+
+\item{emailMessage}{Optional character vector of length 1 containing a
+custom message to send in email invitation. Defaults to NULL, which
+will use default invitation message.}
 }
 \description{
 Add authorized user to application


### PR DESCRIPTION
This modification allows users to specify a custom message when adding users via the rsconnect package, as is possible when adding users from the shinyapps.io dashboard.