### PR TITLE
Import the backports package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ Imports:
     openssl,
     packrat (>= 0.4.8-1),
     rstudioapi (>= 0.5),
-    yaml (>= 2.1.5)
+    yaml (>= 2.1.5),
+    backports
 Suggests:
     RCurl,
     callr,

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -15,4 +15,6 @@
     options(rsconnect.http.timeout = ifelse(windows, 20, 5))
   }
 
+  backports::import(pkgname)
 }
+


### PR DESCRIPTION
On older versions of R, when deploying content, I get the error 

```
Error in isFALSE(upload) : could not find function "isFALSE"
Calls: <Anonymous>
Execution halted
```

The function `isFALSE()` is not available in older versions of R, and importing `backport` fixes this.
