### PR TITLE
Simplify python injection

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -316,6 +316,11 @@ writeManifest <- function(appDir = getwd(),
   manifestPath <- file.path(appDir, "manifest.json")
   writeLines(manifestJson, manifestPath, useBytes = TRUE)
 
+  srcRequirementsFile <- file.path(bundleDir, "requirements.txt")
+  dstRequirementsFile <- file.path(appDir, "requirements.txt")
+  if(file.exists(srcRequirementsFile) && !file.exists(dstRequirementsFile)) {
+    file.copy(srcRequirementsFile, dstRequirementsFile)
+  }
   invisible()
 }
 
@@ -525,7 +530,7 @@ inferPythonEnv <- function(workdir, python) {
 }
 
 createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
-                              appPrimaryDoc, assetTypeName, users, python = NULL, 
+                              appPrimaryDoc, assetTypeName, users, python = NULL,
                               hasPythonRmd = FALSE) {
 
   # provide package entries for all dependencies

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -260,6 +260,8 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
 #' @param python Full path to a python binary for use by `reticulate`.
 #'   The specified python binary will be invoked to determine its version
 #'   and to list the python packages installed in the environment.
+#'   If python = NULL, and RETICULATE_PYTHON is set in the environment,
+#'   its value will be used.
 #'
 #' @export
 writeManifest <- function(appDir = getwd(),
@@ -296,6 +298,8 @@ writeManifest <- function(appDir = getwd(),
       appFiles = appFiles,
       appPrimaryDoc = appPrimaryDoc)
   on.exit(unlink(bundleDir, recursive = TRUE), add = TRUE)
+
+  python <- getPython(python)
 
   # generate the manifest and write it into the bundle dir
   manifest <- createAppManifest(

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -60,8 +60,9 @@
 #'   `getOption("rsconnect.force.update.apps", FALSE)`.
 #' @param python Full path to a python binary for use by `reticulate`.
 #'   Required if `reticulate` is a dependency of the app being deployed.
-#'   The specified python binary will be invoked to determine its version
-#'   and to list the python packages installed in the environment.
+#'   If python = NULL, and RETICULATE_PYTHON is set in the environment, its
+#'   value will be used. The specified python binary will be invoked to determine
+#'   its version and to list the python packages installed in the environment.
 #' @examples
 #' \dontrun{
 #'

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -740,7 +740,7 @@ openURL <- function(client, application, launch.browser, on.failure, deploymentS
     # shinyapps.io should land here if things succeeded
     showURL(application$url)
   } else if (is.function(on.failure)) {
-    on.failure(null)
+    on.failure(NULL)
   }
     # or open no url if things failed
 }

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -87,8 +87,9 @@ asking. If \code{FALSE}, ask to update. If unset, defaults to the value of
 
 \item{python}{Full path to a python binary for use by \code{reticulate}.
 Required if \code{reticulate} is a dependency of the app being deployed.
-The specified python binary will be invoked to determine its version
-and to list the python packages installed in the environment.}
+If python = NULL, and RETICULATE_PYTHON is set in the environment, its
+value will be used. The specified python binary will be invoked to determine
+its version and to list the python packages installed in the environment.}
 
 \item{on.failure}{Function to be called if the deployment fails. If a
 deployment log URL is available, it's passed as a parameter.}

--- a/man/deploySite.Rd
+++ b/man/deploySite.Rd
@@ -50,8 +50,9 @@ record. These fields will be returned on subsequent calls to
 
 \item{python}{Full path to a python binary for use by \code{reticulate}.
 Required if \code{reticulate} is a dependency of the app being deployed.
-The specified python binary will be invoked to determine its version
-and to list the python packages installed in the environment.}
+If python = NULL, and RETICULATE_PYTHON is set in the environment, its
+value will be used. The specified python binary will be invoked to determine
+its version and to list the python packages installed in the environment.}
 }
 \description{
 Deploy an R Markdown website to a server.

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -25,7 +25,9 @@ deployed (e.g. \code{"plot"} or \code{"site"}).}
 
 \item{python}{Full path to a python binary for use by \code{reticulate}.
 The specified python binary will be invoked to determine its version
-and to list the python packages installed in the environment.}
+and to list the python packages installed in the environment.
+If python = NULL, and RETICULATE_PYTHON is set in the environment,
+its value will be used.}
 }
 \description{
 Given a directory content targeted for deployment, write a manifest.json

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -9,6 +9,15 @@ makeShinyBundleTempDir <- function(appName, appDir, appPrimaryDoc, python = NULL
   bundleTempDir
 }
 
+makeManifest <- function(appDir, appPrimaryDoc, python = NULL) {
+  writeManifest(appDir, NULL, appPrimaryDoc, NULL, python)
+  manifestFile <-file.path(appDir, "manifest.json")
+  data <- readLines(manifestFile, warn = FALSE, encoding = "UTF-8")
+  manifestJson <- jsonlite::fromJSON(data)
+  unlink(manifestFile)
+  manifestJson
+}
+
 # avoid 'trying to use CRAN without setting a mirror' errors
 repos <- getOption("repos")
 options(repos = c(CRAN = "https://cran.rstudio.com"))
@@ -183,6 +192,67 @@ test_that("Rmd without a python block doesn't include reticulate or python in th
   expect_equal(manifest$metadata$primary_rmd, "simple.Rmd")
   expect_equal(manifest$python, NULL)
 })
