### PR TITLE
Add python enable flag

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -518,8 +518,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
 
       if (name == "reticulate") {
         if (python == "") {
-          # TODO, should this be a warning for backward compatibility?
-          msg <- c(msg, "reticulate is in use, but python was not specified")
+          warning("reticulate is in use, but python was not specified")
         }
         else {
           pyInfo <- inferPythonEnv(appDir, python)

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -488,13 +488,6 @@ inferPythonEnv <- function(workdir, python) {
   })
 }
 
-getPython <- function(path) {
-    if (is.null(path)) {
-      path <- Sys.getenv("RETICULATE_PYTHON")
-    }
-    path.expand(path)
-}
-
 createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
                               appPrimaryDoc, assetTypeName, users, python = NULL) {
 

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -328,10 +328,20 @@ deployApp <- function(appDir = getwd(),
       cat("----- Bundle upload started at ", as.character(Sys.time()), " -----\n")
     withStatus(paste0("Uploading bundle for ", assetTypeName, ": ",
                      application$id), {
+
+      # python is enabled on Connect but not on Shinyapps
+      targetIsShinyapps <- isShinyapps(accountDetails)
+      pythonEnabled = getOption("rsconnect.python.enabled", default=!targetIsShinyapps)
+      if (pythonEnabled) {
+        python <- getPython(python)
+      }
+      else {
+        python <- NULL
+      }
       bundlePath <- bundleApp(target$appName, appDir, appFiles,
                               appPrimaryDoc, assetTypeName, contentCategory, verbose, python)
 
-      if (isShinyapps(accountDetails)) {
+      if (targetIsShinyapps) {
 
         # Step 1. Create presigned URL and register pending bundle.
         bundleSize <- file.info(bundlePath)$size

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -452,7 +452,7 @@ getPython <- function(path) {
   if (is.null(path)) {
     path <- Sys.getenv("RETICULATE_PYTHON")
     if (path == "") {
-      NULL
+      return(NULL)
     }
   }
   path.expand(path)

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -330,14 +330,7 @@ deployApp <- function(appDir = getwd(),
                      application$id), {
 
       # python is enabled on Connect but not on Shinyapps
-      targetIsShinyapps <- isShinyapps(accountDetails)
-      pythonEnabled = getOption("rsconnect.python.enabled", default=!targetIsShinyapps)
-      if (pythonEnabled) {
-        python <- getPython(python)
-      }
-      else {
-        python <- NULL
-      }
+      python <- getPythonForTarget(python, accountDetails)
       bundlePath <- bundleApp(target$appName, appDir, appFiles,
                               appPrimaryDoc, assetTypeName, contentCategory, verbose, python)
 
@@ -458,6 +451,18 @@ getPython <- function(path) {
   path.expand(path)
 }
 
+
+getPythonForTarget <- function(path, accountDetails) {
+  # python is enabled on Connect but not on Shinyapps
+  targetIsShinyapps <- isShinyapps(accountDetails)
+  pythonEnabled = getOption("rsconnect.python.enabled", default=!targetIsShinyapps)
+  if (pythonEnabled) {
+    getPython(path)
+  }
+  else {
+    NULL
+  }
+}
 
 # calculate the deployment target based on the passed parameters and
 # any saved deployments that we have

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -447,6 +447,18 @@ deployApp <- function(appDir = getwd(),
   invisible(deploymentSucceeded)
 }
 
+
+getPython <- function(path) {
+  if (is.null(path)) {
+    path <- Sys.getenv("RETICULATE_PYTHON")
+    if (path == "") {
+      NULL
+    }
+  }
+  path.expand(path)
+}
+
+
 # calculate the deployment target based on the passed parameters and
 # any saved deployments that we have
 deploymentTarget <- function(appPath, appName, appTitle, appId, account,

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -334,7 +334,7 @@ deployApp <- function(appDir = getwd(),
       bundlePath <- bundleApp(target$appName, appDir, appFiles,
                               appPrimaryDoc, assetTypeName, contentCategory, verbose, python)
 
-      if (targetIsShinyapps) {
+      if (isShinyapps(accountDetails)) {
 
         # Step 1. Create presigned URL and register pending bundle.
         bundleSize <- file.info(bundlePath)$size

--- a/man/options.Rd
+++ b/man/options.Rd
@@ -33,6 +33,7 @@ Supported global options include:
    \item{\code{rsconnect.force.update.apps}}{When \code{TRUE}, bypasses the prompt to confirm whether you wish to update previously-deployed content}
    \item{\code{rsconnect.pre.deploy}}{A function to run prior to deploying content; it receives as an argument the path to the content that's about to be deployed.}
    \item{\code{rsconnect.post.deploy}}{A function to run after successfully deploying content; it receives as an argument the path to the content that was just deployed.}
+   \item{\code{rsconnect.python.enabled}}{When \code{TRUE}, use the python executable specified by the \code{RETICULATE_PYTHON} environment variable and add a \code{python} section to the deployment manifest. By default, python is enabled when deploying to RStudio Connect and disabled when deploying to shinyapps.io.}
 }
 When deploying content from the RStudio IDE, the rsconnect package's deployment methods are executed in a vanilla R session that doesn't execute startup scripts. This can make it challenging to ensure options are set properly prior to push-button deployment, so the rsconnect package has a parallel set of ``startup'' scripts it runs prior to deploying. The follow are run in order, if they exist, prior to deployment:
 \describe{

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -140,35 +140,3 @@ test_that("Rmd with reticulate as an inferred dependency includes reticulate and
   expect_equal(manifest$metadata$primary_rmd, "implicit.Rmd")
   expect_true(file.exists(file.path(bundleTempDir, manifest$python$package_manager$package_file)))
 })
-
-test_that("Rmd with reticulate but no python is an error", {
-  skip_on_cran()
-  expect_error(makeShinyBundleTempDir("reticulated rmd", "test-reticulate-rmds", NULL), "*python was not specified")
-})
-
-test_that("Rmd with reticulate but no python is an error", {
-  skip_on_cran()
-  expect_error(makeShinyBundleTempDir("reticulated rmd", "test-reticulate-rmds", "implicit.Rmd"), "*python was not specified")
-})
-
-test_that("Rmd with reticulate can use python specified in RETICULATE_PYTHON environment variable", {
-  skip_on_cran()
-  skip_if_not_installed("reticulate")
-
-  python <- Sys.which("python")
-  Sys.setenv(RETICULATE_PYTHON=python)
-  skip_if(python == "", "python is not installed")
-
-  bundleTempDir <- makeShinyBundleTempDir("reticulated rmd", "test-reticulate-rmds", "implicit.Rmd")
-  on.exit(unlink(bundleTempDir, recursive = TRUE))
-
-  lockfile <- file.path(bundleTempDir, "packrat/packrat.lock")
-  deps <- packrat:::readLockFilePackages(lockfile)
-  expect_true("reticulate" %in% names(deps))
-
-  manifest <- jsonlite::fromJSON(file.path(bundleTempDir, "manifest.json"))
-  expect_equal(manifest$metadata$appmode, "rmd-static")
-  expect_equal(manifest$metadata$primary_rmd, "implicit.Rmd")
-  expect_true(file.exists(file.path(bundleTempDir, manifest$python$package_manager$package_file)))
-  Sys.unsetenv("RETICULATE_PYTHON")
-})

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -140,3 +140,26 @@ test_that("Rmd with reticulate as an inferred dependency includes reticulate and
   expect_equal(manifest$metadata$primary_rmd, "implicit.Rmd")
   expect_true(file.exists(file.path(bundleTempDir, manifest$python$package_manager$package_file)))
 })
+
+test_that("getPython handles null python by checking RETICULATE_PYTHON", {
+  skip_on_cran()
+
+  Sys.setenv(RETICULATE_PYTHON="/usr/local/bin/python")
+  expect_equal(getPython(NULL), "/usr/local/bin/python")
+  Sys.unsetenv("RETICULATE_PYTHON")
+})
+
+test_that("getPython handles null python and empty RETICULATE_PYTHON", {
+  skip_on_cran()
+
+  Sys.unsetenv("RETICULATE_PYTHON")
+  expect_equal(getPython(NULL), NULL)
+})
+
+test_that("getPython expands paths", {
+  skip_on_cran()
+
+  result <- getPython("~/bin/python")
+  expect_true(result != "~/bin/python")
+  expect_match(result, "*/bin/python")
+})

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -163,3 +163,35 @@ test_that("getPython expands paths", {
   expect_true(result != "~/bin/python")
   expect_match(result, "*/bin/python")
 })
+
+test_that("getPythonForTarget honors rsconnect.python.enabled = FALSE", {
+  skip_on_cran()
+
+  options(rsconnect.python.enabled = FALSE)
+  result <- getPythonForTarget("/usr/bin/python", list(server="shinyapps.io"))
+  expect_equal(result, NULL)
+  options(rsconnect.python.enabled = NULL)
+})
+
+test_that("getPythonForTarget honors rsconnect.python.enabled = TRUE", {
+  skip_on_cran()
+
+  options(rsconnect.python.enabled = TRUE)
+  result <- getPythonForTarget("/usr/bin/python", list(server="shinyapps.io"))
+  expect_equal(result, "/usr/bin/python")
+  options(rsconnect.python.enabled = NULL)
+})
+
+test_that("getPythonForTarget defaults to enabled for Connect", {
+  skip_on_cran()
+
+  result <- getPythonForTarget("/usr/bin/python", list(server="connect.example.com"))
+  expect_equal(result, "/usr/bin/python")
+})
+
+test_that("getPythonForTarget defaults to disabled for shinyapps.io", {
+  skip_on_cran()
+
+  result <- getPythonForTarget("/usr/bin/python", list(server="shinyapps.io"))
+  expect_equal(result, NULL)
+})


### PR DESCRIPTION
This PR adds an option (`rsconnect.python.enabled`) to enable/disable python support. Supported values are:
* `TRUE`: python support is enabled. If `RETICULATE_PYTHON` is set, the python environment will be sent in the bundle manifest. Note that this is supported by RStudio Connect, but not by shinyapps.io. Attempting to deploy python content to shinyapps.io will result in an error from the server.
* `FALSE`: python support is disabled. No python information will be sent in the manifest. If you deploy content that depends on python, the deployment will fail at the Connect server.
* `NULL` (the default): python is enabled when deploying to RStudio Connect, but not when deploying to shinyapps.io.

