### PR TITLE
API+TF do not need to specify contentCategory

### DIFF
--- a/R/deployAPI.R
+++ b/R/deployAPI.R
@@ -28,7 +28,5 @@ deployAPI <- function(api,
     stop("The api at '", api, "' is not a directory.")
   }
   # Checking for entrypoint.R or plumber.R is done in `lint-framework.R`
-  deployApp(appDir = api,
-            contentCategory = 'api',
-            ...)
+  deployApp(appDir = api, ...)
 }

--- a/R/deployTFModel.R
+++ b/R/deployTFModel.R
@@ -43,7 +43,5 @@ deployTFModel <- function(modelDir,
     stop("The modelDir at '", modelDir, "' is not a directory.")
   }
   # Checking for saved_model.pb is done in `lint-framework.R`
-  deployApp(appDir = modelDir,
-            contentCategory = 'tensorflow-saved-model',
-            ...)
+  deployApp(appDir = modelDir, ...)
 }


### PR DESCRIPTION
RSC only needs to see contentCategory for plots (altering the displayed icon) and for sites (altering how we perform a render). Other values are not used.

In the case of Plumber APIs and TensorFlow models, `contentCategory` is redundant with the `appMode`.