### PR TITLE
Update cookie regular expression to be closer to spec

### DIFF
--- a/R/http.R
+++ b/R/http.R
@@ -105,7 +105,10 @@ storeCookies <- function(requestURL, cookieHeaders){
 #   header name omitted.
 parseCookie <- function(requestURL, cookieHeader){
   keyval <- regmatches(cookieHeader, regexec(
-    "^(\\w+)\\s*=\\s*([^;]*)(;|$)", cookieHeader, ignore.case=TRUE))[[1]]
+    # https://curl.haxx.se/rfc/cookie_spec.html
+    # "characters excluding semi-colon, comma and white space"
+    # white space is not excluded from values so we can capture `expires`
+    "^([^;=, ]+)\\s*=\\s*([^;,]*)(;|$)", cookieHeader, ignore.case=TRUE))[[1]]
   if (length(keyval) == 0){
     # Invalid cookie format.
     warning("Unable to parse set-cookie header: ", cookieHeader)

--- a/tests/testthat/test-http.R
+++ b/tests/testthat/test-http.R
@@ -78,6 +78,12 @@ test_that("Parsing cookies works", {
   expect_equal(cookie$name, "mycookie")
   expect_equal(cookie$value, "")
   expect_equal(cookie$path, "/")
+
+  # prove #229 is fixed
+  cookie <- parseCookie(parsedUrl, "my_cookie-which/uses%20strange?characters=foo_-%20+?1234bar; Path = /")
+  expect_equal(cookie$name, "my_cookie-which/uses%20strange?characters")
+  expect_equal(cookie$value, "foo_-%20+?1234bar")
+  expect_equal(cookie$path, "/")
 })
 
 test_that("Invalid cookies fail parsing", {


### PR DESCRIPTION
Connected to #229

Old way: 

- `"^(\\w+)\\s*=\\s*([^;]*)(;|$)"` means "start of line followed by a group of word characters, followed by any number of spaces, followed by an equal sign, followed by any number of spaces, followed by any number of characters not a semicolon, followed by a semicolon or EOL"

New way:

- `"^([^;=, ]+)\\s*=\\s*([^;,]*)(;|$)"` means "start of line followed by **a group of characters not semicolon, equals sign, comma, or space**, followed by (unmodified from the old way...)"

Tests added to cover the offending cases.