### PR TITLE
Update showMetrics documentation

### DIFF
--- a/R/usage.R
+++ b/R/usage.R
@@ -60,10 +60,10 @@ showUsage <- function(appDir=getwd(), appName=NULL, account = NULL, server=NULL,
 #'
 #' Show application metrics of a currently deployed application
 #' @param metricSeries Metric series to query. Refer to the
-#'   [shinyapps.io docs](http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics)
+#'   [shinyapps.io documentation](http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics)
 #'   for available series.
 #' @param metricNames Metric names in the series to query. Refer to the
-#'   [shinyapps.io docs](http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics)
+#'   [shinyapps.io documentation](http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics)
 #'   for available metrics.
 #' @param appName Name of application
 #' @param appDir Directory containing application. Defaults to

--- a/R/usage.R
+++ b/R/usage.R
@@ -59,8 +59,12 @@ showUsage <- function(appDir=getwd(), appName=NULL, account = NULL, server=NULL,
 #' Show Application Metrics
 #'
 #' Show application metrics of a currently deployed application
-#' @param metricSeries Metric series to query e.g. "container.cpu"
-#' @param metricNames Metric names in the series to query e.g. c("cpu.user", "cpu.system")
+#' @param metricSeries Metric series to query. Refer to the
+#'   [shinyapps.io docs](http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics)
+#'   for available series.
+#' @param metricNames Metric names in the series to query. Refer to the
+#'   [shinyapps.io docs](http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics)
+#'   for available metrics.
 #' @param appName Name of application
 #' @param appDir Directory containing application. Defaults to
 #'   current working directory.

--- a/man/showMetrics.Rd
+++ b/man/showMetrics.Rd
@@ -10,11 +10,11 @@ showMetrics(metricSeries, metricNames, appDir = getwd(), appName = NULL,
 }
 \arguments{
 \item{metricSeries}{Metric series to query. Refer to the
-\href{http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics}{shinyapps.io docs}
+\href{http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics}{shinyapps.io documentation}
 for available series.}
 
 \item{metricNames}{Metric names in the series to query. Refer to the
-\href{http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics}{shinyapps.io docs}
+\href{http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics}{shinyapps.io documentation}
 for available metrics.}
 
 \item{appDir}{Directory containing application. Defaults to

--- a/man/showMetrics.Rd
+++ b/man/showMetrics.Rd
@@ -9,9 +9,13 @@ showMetrics(metricSeries, metricNames, appDir = getwd(), appName = NULL,
   interval = NULL)
 }
 \arguments{
-\item{metricSeries}{Metric series to query e.g. "container.cpu"}
+\item{metricSeries}{Metric series to query. Refer to the
+\href{http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics}{shinyapps.io docs}
+for available series.}
 
-\item{metricNames}{Metric names in the series to query e.g. c("cpu.user", "cpu.system")}
+\item{metricNames}{Metric names in the series to query. Refer to the
+\href{http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics}{shinyapps.io docs}
+for available metrics.}
 
 \item{appDir}{Directory containing application. Defaults to
 current working directory.}


### PR DESCRIPTION
This is in preparation for the lucid metrics upgrade on May 24. This change points the `showMetrics` documentation to the relevant section of the shinyapps.io doc where the available series and metrics are listed. 

I checked in the generated .Rd file because it seemed like that was the correct thing. But if that shouldn't be included I can make a new PR without it. 