### PR TITLE
Add spaces to max.bundle.size and .files errors

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -152,12 +152,12 @@ listBundleFiles <- function(appDir) {
 bundleFiles <- function(appDir) {
   files <- listBundleFiles(appDir)
   if (files$totalSize > getOption("rsconnect.max.bundle.size")) {
-    stop("The directory", appDir, "cannot be deployed because it is too ",
-         "large (the maximum size is", getOption("rsconnect.max.bundle.size"),
-         "bytes). Remove some files or adjust the rsconnect.max.bundle.size ",
+    stop("The directory ", appDir, " cannot be deployed because it is too ",
+         "large (the maximum size is ", getOption("rsconnect.max.bundle.size"),
+         " bytes). Remove some files or adjust the rsconnect.max.bundle.size ",
          "option.")
   } else if (length(files$contents) > getOption("rsconnect.max.bundle.files")) {
-    stop("The directory", appDir, "cannot be deployed because it contains ",
+    stop("The directory ", appDir, " cannot be deployed because it contains ",
          "too many files (the maximum number of files is ",
          getOption("rsconnect.max.bundle.files"), "). Remove some files or ",
          "adjust the rsconnect.max.bundle.files option.")


### PR DESCRIPTION
Making this and rsconnect.max.bundle.files error look less smooshed:

```
Error in bundleFiles(appDir) : 
  The directory/Users/questionsleepcannot be deployed because it is too large (the maximum size is3145728000bytes). Remove some files or adjust the rsconnect.max.bundle.size option.
```

**Testing Notes**

Install the rsconnect branch with changes: `devtools::install_github("rstudio/rsconnect@dethmasque-spaces")`

Attempt to deploy a large directory so the `rsconnect.max.bundle.size` error is displayed.

Ex: `setwd("/Users/questionsleep")`
`rsconnect::deployApp(account="toni",server="192.168.42.14")`

Set `rsconnect.max.bundle.files` to something small and attempt to deploy a directory containing more than that number, but not a large enough directory to trigger the `rsconnect.max.bundle.size` error. 

Ex: `options("rsconnect.max.bundle.files"=1)` 
`setwd("/Users/questionsleep/rsconnect_test/")`
`rsconnect::deployApp(account="toni",server="192.168.42.14")`