### PR TITLE
Upgrade from RJSONIO to jsonlite

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Depends:
 Imports:
     openssl,
     RCurl,
-    RJSONIO,
+    jsonlite,
     packrat (>= 0.4.8-1),
     yaml (>= 2.1.5),
     rstudioapi (>= 0.5)

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -393,9 +393,11 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
       # include github package info
       info <- c(info, as.list(deps[i, grep('Github', colnames(deps), perl = TRUE, value = TRUE)]))
 
-      # get package description
+      # get package description; note that we need to remove the
+      # packageDescription S3 class from the object or jsonlite will refuse to
+      # serialize it when building the manifest JSON
       # TODO: should we get description from packrat/desc folder?
-      info$description = suppressWarnings(utils::packageDescription(name))
+      info$description = suppressWarnings(unclass(utils::packageDescription(name)))
 
       # if description is NA, application dependency may not be installed
       if (is.na(info$description[1])) {
@@ -480,7 +482,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
   }
 
   # return it as json
-  RJSONIO::toJSON(manifest, pretty = TRUE)
+  jsonlite::toJSON(manifest, pretty = TRUE)
 }
 
 validatePackageSource <- function(pkg) {

--- a/R/client.R
+++ b/R/client.R
@@ -11,7 +11,7 @@ handleResponse <- function(response, jsonFilter = NULL) {
   # json responses
   if (isContentType(response, "application/json")) {
 
-    json <- RJSONIO::fromJSON(response$content, simplify = FALSE)
+    json <- jsonlite::fromJSON(response$content, simplifyVector = FALSE)
 
     if (response$status %in% 200:399)
       if (!is.null(jsonFilter))

--- a/R/http.R
+++ b/R/http.R
@@ -690,7 +690,7 @@ POST_JSON <- function(service,
        path,
        query,
        "application/json",
-       content = RJSONIO::toJSON(json, pretty = TRUE, digits=30),
+       content = jsonlite::toJSON(json, pretty = TRUE, digits = 30),
        headers = headers)
 }
 
@@ -705,7 +705,7 @@ PUT_JSON <- function(service,
       path,
       query,
       "application/json",
-      content = RJSONIO::toJSON(json, pretty = TRUE, digits=30),
+      content = jsonlite::toJSON(json, pretty = TRUE, digits = 30),
       headers = headers)
 }
 

--- a/R/rpubs.R
+++ b/R/rpubs.R
@@ -71,7 +71,7 @@ rpubsUpload <- function(title,
 
     # build package.json
     properties$title = title
-    packageJson <- RJSONIO::toJSON(properties)
+    packageJson <- jsonlite::toJSON(properties)
 
     # create a tempdir to build the package in and copy the files to it
     fileSep <- .Platform$file.sep
@@ -138,7 +138,7 @@ rpubsUpload <- function(title,
 
   # return either id & continueUrl or error
   if (succeeded) {
-    parsedContent <- RJSONIO::fromJSON(content)
+    parsedContent <- jsonlite::fromJSON(content)
     id <- ifelse(isUpdate, id, result$location)
     url <- as.character(parsedContent["continueUrl"])
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -206,6 +206,6 @@ md5sum <- function(path) {
   con <- base::file(path, open = "rb")
   on.exit(close(con), add = TRUE)
 
-  # compute md5 sum of contents
-  as.character(openssl::md5(con))
+  # compute md5 sum of contents and return as ordinary characters
+  unclass(as.character(openssl::md5(con)))
 }

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -61,7 +61,7 @@ test_that("simple Rmd as primary not identified as parameterized when parameteri
   bundleTempDir <- makeShinyBundleTempDir("rmd primary", "test-rmds",
                                           "simple.Rmd")
   on.exit(unlink(bundleTempDir, recursive = TRUE))
-  manifest <- RJSONIO::fromJSON(file.path(bundleTempDir, "manifest.json"))
+  manifest <- jsonlite::fromJSON(file.path(bundleTempDir, "manifest.json"))
   expect_equal(manifest$metadata$appmode, "rmd-static")
   expect_equal(manifest$metadata$primary_rmd, "simple.Rmd")
   expect_equal(manifest$metadata$has_parameters, FALSE)
@@ -72,7 +72,7 @@ test_that("parameterized Rmd identified as parameterized when other Rmd in bundl
   bundleTempDir <- makeShinyBundleTempDir("rmd primary", "test-rmds",
                                           "parameterized.Rmd")
   on.exit(unlink(bundleTempDir, recursive = TRUE))
-  manifest <- RJSONIO::fromJSON(file.path(bundleTempDir, "manifest.json"))
+  manifest <- jsonlite::fromJSON(file.path(bundleTempDir, "manifest.json"))
   expect_equal(manifest$metadata$appmode, "rmd-static")
   expect_equal(manifest$metadata$primary_rmd, "parameterized.Rmd")
   expect_equal(manifest$metadata$has_parameters, TRUE)
@@ -83,7 +83,7 @@ test_that("primary doc can be inferred (and non-parameterized dispite an include
   bundleTempDir <- makeShinyBundleTempDir("rmd primary", "test-rmds",
                                           NULL)
   on.exit(unlink(bundleTempDir, recursive = TRUE))
-  manifest <- RJSONIO::fromJSON(file.path(bundleTempDir, "manifest.json"))
+  manifest <- jsonlite::fromJSON(file.path(bundleTempDir, "manifest.json"))
   expect_equal(manifest$metadata$appmode, "rmd-static")
   expect_equal(manifest$metadata$primary_rmd, "index.Rmd")
   expect_equal(manifest$metadata$has_parameters, FALSE)
@@ -94,7 +94,7 @@ test_that("multiple shiny Rmd without index file have a generated one", {
   bundleTempDir <- makeShinyBundleTempDir("rmd primary", "shiny-rmds",
                                           NULL)
   on.exit(unlink(bundleTempDir, recursive = TRUE))
-  manifest <- RJSONIO::fromJSON(file.path(bundleTempDir, "manifest.json"))
+  manifest <- jsonlite::fromJSON(file.path(bundleTempDir, "manifest.json"))
   expect_equal(manifest$metadata$appmode, "rmd-shiny")
   expect_true(file.exists(file.path(bundleTempDir, "index.htm")))
 })


### PR DESCRIPTION
This change replaces RJSONIO with jsonlite, which in addition to several improvements is more actively maintained, and doesn't have the "evil clause" in its license. 

The change has been tested for basic publish compatibility/interoperability with RStudio Connect, shinyapps.io, and RPubs.

Closes #277. 