### PR TITLE
Add prefix to Connect messages

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -157,8 +157,13 @@ connectClient <- function(service, authInfo) {
       while (TRUE) {
         path <- paste0(file.path("/tasks", taskId), "?first_status=", start)
         response <- handleResponse(GET(service, authInfo, path))
+
+        labeledMessage = function(msg) {
+          message(paste('[Connect]', msg))
+        }
+
         if (length(response$status) > 0) {
-          lapply(response$status, message)
+          lapply(response$status, labeledMessage)
           start <- response$last_status
         }
         if (length(response$finished) > 0 && response$finished) {


### PR DESCRIPTION
This PR is intended to make a clearer distinction between messages that originate from within rsconnect, and those that originate in the Connect server. There are currently some indications, but they are not necessarily obvious to end users or 10-% reliable. For example, the color of the messages or the presence of a server timestamp (some Connect log messages do not include timestamps).