### PR TITLE
Lint calls to browser()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## 0.8.16 (in development)
 
 * Prevent attempts to deploy Connect applications without uploading (#145)
+* Flag usage of `browser()` debugging calls when deploying (#196)
 * Prevent accidental deployment of Plumber APIs to shinyapps.io (#204)
 * Allow `appId` and other global deployment parameters to `deploySite` (#231)
 * Fix error when running `deployments()` without any registered accounts (#261)

--- a/R/applications.R
+++ b/R/applications.R
@@ -202,7 +202,8 @@ showLogs <- function(appPath = getwd(), appFile = NULL, appName = NULL,
                      account = NULL, entries = 50, streaming = FALSE) {
 
   # determine the log target and target account info
-  target <- deploymentTarget(appPath, appName, NULL, NULL, account)
+  target <- deploymentTarget(appPath, appName, NULL, NULL, account,
+                             "shinyapps.io")
   accountDetails <- accountInfo(target$account)
   client <- lucidClient(shinyappsServerInfo()$url, accountDetails)
   application <- getAppByName(client, accountDetails, target$appName)

--- a/R/applications.R
+++ b/R/applications.R
@@ -202,8 +202,7 @@ showLogs <- function(appPath = getwd(), appFile = NULL, appName = NULL,
                      account = NULL, entries = 50, streaming = FALSE) {
 
   # determine the log target and target account info
-  target <- deploymentTarget(appPath, appName, NULL, NULL, account,
-                             "shinyapps.io")
+  target <- deploymentTarget(appPath, appName, NULL, NULL, account)
   accountDetails <- accountInfo(target$account)
   client <- lucidClient(shinyappsServerInfo()$url, accountDetails)
   application <- getAppByName(client, accountDetails, target$appName)

--- a/R/lint-utils.R
+++ b/R/lint-utils.R
@@ -3,6 +3,11 @@ stripComments <- function(content) {
   gsub("#.*", "", content, perl = TRUE)
 }
 
+hasBrowserCalls <- function(content) {
+  # look for calls to browser()
+  grepl("browser\\([^)]*\\)", content, perl = TRUE)
+}
+
 hasAbsolutePaths <- function(content) {
 
   regex <- c(

--- a/R/lint-utils.R
+++ b/R/lint-utils.R
@@ -4,8 +4,15 @@ stripComments <- function(content) {
 }
 
 hasBrowserCalls <- function(content) {
-  # look for calls to browser()
+  # look for calls to browser(); they will cause a debug halt, which is almost
+  # never wanted in a production application
   grepl("browser\\([^)]*\\)", content, perl = TRUE)
+}
+
+hasBrowseURLCalls <- function(content) {
+  # look for calls to browseURL(); browsers can't be opened on the server in
+  # deployed applications
+  grepl("browseURL\\([^)]*\\)", content, perl = TRUE)
 }
 
 hasAbsolutePaths <- function(content) {

--- a/R/linters.R
+++ b/R/linters.R
@@ -153,4 +153,20 @@ addLinter("browser", linter (
   suggestion = "The browser() debugging function should be removed."
 ))
 
+addLinter("browseURL", linter (
+  apply = function(content, ...) {
+    content <- stripComments(content)
+    which(hasBrowseURLCalls(content))
+  },
+
+  takes = isRCodeFile,
+
+  message = function(content, lines) {
+    makeLinterMessage("The following lines contain calls to the browseURL function",
+                      content,
+                      lines)
+  },
+
+  suggestion = "Remove browseURL calls; browseURL does not work in deployed applications."
+))
 

--- a/R/linters.R
+++ b/R/linters.R
@@ -14,7 +14,23 @@ addLinter("absolute.paths", linter(
   },
 
   suggestion = "Paths should be to files within the project directory."
+))
 
+addLinter("browser", linter (
+  apply = function(content, ...) {
+    content <- stripComments(content)
+    logical(0)
+  },
+
+  takes = isRCodeFile,
+
+  message = function(content, lines) {
+    makeLinterMessage("The following lines contain the browser() debugging function",
+                      content,
+                      lines)
+  },
+
+  suggestion = "The browser() debugging function should be removed."
 ))
 
 addLinter("invalid.relative.paths", linter(

--- a/R/linters.R
+++ b/R/linters.R
@@ -16,23 +16,6 @@ addLinter("absolute.paths", linter(
   suggestion = "Paths should be to files within the project directory."
 ))
 
-addLinter("browser", linter (
-  apply = function(content, ...) {
-    content <- stripComments(content)
-    logical(0)
-  },
-
-  takes = isRCodeFile,
-
-  message = function(content, lines) {
-    makeLinterMessage("The following lines contain the browser() debugging function",
-                      content,
-                      lines)
-  },
-
-  suggestion = "The browser() debugging function should be removed."
-))
-
 addLinter("invalid.relative.paths", linter(
 
   apply = function(content, ...) {
@@ -152,3 +135,22 @@ addLinter("filepath.capitalization", linter(
   suggestion = "Filepaths are case-sensitive on deployment server."
 
 ))
+
+addLinter("browser", linter (
+  apply = function(content, ...) {
+    content <- stripComments(content)
+    which(hasBrowserCalls(content))
+  },
+
+  takes = isRCodeFile,
+
+  message = function(content, lines) {
+    makeLinterMessage("The following lines contain the browser() debugging function",
+                      content,
+                      lines)
+  },
+
+  suggestion = "The browser() debugging function should be removed."
+))
+
+

--- a/tests/testthat/shinyapp-with-browser/server.R
+++ b/tests/testthat/shinyapp-with-browser/server.R
@@ -1,0 +1,10 @@
+library(shiny)
+shinyServer(function(input, output) {
+  output$distPlot <- renderPlot({
+    dist <- rnorm(input$obs)
+    hist(dist)
+    # stop to examine state
+    browser()
+  })
+  output$obs <- renderText({paste(input$obs, "\n", input$obs)})
+})

--- a/tests/testthat/shinyapp-with-browser/server.R
+++ b/tests/testthat/shinyapp-with-browser/server.R
@@ -1,6 +1,8 @@
 library(shiny)
 shinyServer(function(input, output) {
   output$distPlot <- renderPlot({
+    # open Google. no reason, just do it
+    browseURL("https://www.google.com/")
     dist <- rnorm(input$obs)
     hist(dist)
     # stop to examine state

--- a/tests/testthat/shinyapp-with-browser/ui.R
+++ b/tests/testthat/shinyapp-with-browser/ui.R
@@ -1,0 +1,11 @@
+library(shiny)
+shinyUI(pageWithSidebar(
+  headerPanel("Hello, Shiny!"),
+  sidebarPanel(
+    sliderInput("obs", "Number of observations:",
+                min = 1,
+                max = 1000,
+                value = 500)),
+  mainPanel(
+    plotOutput("distPlot")))
+)

--- a/tests/testthat/test-lint.R
+++ b/tests/testthat/test-lint.R
@@ -65,10 +65,14 @@ test_that("The linter believes that the Shiny example apps are okay", {
         })
       })
     })
-
   }
+})
 
-
+test_that("The linter identifies browser() statements correctly", {
+  result <- lint("shinyapp-with-browser")
+  server.R <- result[["server.R"]]
+  browseLines <- server.R[["browser"]]
+  expect_true(browseLines$indices == 7)
 })
 
 test_that("The linter accepts a plumber API", {

--- a/tests/testthat/test-lint.R
+++ b/tests/testthat/test-lint.R
@@ -72,7 +72,14 @@ test_that("The linter identifies browser() statements correctly", {
   result <- lint("shinyapp-with-browser")
   server.R <- result[["server.R"]]
   browseLines <- server.R[["browser"]]
-  expect_true(browseLines$indices == 7)
+  expect_true(browseLines$indices == 9)
+})
+
+test_that("The linter identifies browseURL() statements correctly", {
+  result <- lint("shinyapp-with-browser")
+  server.R <- result[["server.R"]]
+  browseLines <- server.R[["browseURL"]]
+  expect_true(browseLines$indices == 5)
 })
 
 test_that("The linter accepts a plumber API", {


### PR DESCRIPTION
This change emits a linter warning when the browser() call is present. browser() halts an application for debugging, which is almost never wanted in a deployed application. 

Closes #196. 