### PR TITLE
Make it possible to re-deploy to shinyapps.io

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -383,14 +383,16 @@ deployApp <- function(appDir = getwd(),
         ", from account", accountDetails$username)
   }
 
-  # wait for the deployment to complete (will raise an error if it can't)
-  displayStatus(paste0("Deploying bundle: ", bundle$id,
-                       " for ", assetTypeName, ": ", application$id,
-                       " ...\n", sep=""))
+  if (length(bundle$id) > 0 && nzchar(bundle$id)) {
+    displayStatus(paste0("Deploying bundle: ", bundle$id,
+                         " for ", assetTypeName, ": ", application$id,
+                         " ...\n", sep=""))
+  }
   if (verbose) {
     cat("----- Server deployment started at ", as.character(Sys.time()), " -----\n")
   }
 
+  # wait for the deployment to complete (will raise an error if it can't)
   task <- client$deployApplication(application$id, bundle$id)
   taskId <- if (is.null(task$task_id)) task$id else task$task_id
   response <- client$waitForTask(taskId, quiet)

--- a/R/lucid.R
+++ b/R/lucid.R
@@ -134,7 +134,10 @@ lucidClient <- function(service, authInfo) {
     deployApplication = function(applicationId, bundleId=NULL) {
       path <- paste("/applications/", applicationId, "/deploy", sep="")
       json <- list()
-      json$bundle <- as.numeric(bundleId)
+      if (length(bundleId) > 0 && nzchar(bundleId))
+        json$bundle <- as.numeric(bundleId)
+      else
+        json$rebuild = FALSE
       handleResponse(POST_JSON(service, authInfo, path, json))
     },
 


### PR DESCRIPTION
This change makes it possible to trigger a shinyapps.io re-deploy without re-upload by specifying `upload = FALSE` when invoking `deployApp`.

When no bundle ID is present (because we didn't upload one), we pass `rebuild: false` to the endpoint instead of the bundle ID.

Fixes #312. 