### PR TITLE
provide way to write publish record in site directory when publishing website via deployApp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rsconnect
 Type: Package
 Title: Deployment Interface for R Markdown Documents and Shiny Applications
-Version: 0.8.8
+Version: 0.8.9
 Author: JJ Allaire
 Maintainer: Jonathan McPherson <jonathan@rstudio.com>
 Description: Programmatic deployment interface for 'RPubs', 'shinyapps.io', and
@@ -27,5 +27,5 @@ Suggests:
     xtable
 Enhances: BiocInstaller
 License: GPL-2
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0
 Roxygen: list(markdown = TRUE)

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -185,7 +185,7 @@ deployApp <- function(appDir = getwd(),
     recordDir <- appPath
   } else {
     # custom recordDir only supported for directory-level publish
-    if (!file.info(appDir)$isdir) {
+    if (!file.info(appPath)$isdir) {
       stop("Cannot specify recordDir when deploying a single file")
     }
     if (!file.exists(recordDir)) {

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -39,6 +39,10 @@
 #' @param upload If `TRUE` (the default) then the application is uploaded from
 #'   the local system prior to deployment. If `FALSE` then it is re-deployed
 #'   using the last version that was uploaded.
+#' @param recordDir Directory where publish record is written. Can be `NULL`
+#'   in which case record will be written to the location specified with `appDir`.
+#'   Only for use in conjunction with publishing an entire directory, not a single
+#'   file.
 #' @param launch.browser If true, the system's default web browser will be
 #'   launched automatically after the app is started. Defaults to `TRUE` in
 #'   interactive sessions only.
@@ -90,6 +94,7 @@ deployApp <- function(appDir = getwd(),
                       account = NULL,
                       server = NULL,
                       upload = TRUE,
+                      recordDir = NULL,
                       launch.browser = getOption("rsconnect.launch.browser",
                                                  interactive()),
                       logLevel = c("normal", "quiet", "verbose"),
@@ -167,11 +172,27 @@ deployApp <- function(appDir = getwd(),
         grepl("\\.html?$", appDir, ignore.case = TRUE)) {
       return(deployDoc(appDir, appName = appName, appTitle = appTitle,
                        account = account, server = server, upload = upload,
-                       launch.browser = launch.browser, logLevel = logLevel,
-                       lint = lint))
+                       recordDir = recordDir, launch.browser = launch.browser,
+                       logLevel = logLevel, lint = lint))
     } else {
       stop(appDir, " must be a directory, an R Markdown document, or an HTML ",
            "document.")
+    }
+  }
+
+  # directory for recording deployment
+  if (is.null(recordDir)) {
+    recordDir <- appPath
+  } else {
+    # custom recordDir only supported for directory-level publish
+    if (!file.info(appDir)$isdir) {
+      stop("Cannot specify recordDir when deploying a single file")
+    }
+    if (!file.exists(recordDir)) {
+      stop(recordDir, " does not exist")
+    }
+    if (!file.info(recordDir)$isdir) {
+      stop(recordDir, " must be a directory")
     }
   }
 
@@ -340,7 +361,7 @@ deployApp <- function(appDir = getwd(),
     # attempting the deployment itself to make retry easy on failure.
     if (verbose)
       timestampedLog("Saving deployment record for", target$appName, "-", target$username)
-    saveDeployment(appPath,
+    saveDeployment(recordDir,
                    target$appName,
                    target$appTitle,
                    target$username,

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -41,8 +41,6 @@
 #'   using the last version that was uploaded.
 #' @param recordDir Directory where publish record is written. Can be `NULL`
 #'   in which case record will be written to the location specified with `appDir`.
-#'   Only for use in conjunction with publishing an entire directory, not a single
-#'   file.
 #' @param launch.browser If true, the system's default web browser will be
 #'   launched automatically after the app is started. Defaults to `TRUE` in
 #'   interactive sessions only.
@@ -184,10 +182,6 @@ deployApp <- function(appDir = getwd(),
   if (is.null(recordDir)) {
     recordDir <- appPath
   } else {
-    # custom recordDir only supported for directory-level publish
-    if (!file.info(appPath)$isdir) {
-      stop("Cannot specify recordDir when deploying a single file")
-    }
     if (!file.exists(recordDir)) {
       stop(recordDir, " does not exist")
     }

--- a/R/deploySite.R
+++ b/R/deploySite.R
@@ -70,10 +70,6 @@ deploySite <- function(siteDir = getwd(),
   if (is.null(appName))
     appName <- siteGenerator$name
 
-  # publish record written to site directory for local or
-  # server-based rendering
-  recordDir <- siteDir
-
   # determine appDir based on whether we are rendering on the server
   if (render == "server") {
     appDir <- '.'
@@ -98,7 +94,6 @@ deploySite <- function(siteDir = getwd(),
             contentCategory = "site",
             account = account,
             server = server,
-            recordDir = recordDir,
             launch.browser = launch.browser,
             logLevel = logLevel,
             lint = lint,

--- a/R/deploySite.R
+++ b/R/deploySite.R
@@ -9,8 +9,6 @@
 #' @param siteName Name for the site (names must be unique within
 #'   an account). Defaults to the base name of the specified siteDir,
 #'   (or to a name provided by a custom site generation function).
-#' @param recordDir Directory where publish record is written. Can be `NULL`
-#'   in which case record will be written to the location specified with `siteDir`.
 #' @param render Rendering behavior for site: "none" to upload a
 #'   static version of the current contents of the site directory;
 #'   "local" to render the site locally then upload it; "server" to
@@ -24,7 +22,6 @@ deploySite <- function(siteDir = getwd(),
                        siteName = NULL,
                        account = NULL,
                        server = NULL,
-                       recordDir = NULL,
                        render = c("none", "local", "server"),
                        launch.browser = getOption("rsconnect.launch.browser", interactive()),
                        logLevel = c("normal", "quiet", "verbose"),
@@ -72,6 +69,10 @@ deploySite <- function(siteDir = getwd(),
   appName <- siteName
   if (is.null(appName))
     appName <- siteGenerator$name
+
+  # publish record written to site directory for local or
+  # server-based rendering
+  recordDir <- siteDir
 
   # determine appDir based on whether we are rendering on the server
   if (render == "server") {

--- a/R/deploySite.R
+++ b/R/deploySite.R
@@ -9,6 +9,8 @@
 #' @param siteName Name for the site (names must be unique within
 #'   an account). Defaults to the base name of the specified siteDir,
 #'   (or to a name provided by a custom site generation function).
+#' @param recordDir Directory where publish record is written. Can be `NULL`
+#'   in which case record will be written to the location specified with `siteDir`.
 #' @param render Rendering behavior for site: "none" to upload a
 #'   static version of the current contents of the site directory;
 #'   "local" to render the site locally then upload it; "server" to
@@ -22,6 +24,7 @@ deploySite <- function(siteDir = getwd(),
                        siteName = NULL,
                        account = NULL,
                        server = NULL,
+                       recordDir = NULL,
                        render = c("none", "local", "server"),
                        launch.browser = getOption("rsconnect.launch.browser", interactive()),
                        logLevel = c("normal", "quiet", "verbose"),
@@ -94,6 +97,7 @@ deploySite <- function(siteDir = getwd(),
             contentCategory = "site",
             account = account,
             server = server,
+            recordDir = recordDir,
             launch.browser = launch.browser,
             logLevel = logLevel,
             lint = lint,


### PR DESCRIPTION
If you publish a website (the rendered files) via `rsconnect::deploySite`, it creates the publish record (rsconnect folder) in the website project folder, not in the _site (build output) folder.

However, the IDE uses rsconnect::deployApp for all types of deployments, including websites, and this was resulting in the folder being created under the _site folder where it is: (1) prone to being deleted when blowing away _site and rebuilding the site and (2) not found by the IDE when looking for previous publishes.

Added a new optional parameter to deployApp which allows customizing the location of the rsconnect publish record. Alternative was to have IDE start using deploySite, but that had other consequences and would have also required changes to this package.