### PR TITLE
Add pre/post deploy hooks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*.R]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+max_line_length = 100
+insert_final_newline = true

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -713,9 +713,9 @@ runStartupScripts <- function(appDir, logLevel) {
   for (script in scripts) {
     if (file.exists(script)) {
       if (logLevel == "verbose") {
-        cat("----- Sourcing startup script ", script, " -----\n")
+        cat("----- Sourcing startup script", script, "-----\n")
       }
-      source(file = global, verbose = (logLevel == "verbose"))
+      source(file = script, verbose = (logLevel == "verbose"))
     }
   }
 }

--- a/R/http.R
+++ b/R/http.R
@@ -925,8 +925,11 @@ signatureHeaders <- function(authInfo, method, path, file) {
   } else if (!is.null(authInfo$private_key)) {
     # generate contents hash (this is done slightly differently for private key
     # auth since we use base64 throughout)
-    if (!is.null(file))
-      md5 <- openssl::md5(base::file(file, open = "rb"))
+    if (!is.null(file)) {
+      con <- base::file(file, open = "rb")
+      on.exit(close(con), add = TRUE)
+      md5 <- openssl::md5(con)
+    }
     else
       md5 <- openssl::md5(raw(0))
     md5 <- openssl::base64_encode(md5)

--- a/man/options.Rd
+++ b/man/options.Rd
@@ -33,6 +33,13 @@ Supported global options include:
    \item{\code{rsconnect.pre.deploy}}{A function to run prior to deploying content; it receives as an argument the path to the content that's about to be deployed.}
    \item{\code{rsconnect.post.deploy}}{A function to run after successfully deploying content; it receives as an argument the path to the content that was just deployed.}
 }
+When deploying content from the RStudio IDE, the rsconnect package's deployment methods are executed in a vanilla R session that doesn't execute startup scripts. This can make it challenging to ensure options are set properly prior to push-button deployment, so the rsconnect package has a parallel set of ``startup'' scripts it runs prior to deploying. The follow are run in order, if they exist, prior to deployment:
+\describe{
+    \item{\code{$R_HOME/etc/rsconnect.site}}{Like \code{Rprofile.site}; for site-wide pre-flight and options.}
+    \item{\code{~/.rsconnect_profile}}{Like \code{.Rprofile}; for user-specific content.}
+    \item{\code{$PROJECT/.rsconnect_profile}}{Like \code{.Rprofile} for projects; \code{$PROJECT} here refers to the root directory of the content being deployed.}
+}
+Note that, unlike \code{.Rprofile}, these files don't replace each other; \emph{all three} will be run if they exist.
 }
 
 \examples{

--- a/man/options.Rd
+++ b/man/options.Rd
@@ -30,6 +30,8 @@ Supported global options include:
    \item{\code{rsconnect.max.bundle.size}}{The maximum size, in bytes, for deployed content. If not set, defaults to 3 GB.}
    \item{\code{rsconnect.max.bundle.files}}{The maximum number of files to deploy. If not set, defaults to 10,000.}
    \item{\code{rsconnect.force.update.apps}}{When \code{TRUE}, bypasses the prompt to confirm whether you wish to update previously-deployed content}
+   \item{\code{rsconnect.pre.deploy}}{A function to run prior to deploying content; it receives as an argument the path to the content that's about to be deployed.}
+   \item{\code{rsconnect.post.deploy}}{A function to run after successfully deploying content; it receives as an argument the path to the content that was just deployed.}
 }
 }
 


### PR DESCRIPTION
A number of RStudio Connect customers have struggled with getting push-button deployment working because the HTTP defaults in the package don't work in their environment. This is significantly exacerbated by the fact that RStudio does push-button deployments with `--vanilla` R sessions, so it's not possible to inject R code that runs inside the deployment process using the usual `.Rprofile`/`Rprofile.site` mechanisms. 

This change makes deployment more customizable for these advanced cases by adding two mechanisms:

1. An rsconnect-specific set of startup scripts. These allow customers to set rsconnect options to be used for deployment at the site, user, or project level. 

2. A pair of user-defined options which provide functions to be called prior to (and after) deployment. 

Using these tools, it is possible to do arbitrarily complex pre-flight checks and post-deploy cleanup. Ideally most customers won't have to use them, but for those with difficult authentication configurations, it'll provide a useful escape hatch.  

Closes #283. 