### PR TITLE
Check HTTP status header before normalizing case

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rsconnect
 Type: Package
 Title: Deployment Interface for R Markdown Documents and Shiny Applications
-Version: 0.8.12
+Version: 0.8.12-9000
 Author: JJ Allaire
 Maintainer: Jonathan McPherson <jonathan@rstudio.com>
 Description: Programmatic deployment interface for 'RPubs', 'shinyapps.io', and

--- a/R/http.R
+++ b/R/http.R
@@ -644,6 +644,17 @@ httpRCurl <- function(protocol,
 
   contentValue <- textGatherer$value()
 
+  # deduce status -- the "status" header can be present multiple times; we want
+  # to select the copy of the header that contains just the status code itself.
+  # if no header present, presume 200 (OK).
+  status <- 200
+  statuses <- headers[names(headers) == "status"]   # select all "status" headers
+  statuses <- statuses[grepl("^\\d+$", statuses)]   # select fully numeric values
+  if (length(statuses) > 0) {
+    # we found a numeric status header
+    status <- as.integer(statuses[[1]])
+  }
+
   # emit JSON trace if requested
   if (httpTraceJson() && identical(contentType, "application/json"))
     cat(paste0(">> ", contentValue, "\n"))
@@ -653,7 +664,7 @@ httpRCurl <- function(protocol,
                   port     = port,
                   method   = method,
                   path     = path),
-       status = as.integer(headers[["status"]]),
+       status = status,
        location = location,
        contentType = contentType,
        content = contentValue)


### PR DESCRIPTION
This change fixes an issue uploading content to RPubs, described here:

https://community.rstudio.com/t/rstudio-v1-1-456-rpubs-upload-error-no-login-prompt/19393/7

The issue is a recent regression from https://github.com/rstudio/rsconnect/commit/47b7171b6c1d7fc875747d5b69a962c75e80d84e. This change was intended to add HTTP/2 support by tolerating lowercase headers. However, it turns out that RPubs returns *two* status headers, differing only in case (`status` and `Status`); the former has the HTTP status code, whereas the latter also has a status message.

The fix is to:

1. Check the `status` header *before* normalizing headers to lowercase, and
2. Further guard against the issue by (a) establishing a default status when one cannot be read, and (b) ensuring the `status` header is numeric, as we expect