### PR TITLE
Add warning for malformed YAML for flexdashboard

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -360,6 +360,10 @@ isShinyRmd <- function(filename) {
       # ...and "runtime: shiny", then it's a dynamic Rmd.
       return(TRUE)
     }
+    if (any(grepl('^shiny', unlist(yaml)))) {
+      # if shiny appears somewhere, but not in runtime, may be indentation error
+      warning("'shiny' appears in YAML, but not as runtime. Check indentation?")
+    }
   }
   return(FALSE)
 }


### PR DESCRIPTION
A potential fix for #357.

Also referenced in this community thread: https://community.rstudio.com/t/rstudio-connect-interactive-markdown-with-shiny-error-path-for-html-dependency-not-provided/7263/10