### PR TITLE
Added deployApp(update = c("ask", "force")) argument to reduce friction in interactive environments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rsconnect
 Type: Package
 Title: Deployment Interface for R Markdown Documents and Shiny Applications
-Version: 0.8.7
+Version: 0.8.8
 Author: JJ Allaire
 Maintainer: JJ Allaire <jj@rstudio.com>
 Description: Programmatic deployment interface for 'RPubs', 'shinyapps.io', and

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -10,7 +10,7 @@ deployApp(appDir = getwd(), appFiles = NULL, appFileManifest = NULL,
   server = NULL, upload = TRUE,
   launch.browser = getOption("rsconnect.launch.browser", interactive()),
   logLevel = c("normal", "quiet", "verbose"), lint = TRUE,
-  metadata = list())
+  metadata = list(), update = c("ask", "force"))
 }
 \arguments{
 \item{appDir}{Directory containing application. Defaults to current working
@@ -76,6 +76,8 @@ potentially problematic code?}
 \item{metadata}{Additional metadata fields to save with the deployment
 record. These fields will be returned on subsequent calls to
 \code{\link{deployments}}.}
+
+\item{update}{If app already exists should the app be updated without a prompt in interactive mode? Either \code{"ask"} or \ask{"force"}, defaults to \code{"ask"}.}
 }
 \description{
 Deploy a \link[shiny:shiny-package]{shiny} application, an R Markdown


### PR DESCRIPTION
The update argument allows the interactive menu choice to be overridden if the specified app already exists. I feel a documented method to circumvent this interactive menu is important, though alternatives to this PR might be preferential :)