### PR TITLE
Create a separate callback for deployment failure

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -730,14 +730,14 @@ openURL <- function(client, application, launch.browser, on.failure, deploymentS
       # Connect should always end up here, even on deployment failures
       if (deploymentSucceeded) {
         showURL(url)
-      } else {
+      } else if (is.function(on.failure)) {
         on.failure(url)
       }
     }
   } else if (deploymentSucceeded) {
     # shinyapps.io should land here if things succeeded
     showURL(application$url)
-  } else {
+  } else if (is.function(on.failure)) {
       on.failure(application$url)
   }
     # or open no url if things failed

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -45,7 +45,8 @@
 #'   launched automatically after the app is started. Defaults to `TRUE` in
 #'   interactive sessions only. If a function is passed, it will be called
 #'   after the app is started, with the app URL as a paramter.
-#' @param on.failure Function to be called if the deployment fails.
+#' @param on.failure Function to be called if the deployment fails, with the
+#'   application as a parameter.
 #' @param logLevel One of `"quiet"`, `"normal"` or `"verbose"`; indicates how
 #'   much logging to the console is to be performed. At `"quiet"` reports no
 #'   information; at `"verbose"`, a full diagnostic log is captured.
@@ -731,14 +732,14 @@ openURL <- function(client, application, launch.browser, on.failure, deploymentS
       if (deploymentSucceeded) {
         showURL(url)
       } else if (is.function(on.failure)) {
-        on.failure(url)
+        on.failure(application)
       }
     }
   } else if (deploymentSucceeded) {
     # shinyapps.io should land here if things succeeded
     showURL(application$url)
   } else if (is.function(on.failure)) {
-      on.failure(application$url)
+    on.failure(application)
   }
     # or open no url if things failed
 }

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -45,8 +45,8 @@
 #'   launched automatically after the app is started. Defaults to `TRUE` in
 #'   interactive sessions only. If a function is passed, it will be called
 #'   after the app is started, with the app URL as a paramter.
-#' @param on.failure Function to be called if the deployment fails, with the
-#'   application as a parameter.
+#' @param on.failure Function to be called if the deployment fails. If a
+#'   deployemnt log URL is available, it's passed as a parameter.
 #' @param logLevel One of `"quiet"`, `"normal"` or `"verbose"`; indicates how
 #'   much logging to the console is to be performed. At `"quiet"` reports no
 #'   information; at `"verbose"`, a full diagnostic log is captured.
@@ -732,14 +732,14 @@ openURL <- function(client, application, launch.browser, on.failure, deploymentS
       if (deploymentSucceeded) {
         showURL(url)
       } else if (is.function(on.failure)) {
-        on.failure(application)
+        on.failure(url)
       }
     }
   } else if (deploymentSucceeded) {
     # shinyapps.io should land here if things succeeded
     showURL(application$url)
   } else if (is.function(on.failure)) {
-    on.failure(application)
+    on.failure(null)
   }
     # or open no url if things failed
 }

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -46,7 +46,7 @@
 #'   interactive sessions only. If a function is passed, it will be called
 #'   after the app is started, with the app URL as a paramter.
 #' @param on.failure Function to be called if the deployment fails. If a
-#'   deployemnt log URL is available, it's passed as a parameter.
+#'   deployment log URL is available, it's passed as a parameter.
 #' @param logLevel One of `"quiet"`, `"normal"` or `"verbose"`; indicates how
 #'   much logging to the console is to be performed. At `"quiet"` reports no
 #'   information; at `"verbose"`, a full diagnostic log is captured.

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -91,7 +91,7 @@ The specified python binary will be invoked to determine its version
 and to list the python packages installed in the environment.}
 
 \item{on.failure}{Function to be called if the deployment fails. If a
-deployemnt log URL is available, it's passed as a parameter.}
+deployment log URL is available, it's passed as a parameter.}
 }
 \description{
 Deploy a \link[shiny:shiny-package]{shiny} application, an

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -12,7 +12,7 @@ deployApp(appDir = getwd(), appFiles = NULL, appFileManifest = NULL,
   logLevel = c("normal", "quiet", "verbose"), lint = TRUE,
   metadata = list(),
   forceUpdate = getOption("rsconnect.force.update.apps", FALSE),
-  python = NULL)
+  python = NULL, on.failure = NULL)
 }
 \arguments{
 \item{appDir}{Directory containing application. Defaults to current working
@@ -67,7 +67,8 @@ in which case record will be written to the location specified with \code{appDir
 
 \item{launch.browser}{If true, the system's default web browser will be
 launched automatically after the app is started. Defaults to \code{TRUE} in
-interactive sessions only.}
+interactive sessions only. If a function is passed, it will be called
+after the app is started, with the app URL as a paramter.}
 
 \item{logLevel}{One of \code{"quiet"}, \code{"normal"} or \code{"verbose"}; indicates how
 much logging to the console is to be performed. At \code{"quiet"} reports no
@@ -88,6 +89,8 @@ asking. If \code{FALSE}, ask to update. If unset, defaults to the value of
 Required if \code{reticulate} is a dependency of the app being deployed.
 The specified python binary will be invoked to determine its version
 and to list the python packages installed in the environment.}
+
+\item{on.failure}{Function to be called if the deployment fails.}
 }
 \description{
 Deploy a \link[shiny:shiny-package]{shiny} application, an

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -90,7 +90,8 @@ Required if \code{reticulate} is a dependency of the app being deployed.
 The specified python binary will be invoked to determine its version
 and to list the python packages installed in the environment.}
 
-\item{on.failure}{Function to be called if the deployment fails.}
+\item{on.failure}{Function to be called if the deployment fails, with the
+application as a parameter.}
 }
 \description{
 Deploy a \link[shiny:shiny-package]{shiny} application, an

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -90,8 +90,8 @@ Required if \code{reticulate} is a dependency of the app being deployed.
 The specified python binary will be invoked to determine its version
 and to list the python packages installed in the environment.}
 
-\item{on.failure}{Function to be called if the deployment fails, with the
-application as a parameter.}
+\item{on.failure}{Function to be called if the deployment fails. If a
+deployemnt log URL is available, it's passed as a parameter.}
 }
 \description{
 Deploy a \link[shiny:shiny-package]{shiny} application, an

--- a/man/deploySite.Rd
+++ b/man/deploySite.Rd
@@ -34,7 +34,8 @@ uploaded to the server.}
 
 \item{launch.browser}{If true, the system's default web browser will be
 launched automatically after the app is started. Defaults to \code{TRUE} in
-interactive sessions only.}
+interactive sessions only. If a function is passed, it will be called
+after the app is started, with the app URL as a paramter.}
 
 \item{logLevel}{One of \code{"quiet"}, \code{"normal"} or \code{"verbose"}; indicates how
 much logging to the console is to be performed. At \code{"quiet"} reports no


### PR DESCRIPTION
Currently, the `launch.browser` parameter to `deployApp` controls whether a browser is opened to the app after deployment. It's a boolean, but also accepts a function which is called after deployment. If a function is passed, it is called on both success and failure.

This PR introduces a separate parameter `on.failure` which is called on failure, and `launch.browser` is now only called if the deployment succeeds. 
