### PR TITLE
switch back to generating our own random token

### DIFF
--- a/R/rsa.R
+++ b/R/rsa.R
@@ -29,7 +29,7 @@ createUniqueId <- function(bytes) {
   )
 
   set.seed(NULL)
-  paste(as.hexmode(sample(256, bytes)-1), collapse="")
+  paste0(as.hexmode(sample(256, bytes)-1), collapse="")
 }
 
 # generateToken generates a token for signing requests sent to the RStudio

--- a/R/rsa.R
+++ b/R/rsa.R
@@ -1,3 +1,35 @@
+# createUniqueId creates a random hex string of length bytes.
+# Uses its own random state.
+#
+# createUniqueId is used to create the token (name) for a public/private
+# key-pair. We have used three approaches for token generation:
+#
+# 1. Random hex string using the incoming random state. Produced duplicate
+#    tokens when users forced a constant initial seed (set.seed(0)).
+#    https://github.com/rstudio/rsconnect/issues/221
+# 2. MD5 of the public key. Produced empty tokens when the MD5 algorithm
+#    is disabled (due to FIPS mode).
+#    https://github.com/rstudio/rsconnect/issues/378
+# 3. Random hex string with isolated random state.
+createUniqueId <- function(bytes) {
+  # Seed handling inspired by:
+  # http://www.cookbook-r.com/Numbers/Saving_the_state_of_the_random_number_generator/
+  if (exists(".Random.seed", .GlobalEnv)) {
+    oldseed <- .GlobalEnv$.Random.seed
+  } else {
+    oldseed <- NULL
+  }
+  on.exit(
+    if (!is.null(oldseed)) {
+      .GlobalEnv$.Random.seed <- oldseed
+    } else {
+      rm(".Random.seed", envir = .GlobalEnv)
+    }
+  )
+
+  set.seed(NULL)
+  paste(as.hexmode(sample(256, bytes)-1), collapse="")
+}
 
 # generateToken generates a token for signing requests sent to the RStudio
 # Connect service. The token's ID and public key are sent to the server, and
@@ -6,13 +38,8 @@ generateToken <- function() {
   key <- openssl::rsa_keygen(2048L)
   priv.der <- openssl::write_der(key)
   pub.der <- openssl::write_der(key$pubkey)
+  tokenId <- createUniqueId(16)
 
-  # hash the public key to generate the token ID; we used to create a random
-  # token ID using sample(), but this causes trouble for users who use a fixed
-  # RNG seed and/or need the RNG state to remain unperturbed.
-  tokenId <- as.character(openssl::md5(serialize(pub.der, NULL)))
-
-  # form the token from the
   list(
     token = paste0("T", tokenId),
     public_key = openssl::base64_encode(pub.der),

--- a/R/rsa.R
+++ b/R/rsa.R
@@ -24,7 +24,8 @@ createUniqueId <- function(bytes) {
       .GlobalEnv$.Random.seed <- oldseed
     } else {
       rm(".Random.seed", envir = .GlobalEnv)
-    }
+    },
+    add = TRUE
   )
 
   set.seed(NULL)


### PR DESCRIPTION
we are no longer sensitive to the incoming seed.

fixes #378

Given no random state, we produce tokens and leave no random state.

```r
rm(".Random.seed", envir = .GlobalEnv)
rsconnect:::generateToken()$token
# => [1] "T79f9a4b65351a0095590a6292024e83e"
.Random.seed
# => Error: object '.Random.seed' not found
```

Given random state, we produce tokens and restore the random state.

```r
set.seed(NULL)
s <- .Random.seed
rsconnect:::generateToken()$token
# => [1] "Tb613bf39e73cb0a47b41fdead6d42a9c"
all(s == .Random.seed)
# => [1] TRUE
```

Given a fixed random state, we do not produce repeated tokens.

```r
set.seed(0)
rsconnect:::generateToken()$token
# => [1] "T389daa5047cded18b6ce5d95625b05b4"
set.seed(0)
rsconnect:::generateToken()$token
# => [1] "T3d47b750a6026313e4c84cad30f62e49"
```