### PR TITLE
Skip package dependency check for tensorflow models

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -461,7 +461,8 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
   msg      <- NULL
 
   # get package dependencies for non-static content deployment
-  if (!identical(appMode, "static")) {
+  if (!identical(appMode, "static") &&
+      !identical(appMode, "tensorflow-saved-model")) {
 
     # detect dependencies including inferred dependences
     deps = snapshotDependencies(appDir, inferDependencies(appMode, hasParameters))


### PR DESCRIPTION
This change fixes an issue when running `deployTFModel` and trying to snapshot package dependencies (which is unnecessary when deploying Tensorflow models).