### PR TITLE
default to curl + bump timeout for Windows

### DIFF
--- a/R/http.R
+++ b/R/http.R
@@ -646,7 +646,7 @@ httpTrace <- function(method, path, time) {
 }
 
 httpFunction <- function() {
-  httpType <- getOption("rsconnect.http", "rcurl")
+  httpType <- getOption("rsconnect.http", "curl")
   if (identical("rcurl", httpType))
     httpRCurl
   else if (identical("curl",  httpType))

--- a/R/ide.R
+++ b/R/ide.R
@@ -39,13 +39,10 @@ validateServerUrl <- function(url, certificate = NULL) {
   retry <- TRUE
   while (retry) {
     tryCatch({
-      # this shouldn't take more than 5 seconds since it does no work (i.e we
-      # should just be waiting for the network), so timeout quickly to avoid
-      # hanging when the server doesn't accept the connection
       httpResponse <- GET(parseHttpUrl(url),
                           list(certificate = certificate),
                           settingsEndpoint,
-                          timeout = 5)
+                          timeout = getOption("rsconnect.http.timeout", 10))
 
       # check for redirect
       if (httpResponse$status == 307 &&

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -1,8 +1,18 @@
 .onLoad <- function(libname, pkgname) {
+
   if (is.null(getOption("rsconnect.max.bundle.size"))) {
     options(rsconnect.max.bundle.size = 3145728000)
   }
+
   if (is.null(getOption("rsconnect.max.bundle.files"))) {
     options(rsconnect.max.bundle.files = 10000)
   }
+
+  # HTTP requests can take longer on Windows, so set a larger timeout
+  # by default (primarily used by the IDE when validating server URLs)
+  if (is.null(getOption("rsconnect.http.timeout"))) {
+    windows <- identical(.Platform$OS.type, "windows")
+    options(rsconnect.http.timeout = ifelse(windows, 20, 5))
+  }
+
 }


### PR DESCRIPTION
NOTE: We probably don't want to merge this right away since there is almost surely some larger discussion required as to whether we can just flip the switch and move from RCurl to curl (especially regarding certificates and other authentication issues)

---

The version of OpenSSL bundled by RCurl on Windows (at the time of this commit) was 1.0.0o, which is too old. The 'curl' package bundles an up-to-date version of curl and OpenSSL, so its usage should be preferred.

Closes #286.