### PR TITLE
Honor python env var

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -488,6 +488,13 @@ inferPythonEnv <- function(workdir, python) {
   })
 }
 
+getPython <- function(path) {
+    if (is.null(path)) {
+      path <- Sys.getenv("RETICULATE_PYTHON")
+    }
+    path.expand(path)
+}
+
 createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
                               appPrimaryDoc, assetTypeName, users, python = NULL) {
 
@@ -502,11 +509,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
       !identical(appMode, "tensorflow-saved-model")) {
 
     # detect dependencies including inferred dependences
-    if (is.null(python)) {
-      python <- Sys.getenv("RETICULATE_PYTHON")
-    }
-    python <- path.expand(python)
-
+    python <- getPython(python)
     deps = snapshotDependencies(appDir, inferDependencies(appMode, hasParameters, python))
 
     # construct package list from dependencies

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -503,8 +503,9 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
 
     # detect dependencies including inferred dependences
     if (is.null(python)) {
-      python = Sys.getenv("RETICULATE_PYTHON")
+      python <- Sys.getenv("RETICULATE_PYTHON")
     }
+    python <- path.expand(python)
 
     deps = snapshotDependencies(appDir, inferDependencies(appMode, hasParameters, python))
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -456,7 +456,7 @@ inferDependencies <- function(appMode, hasParameters, python) {
   if (appMode == 'api') {
     deps <- c(deps, "plumber")
   }
-  if (!is.null(python)) {
+  if (python != "") {
     deps <- c(deps, "reticulate")
   }
   unique(deps)
@@ -502,6 +502,10 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
       !identical(appMode, "tensorflow-saved-model")) {
 
     # detect dependencies including inferred dependences
+    if (is.null(python)) {
+      python = Sys.getenv("RETICULATE_PYTHON")
+    }
+
     deps = snapshotDependencies(appDir, inferDependencies(appMode, hasParameters, python))
 
     # construct package list from dependencies
@@ -509,7 +513,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
       name <- deps[i, "Package"]
 
       if (name == "reticulate") {
-        if (is.null(python)) {
+        if (python == "") {
           # TODO, should this be a warning for backward compatibility?
           msg <- c(msg, "reticulate is in use, but python was not specified")
         }

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -150,3 +150,25 @@ test_that("Rmd with reticulate but no python is an error", {
   skip_on_cran()
   expect_error(makeShinyBundleTempDir("reticulated rmd", "test-reticulate-rmds", "implicit.Rmd"), "*python was not specified")
 })
+
+test_that("Rmd with reticulate can use python specified in RETICULATE_PYTHON environment variable", {
+  skip_on_cran()
+  skip_if_not_installed("reticulate")
+
+  python <- Sys.which("python")
+  Sys.setenv(RETICULATE_PYTHON=python)
+  skip_if(python == "", "python is not installed")
+
+  bundleTempDir <- makeShinyBundleTempDir("reticulated rmd", "test-reticulate-rmds", "implicit.Rmd")
+  on.exit(unlink(bundleTempDir, recursive = TRUE))
+
+  lockfile <- file.path(bundleTempDir, "packrat/packrat.lock")
+  deps <- packrat:::readLockFilePackages(lockfile)
+  expect_true("reticulate" %in% names(deps))
+
+  manifest <- jsonlite::fromJSON(file.path(bundleTempDir, "manifest.json"))
+  expect_equal(manifest$metadata$appmode, "rmd-static")
+  expect_equal(manifest$metadata$primary_rmd, "implicit.Rmd")
+  expect_true(file.exists(file.path(bundleTempDir, manifest$python$package_manager$package_file)))
+  Sys.unsetenv("RETICULATE_PYTHON")
+})


### PR DESCRIPTION
This PR updates the reticulate/python support to honor the `RETICULATE_PYTHON` environment variable. Setting this variable enables the IDE's pushbutton publishing to work with reticulate content, instead of relying on the user calling the deploy* functions from this package.
