### PR TITLE
Ask RSC for Title Updates

### DIFF
--- a/R/deployments.R
+++ b/R/deployments.R
@@ -184,7 +184,7 @@ deployments <- function(appPath, nameFilter = NULL, accountFilter = NULL,
     }
 
     # check to see if the title has changed for RSC deploys
-    if (!is.null(server) && server != "rpubs.com" && server != "shinyapps.io")
+    if (length(server) > 0 && server != "rpubs.com" && server != "shinyapps.io")
       deployment$title <- confirmTitle(deployment)
 
     # append to record set to return
@@ -203,7 +203,7 @@ confirmTitle <- function(deploymentRecord) {
   accountDetails <- accountInfo(deploymentRecord$account, deploymentRecord$server)
   client <- clientForAccount(accountDetails)
   title <- tryCatch(
-            {client$getApplication(deploymentRecord$appId)},
+            {client$getApplication(deploymentRecord$appId)$title},
             error = function(e){warning(
                 sprintf("Could not confirm title for app %s on server %s, defaulting to latest title %s",
                         deploymentRecord$appId,
@@ -249,10 +249,6 @@ deploymentRecord <- function(name, title, username, account, server, hostUrl,
     if (!is.null(serverinfo$url))
       hostUrl <- serverinfo$url
   }
-
-  # check to see if the title has changed for RSC deploys
-  if (server != "rpubs.com" && server != "shinyapps.io")
-    deployment$title <- confirmTitle(deployment)
 
   # compose the standard set of fields and append any requested
   as.data.frame(c(


### PR DESCRIPTION
This PR introduces a change to `rsconnect::deployments` to account for the fact that in RSC 1.6.8 and above the title can be changed on the Connect end.

This change to `rsconnect` will cause the IDE's publish dialogs to pick up title changes from RSC _each time the content source file is opened_ or _any time content is published_. 

Validated against shinyapps.io to ensure nothing broke.

Also validated the case where the deployment record (rsconnect) folder is deleted, and the case where RSC doesn't respond successfully with the title name (e.g. if the content has been deleted or the publisher's permissions have been changed to viewer).

Small validation note: 

The title change on RSC will not be picked up by the IDE if the source file is left open and the user repeatedly: selects the publish drop down, changes the title on RSC,  reselects the publish drop down _all without ever publishing_.

