### PR TITLE
only consider the primary doc when computing parameterization

### DIFF
--- a/tests/testthat/test-rmds/index.Rmd
+++ b/tests/testthat/test-rmds/index.Rmd
@@ -1,0 +1,5 @@
+---
+title: The index R Markdown document
+---
+
+For those times that you do not specify a primary.

--- a/tests/testthat/test-rmds/parameterized.Rmd
+++ b/tests/testthat/test-rmds/parameterized.Rmd
@@ -1,0 +1,7 @@
+---
+title: Parameterized R Markdown document
+params:
+  color: red
+---
+
+Parameters are `r params$color`.

--- a/tests/testthat/test-rmds/simple.Rmd
+++ b/tests/testthat/test-rmds/simple.Rmd
@@ -1,0 +1,5 @@
+---
+title: Simple R Markdown document
+---
+
+R Markdown is so simple.


### PR DESCRIPTION
The primary document is used when launching the rmarkdown::knit_params_ask UI.
The `has_parameters` manifest field indicates if the configuration UI is
permitted.

If the primary document does not contain parameters, rmarkdown::knit_params_ask
exits before even launching its Shiny app. It is better to avoid setting
`has_parameters`.

Non-default documents may be parameterized, but are no longer considered when
marking the bundle as parameterized.

Note: Hold on merging; still need to do a bunch of testing.