### PR TITLE
Use hash of public key instead of random token

### DIFF
--- a/R/rsa.R
+++ b/R/rsa.R
@@ -1,9 +1,4 @@
 
-# generate a unique ID
-createUniqueId <- function(bytes) {
-  paste(as.hexmode(sample(256, bytes)-1), collapse="")
-}
-
 # generateToken generates a token for signing requests sent to the RStudio
 # Connect service. The token's ID and public key are sent to the server, and
 # the private key is saved locally.
@@ -11,8 +6,15 @@ generateToken <- function() {
   key <- PKI::PKI.genRSAkey(bits = 2048L)
   priv.der <- PKI::PKI.save.key(key, format = "DER")
   pub.der <- PKI::PKI.save.key(key, format = "DER", private = FALSE)
+
+  # hash the public key to generate the token ID; we used to create a random
+  # token ID using sample(), but this causes trouble for users who use a fixed
+  # RNG seed and/or need the RNG state to remain unperturbed.
+  tokenId <- digest::digest(object = pub.der, algo = "md5")
+
+  # form the token from the
   list(
-    token = paste0("T", createUniqueId(16)),
+    token = paste0("T", tokenId),
     public_key = RCurl::base64Encode(pub.der),
     private_key = RCurl::base64Encode(priv.der)
   )

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -35,7 +35,7 @@ test_that("Users API", {
   server <- getDefaultServer(local = TRUE)
 
   connect <- connectClient(server$url, list())
-  id <- createUniqueId(16)
+  id <- paste(as.hexmode(sample(256, bytes)-1), collapse="")
 
   # add a user
   record <- userRecord(


### PR DESCRIPTION
This change fixes the issue described in #221: instead of using `sample()` to generate a random, unique token, we hash the public key (a large, random value derived from a separate random stream) to generate a token ID. 

Note that this change results in roughly a doubling of the token ID length. As users don't have to type or generally even see these URLs, this is probably fine, but we could discard some of the hashed bytes if it becomes an issue. 