### PR TITLE
Add support for BiocManager

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,8 +17,6 @@ Imports:
     yaml (>= 2.1.5),
     rstudioapi (>= 0.5)
 Suggests:
-    BiocInstaller,
-    BiocManager,
     knitr,
     testthat,
     rmarkdown (>= 1.1),

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -712,10 +712,13 @@ performPackratSnapshot <- function(bundleDir) {
 
   # attempt to eagerly load the BiocInstaller or BiocManaager package if installed, to work around
   # an issue where attempts to load the package could fail within a 'suppressMessages()' context
-  if (length(find.package("BiocManager", quiet = TRUE)))
-    requireNamespace("BiocManager", quietly = TRUE)
-  else if (length(find.package("BiocInstaller", quiet = TRUE)))
-    requireNamespace("BiocInstaller", quietly = TRUE)
+  packages <- c("BiocManager", "BiocInstaller")
+  for (package in packages) {
+    if (length(find.package(package, quiet = TRUE))) {
+      requireNamespace(package, quietly = TRUE)
+      break
+    }
+  }
 
   # generate a snapshot
   suppressMessages(


### PR DESCRIPTION
BiocInstaller is being deprecated in favor of BiocManager. Packages that list BiocInstaller under *Enhances* are being proactively removed from CRAN. Since BiocManager doesn't work with all R versions, this change does the following:

- Removes mentions of Bioc* packages from `DESCRIPTION` as there's no actual dependency
- Adds support for BiocManager (loaded in preference to BiocInstaller if available)