+
+test_that("writeManifest: Rmd with reticulate as a dependency includes python in the manifest", {
+  skip_on_cran()
+  skip_if_not_installed("reticulate")
+
+  python <- Sys.which("python")
+  skip_if(python == "", "python is not installed")
+  pipMissing <- system2(python, "-m pip help", stdout = NULL, stderr = NULL)
+  skip_if(pipMissing != 0, "pip module is not installed")
+
+  appDir <- "test-reticulate-rmds"
+  manifest <- makeManifest(appDir, NULL, python = python)
+  requirements_file <- file.path(appDir, manifest$python$package_manager$package_file)
+  expect_equal(requirements_file, "test-reticulate-rmds/requirements.txt")
+  on.exit(unlink(requirements_file))
+
+  expect_equal(manifest$metadata$appmode, "rmd-static")
+  expect_equal(manifest$metadata$primary_rmd, "index.Rmd")
+  expect_true(file.exists(requirements_file))
+})
+
+test_that("writeManifest: Rmd with reticulate as an inferred dependency includes reticulate and python in the manifest", {
+  skip_on_cran()
+  skip_if_not_installed("reticulate")
+
+  python <- Sys.which("python")
+  skip_if(python == "", "python is not installed")
+  pipMissing <- system2(python, "-m pip help", stdout = NULL, stderr = NULL)
+  skip_if(pipMissing != 0, "pip module is not installed")
+
+  appDir <- "test-reticulate-rmds"
+  manifest <- makeManifest(appDir, "implicit.Rmd", python = python)
+  requirements_file <- file.path(appDir, manifest$python$package_manager$package_file)
+  expect_equal(requirements_file, "test-reticulate-rmds/requirements.txt")
+  on.exit(unlink(requirements_file))
+
+  expect_equal(manifest$metadata$appmode, "rmd-static")
+  expect_equal(manifest$metadata$primary_rmd, "implicit.Rmd")
+  expect_true(file.exists(requirements_file))
+})
+
+test_that("writeManifest: Rmd without a python block doesn't include reticulate or python in the manifest", {
+  skip_on_cran()
+
+  manifest <- makeManifest("test-rmds", "simple.Rmd", python = NULL)
+  expect_equal(manifest$metadata$appmode, "rmd-static")
+  expect_equal(manifest$metadata$primary_rmd, "simple.Rmd")
+  expect_null(manifest$python)
+})
+
+test_that("writeManifest: Rmd without a python block doesn't include reticulate or python in the manifest even if python specified", {
+  skip_on_cran()
+  python <- Sys.which("python")
+  skip_if(python == "", "python is not installed")
+
+  manifest <- makeManifest("test-rmds", "simple.Rmd", python = python)
+  expect_equal(manifest$metadata$appmode, "rmd-static")
+  expect_equal(manifest$metadata$primary_rmd, "simple.Rmd")
+  expect_equal(manifest$python, NULL)
+})
+
 test_that("getPython handles null python by checking RETICULATE_PYTHON", {
   skip_on_cran()
 

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -148,6 +148,41 @@ test_that("Rmd with reticulate as an inferred dependency includes reticulate and
   expect_true(file.exists(file.path(bundleTempDir, manifest$python$package_manager$package_file)))
 })
 
+test_that("Rmd without a python block doesn't include reticulate or python in the manifest", {
+  skip_on_cran()
+
+  bundleTempDir <- makeShinyBundleTempDir("plain rmd", "test-rmds",
+                                          "simple.Rmd", python = NULL)
+  on.exit(unlink(bundleTempDir, recursive = TRUE))
+
+  lockfile <- file.path(bundleTempDir, "packrat/packrat.lock")
+  deps <- packrat:::readLockFilePackages(lockfile)
+  expect_false("reticulate" %in% names(deps))
+
+  manifest <- jsonlite::fromJSON(file.path(bundleTempDir, "manifest.json"))
+  expect_equal(manifest$metadata$appmode, "rmd-static")
+  expect_equal(manifest$metadata$primary_rmd, "simple.Rmd")
+  expect_equal(manifest$python, NULL)
+})
+
+test_that("Rmd without a python block doesn't include reticulate or python in the manifest even if python specified", {
+  skip_on_cran()
+  python <- Sys.which("python")
+  skip_if(python == "", "python is not installed")
+
+  bundleTempDir <- makeShinyBundleTempDir("plain rmd", "test-rmds",
+                                          "simple.Rmd", python = python)
+  on.exit(unlink(bundleTempDir, recursive = TRUE))
+
+  lockfile <- file.path(bundleTempDir, "packrat/packrat.lock")
+  deps <- packrat:::readLockFilePackages(lockfile)
+  expect_false("reticulate" %in% names(deps))
+
+  manifest <- jsonlite::fromJSON(file.path(bundleTempDir, "manifest.json"))
+  expect_equal(manifest$metadata$appmode, "rmd-static")
+  expect_equal(manifest$metadata$primary_rmd, "simple.Rmd")
+  expect_equal(manifest$python, NULL)
+})
 test_that("getPython handles null python by checking RETICULATE_PYTHON", {
   skip_on_cran()
 


### PR DESCRIPTION
Currently, we inject a dependency on `reticulate` and add python to the manifest whenever python is specified - as a parameter to `deployApp`, or via the `RETICULATE_PYTHON` environment variable. This is a bit too aggressive, and often produces an unnecessary python section in the manifest.

This PR removes that behavior, in favor of only injecting an implicit `reticulate` dependency if there is an Rmd in the app files containing a `{python}` block. In that case, there might be no other reference to `reticulate`, but it is needed to render the Rmd.

Additionally, `writeManifest` doesn't currently honor `RETICULATE_PYTHON`. This is a bug (#374) and is also fixed in this PR.

