### PR TITLE
use typical contentCategory examples

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -30,7 +30,7 @@
 #' @param appId If updating an application, the ID of the application being
 #'   updated. Optional unless updating an app owned by another user.
 #' @param contentCategory Optional; the kind of content being deployed (e.g.
-#'   `"plot"`, `"document"`, or `"application"`).
+#'   `"plot"` or `"site"`).
 #' @param account Account to deploy application to. This parameter is only
 #'   required for the initial deployment of an application when there are
 #'   multiple accounts configured on the system (see [accounts]).

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -48,7 +48,7 @@ auto-generated \code{appName}.}
 updated. Optional unless updating an app owned by another user.}
 
 \item{contentCategory}{Optional; the kind of content being deployed (e.g.
-\code{"plot"}, \code{"document"}, or \code{"application"}).}
+\code{"plot"} or \code{"site"}).}
 
 \item{account}{Account to deploy application to. This parameter is only
 required for the initial deployment of an application when there are


### PR DESCRIPTION
The examples of "site" and "plot" are meaningful to RSC; other values are not. This PR adjusts the doc for `contentCategory` to use values we expect to see.