### PR TITLE
Update python environment introspection

### DIFF
--- a/inst/resources/environment.py
+++ b/inst/resources/environment.py
@@ -18,9 +18,7 @@ class EnvironmentException(Exception):
 def detect_environment():
     """Determine the python dependencies in the environment.
 
-    If requirements.txt exists in the notebook directory,
-    its contents will be used. Otherwise, the results
-    of `pip freeze` will be used.
+    `pip freeze` will be used to introspect the environment.
 
     Returns a dictionary containing the package spec filename
     and contents if successful, or a dictionary containing 'error'

--- a/inst/resources/environment.py
+++ b/inst/resources/environment.py
@@ -10,11 +10,12 @@ import sys
 version_re = re.compile(r'\d+\.\d+(\.\d+)?')
 exec_dir = os.path.dirname(sys.executable)
 
+
 class EnvironmentException(Exception):
     pass
 
 
-def detect_environment(dirname):
+def detect_environment():
     """Determine the python dependencies in the environment.
 
     If requirements.txt exists in the notebook directory,
@@ -25,8 +26,7 @@ def detect_environment(dirname):
     and contents if successful, or a dictionary containing 'error'
     on failure.
     """
-    result = (output_file(dirname, 'requirements.txt', 'pip') or
-              pip_freeze(dirname))
+    result = pip_freeze()
 
     if result is not None:
         result['python'] = get_python_version()
@@ -76,7 +76,7 @@ def output_file(dirname, filename, package_manager):
             data = f.read()
 
         data = '\n'.join([line for line in data.split('\n')
-                                if 'rsconnect-jupyter' not in line])
+                                if 'rsconnect' not in line])
 
         return {
             'filename': filename,
@@ -88,7 +88,7 @@ def output_file(dirname, filename, package_manager):
         raise EnvironmentException('Error reading %s: %s' % (filename, str(exc)))
 
 
-def pip_freeze(dirname):
+def pip_freeze():
     """Inspect the environment using `pip freeze`.
 
     Returns a dictionary containing the filename
@@ -110,7 +110,7 @@ def pip_freeze(dirname):
         raise EnvironmentException('Error during pip freeze: %s' % msg)
 
     pip_stdout = '\n'.join([line for line in pip_stdout.split('\n')
-                            if 'rsconnect-jupyter' not in line])
+                            if 'rsconnect' not in line])
 
     return {
         'filename': 'requirements.txt',
@@ -122,12 +122,7 @@ def pip_freeze(dirname):
 
 if __name__ == '__main__':
     try:
-        if len(sys.argv) < 2:
-            raise EnvironmentException('Usage: %s NOTEBOOK_PATH' % sys.argv[0])
-
-        notebook_path = sys.argv[1]
-        dirname = os.path.dirname(notebook_path)
-        result = detect_environment(dirname)
+        result = detect_environment()
     except EnvironmentException as exc:
         result = dict(error=str(exc))
 


### PR DESCRIPTION
This PR simplifies python environment detection by removing support for requirements.txt. Instead, python environments will always be introspected via `pip freeze`.

This reconciles the environment.py script with the one in rsconnect-jupyter, so the same behavior applies to both.
