### PR TITLE
filter the manifest.json from the set of bundle app files

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -63,6 +63,7 @@ maxDirectoryList <- function(dir, parent, totalSize) {
     contents <- contents[!grepl(glob2rx(".DS_Store"), contents)]
     contents <- contents[!grepl(glob2rx(".gitignore"), contents)]
     contents <- contents[!grepl(glob2rx(".Rhistory"), contents)]
+    contents <- contents[!grepl(glob2rx("manifest.json"), contents)]
   }
 
   # sum the size of the files in the directory


### PR DESCRIPTION
Before this change, calls to `rsconnect::writeManifest` include the `manifest.json` in the set of bundle files. This means that the we include a checksum for the `manifest.json` in the manifest itself.

This is most harmful when deploying to shinyapps.io. That checksum is computed before we generate the manifest to include in the bundle and the deployment will err due to a checksum match.

We should not include `manifest.json` in the set of app bundle files; it is what defines the application content, not part of the application itself.

Function to help testing:

```r
writeAndLoadManifest <- function(d) {
  rsconnect::writeManifest(d)
  m <- jsonlite::fromJSON(file.path(d,'manifest.json'))
  return(m)
}
```

Before:

```r
# The first time through, there no manifest on disk.
writeAndLoadManifest('shiny-application')$files[['manifest.json']]
# => NULL

# Run again when there is a manifest in place:
writeAndLoadManifest('shiny-application')$files[['manifest.json']]
# => $checksum
# => [1] "1df41029e660bbce4e6e258e32bbcc0f"
```

After:

```r
# With or without a manifest on disk, we get the same result - no checksum
writeAndLoadManifest('shiny-application')$files[['manifest.json']]
# => NULL
writeAndLoadManifest('shiny-application')$files[['manifest.json']]
# => NULL
```
