### PR TITLE
remove the bundleDir after computing app dependencies

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -47,6 +47,7 @@ appDependencies <- function(appDir = getwd(), appFiles=NULL) {
     appFiles <- bundleFiles(appDir)
   }
   bundleDir <- bundleAppDir(appDir, appFiles)
+  on.exit(unlink(bundleDir, recursive = TRUE), add = TRUE)
   deps <- snapshotDependencies(bundleDir)
   data.frame(package = deps[,"Package"],
              version = deps[,"Version"],


### PR DESCRIPTION
When doing some code reading to prepare for some manifest/bundle rework, I noticed that we were not cleaning up the staging bundle directory on exit. This PR removes that staging location when computing app dependencies. The other call to `bundleAppDir` is from `bundleApp`; I've got another PR in-flight with that cleanup.

Note: There is `on.exit(unlink(bundleDir), add = TRUE)` code inside of `bundleAppDir`; that may have originally performed cleanup of the bundle staging directory, but it is not recursive. That's left alone for now.