### PR TITLE
Removed unused third argument from client

### DIFF
--- a/R/applications.R
+++ b/R/applications.R
@@ -233,7 +233,7 @@ showLogs <- function(appPath = getwd(), appFile = NULL, appName = NULL,
     }
   } else {
     # if not streaming, poll for the entries directly
-    logs <- client$getLogs(application$id, entries, FALSE)
+    logs <- client$getLogs(application$id, entries)
     cat(logs)
   }
 }


### PR DESCRIPTION
Issue #377 notes that there's currently a third unused argument in the call to ```client$getLogs```, which causes an error when calling ```rsconnect::showLogs```. This pull request removes the unused third argument to re-enable viewing logs in the console locally.