### PR TITLE
handle usernames with a trailing dot

### DIFF
--- a/R/accounts.R
+++ b/R/accounts.R
@@ -26,7 +26,7 @@ accounts <- function(server = NULL) {
     path <- file.path(path, server)
 
   # get a raw list of accounts
-  accountnames <- tools::file_path_sans_ext(list.files(path,
+  accountnames <- file_path_sans_ext(list.files(path,
     pattern=glob2rx("*.dcf"), recursive = TRUE))
 
   if (length(accountnames) == 0) {

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -148,7 +148,7 @@ deployments <- function(appPath, nameFilter = NULL, accountFilter = NULL,
       next
 
     # apply optional name filter
-    name <- tools::file_path_sans_ext(basename(deploymentFile))
+    name <- file_path_sans_ext(basename(deploymentFile))
     if (!is.null(nameFilter) && !identical(nameFilter, name))
       next
 

--- a/R/title.R
+++ b/R/title.R
@@ -57,7 +57,7 @@ generateAppName <- function(appTitle, appPath = NULL, account = NULL, unique = T
     # strip extension if present
     base <- basename(appPath)
     if (nzchar(tools::file_ext(base))) {
-      base <- tools::file_path_sans_ext(base)
+      base <- file_path_sans_ext(base)
 
       # if we stripped an extension and the name is now "index", use the parent
       # folder's name

--- a/R/utils.R
+++ b/R/utils.R
@@ -89,6 +89,14 @@ readDcf <- function(...) {
   read.dcf(...)
 }
 
+# Replacement for tools::file_path_sans_ext to work around an issue where
+# filenames like "foo..ext" are not returned as "foo.".
+file_path_sans_ext <- function(x, compression = FALSE) {
+  if (compression) {
+    x <- sub("[.](gz|bz2|xz)$", "", x)
+  }
+  sub("(.+)\\.[[:alnum:]]+$", "\\1", x)
+}
 
 #' Generate a line with embedded message
 #'

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,28 @@
+context("utils")
+
+test_that("file_path_sans_ext removes extensions", {
+  # extensions are removed.
+  expect_equal(
+      file_path_sans_ext(c("noext",
+                           "extension.ext",
+                           "doubledot..ext")),
+      c("noext",
+        "extension",
+        "doubledot."))
+
+  # compression extensions are removed first (when explicitly requested).
+  expect_equal(
+      file_path_sans_ext(c("noext",
+                           "extension.ext",
+                           "doubledot..ext",
+                           "compressed.gz",
+                           "compressext.ext.bz2",
+                           "compressdoubledot..ext.xz"),
+                         compression = TRUE),
+      c("noext",
+        "extension",
+        "doubledot.",
+        "compressed",
+        "compressext",
+        "compressdoubledot."))
+})


### PR DESCRIPTION
tools::file_path_sans_ext does not alter filenames with a period immediately
before the ".ext".

Add a file_path_sans_ext to utils.R that can cope with filenames like
"foo..ext" and returns "foo." as the filename without the extension.