### PR TITLE
don't include 'renv' files in bundle

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -66,6 +66,9 @@ maxDirectoryList <- function(dir, parent, totalSize) {
     contents <- contents[!grepl(glob2rx("manifest.json"), contents)]
   }
 
+  # exclude renv files
+  contents <- setdiff(contents, c("renv", "renv.lock"))
+
   # sum the size of the files in the directory
   info <- file.info(file.path(dir, contents))
   size <- sum(info$size)


### PR DESCRIPTION
This PR doesn't retool rsconnect to use renv or anything -- it simply removes any `renv` files from the bundle, since they're otherwise unused / unneeded.