### PR TITLE
fixup package repository url

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -80,7 +80,7 @@ snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
   } else {
     biocPackages = c()
   }
-  repo.packages <- available.packages(contriburl = contrib.url(repos), type = "source")
+  repo.packages <- available.packages(contriburl = contrib.url(repos, type = "source"), type = "source")
   named.repos <- name.all.repos(repos)
   repo.lookup <- data.frame(
     name = names(named.repos),
@@ -103,7 +103,7 @@ snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
       }
     } else if (tolower(source) %in% c("github", "bitbucket", "source")) {
       # leave source+SCM packages alone.
-    } else if (pkg %in% repo.packages) {
+    } else if (pkg %in% rownames(repo.packages)) {
       # capture CRAN-like repository
 
       # Find this package in the set of available packages then use its


### PR DESCRIPTION
The `repos` option contains URLs for package repositories. Entries can
optionally have names.

Package DESCRIPTION records include a `Repository` field that _may_ capture
where the package originated.

The package `Repository` value is something like CRAN or RSPM - these are
supplied by the download host. There is no guarantee that the `Repository`
corresponds to the (optional) names in `repos`.

This change uses `available.packages` to enumerate all packages known by the
`repos` option. We locate each package in the set of available packages and use
the contrib.url in that record to relate the package back to the configured
`repos` repository.

The package `Source` value is given the name of the `repos` repository. A
random name of the form "repo_XXXXXXXX" is assigned if the `repos` repository
is not named. The `Source` for CRAN packages is not altered.

The package `Source` name for non-CRAN packages is altered because we may have
multiple CRAN-like repositories in play, each with a different URL. We do not
want to have different URLs using the same `Source`.

~Note: This PR is currently rooted on #308 and can be re-rooted against master once that PR merges.~

Testing:

This change is most visible when names in the `repos` option do not match the package `Repository` values. Assuming packages installed both from CRAN and from RSPM, here are some cases to cover:

1. CRAN+RSPM names: `options(repos=list(CRAN = 'cran-url', RSPM = 'rspm-url'))`
1. Renamed CRAN: `options(repos=list(CRANNY = 'cran-url', RSPM = 'rspm-url'))`
1. Renamed RSPM: `options(repos=list(CRAN = 'cran-url', PM = 'rspm-url'))`
1. Renamed CRAN+RSPM: `options(repos=list(CRANNY = 'cran-url', PM = 'rspm-url'))`
1. Nameless CRAN: `options(repos=list('cran-url', RSPM = 'rspm-url'))`
1. Nameless RSPM: `options(repos=list(CRAN = 'cran-url', 'rspm-url'))`
1. Nameless CRAN+RSPM: `options(repos=list('cran-url', 'rspm-url'))`

Some cases that will not produce deployable manifests:

1. Missing CRAN: `options(repos=list(RSPM = 'rspm-url'))`
1. Missing RSPM: `options(repos=list(CRAN = 'cran-url'))`
1. Missing CRAN+RSPM (URL that does not have the requested packages): `options(repos=list('repo-without-packages'))`

Should the manifest generation code not find a repository for a package, we emit a warning:
```
Unable to find repository URL for package NAME
```
The `manifest.json` file will contain `"Repository": null` entries for these packages:
```
...
  "Source": "RSPM",
  "Repository": null,
...
```