### PR TITLE
md5 workaround

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ Depends:
     R (>= 3.0.0)
 Imports:
     curl,
+    digest,
     jsonlite,
     openssl,
     packrat (>= 0.4.8-1),

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -562,7 +562,8 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
   # provide checksums for all files
   filelist <- list()
   for (file in files) {
-    checksum <- list(checksum = md5sum(file.path(appDir, file)))
+    filepath <- file.path(appDir, file)
+    checksum <- list(checksum = fileMD5.as.string(filepath))
     filelist[[file]] <- I(checksum)
   }
 

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -344,8 +344,8 @@ deployApp <- function(appDir = getwd(),
         bundleSize <- file.info(bundlePath)$size
 
         # Generate a hex-encoded md5 hash.
-        checkSum <- md5sum(bundlePath)
-        bundle <- client$createBundle(application$id, "application/x-tar", bundleSize, checkSum)
+        checksum <- fileMD5.as.string(bundlePath)
+        bundle <- client$createBundle(application$id, "application/x-tar", bundleSize, checksum)
 
         if (verbose)
           timestampedLog("Starting upload now")

--- a/R/utils.R
+++ b/R/utils.R
@@ -209,12 +209,28 @@ activeEncoding <- function(project = getwd()) {
   sub("^Encoding:\\s*", "", encodingLine)
 }
 
-md5sum <- function(path) {
+# Returns the MD5 for path as a sequence of 16 hexadecimal pairs with class md5 hash.
+fileMD5 <- function(path) {
+  if (is.null(path)) {
+    # Use raw(0) rather than the empty string so openssl::md5 returns the has as hex values and not
+    # a concatenated string of hex characters.
+    return(openssl::md5(raw(0)))
+  }
+  
   # open the file for reading in binary mode (to ensure we treat newlines
   # literally when computing the md5)
   con <- base::file(path, open = "rb")
   on.exit(close(con), add = TRUE)
 
-  # compute md5 sum of contents and return as ordinary characters
-  unclass(as.character(openssl::md5(con)))
+  openssl::md5(con)
+}
+
+# Returns the MD5 for path as a 32-character concatenated string of hexadecimal characters.
+fileMD5.as.string <- function(path) {
+  md5.as.string(fileMD5(path))
+}
+
+# Returns the input md5 as a 32-character concatenated string of hexadecimal characters.
+md5.as.string <- function(md5) {
+  unclass(as.character(md5))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -209,20 +209,19 @@ activeEncoding <- function(project = getwd()) {
   sub("^Encoding:\\s*", "", encodingLine)
 }
 
-# Returns the MD5 for path as a sequence of 16 hexadecimal pairs with class md5 hash.
+# Returns the MD5 for path as a raw sequence of 16 hexadecimal pairs.
 fileMD5 <- function(path) {
   if (is.null(path)) {
     # Use raw(0) rather than the empty string so openssl::md5 returns the has as hex values and not
     # a concatenated string of hex characters.
     return(openssl::md5(raw(0)))
   }
-  
-  # open the file for reading in binary mode (to ensure we treat newlines
-  # literally when computing the md5)
-  con <- base::file(path, open = "rb")
-  on.exit(close(con), add = TRUE)
 
-  openssl::md5(con)
+  # Use digest::digest to compute file MD5. FIPS mode disables openssl::md5. Workaround until we can
+  # migrate away from MD5 for file content checks.
+  #
+  # See: https://github.com/rstudio/rsconnect/issues/363
+  digest::digest(path, algo = "md5", file = TRUE, raw = TRUE)
 }
 
 # Returns the MD5 for path as a 32-character concatenated string of hexadecimal characters.
@@ -232,5 +231,5 @@ fileMD5.as.string <- function(path) {
 
 # Returns the input md5 as a 32-character concatenated string of hexadecimal characters.
 md5.as.string <- function(md5) {
-  unclass(as.character(md5))
+  paste(md5, collapse = "")
 }


### PR DESCRIPTION
Use `digest::digest` for MD5 file hashes rather than `openssl::md5`. First extracted all MD5 calls into helper functions with tests against those helpers. Once the MD5 calls were encapsulated, shifted from using `openssl` to `digest`.

Workaround until we have a migration path for #363.

Have tested deployments against both RStudio Connect and shinyapps.io.