### PR TITLE
Add reticulate support for conda

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -172,7 +172,7 @@ bundleFiles <- function(appDir) {
 
 bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
                       contentCategory, verbose = FALSE, python = NULL,
-                      compatibilityMode = F, forceGenerate = F) {
+                      compatibilityMode = FALSE, forceGenerate = FALSE) {
   logger <- verboseLogger(verbose)
 
   logger("Inferring App mode and parameters")

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -332,8 +332,9 @@ writeManifest <- function(appDir = getwd(),
   manifestPath <- file.path(appDir, "manifest.json")
   writeLines(manifestJson, manifestPath, useBytes = TRUE)
 
-  srcRequirementsFile <- file.path(bundleDir, "requirements.txt")
-  dstRequirementsFile <- file.path(appDir, "requirements.txt")
+  requirementsFilename <- manifest$python$package_manager$package_file
+  srcRequirementsFile <- file.path(bundleDir, requirementsFilename)
+  dstRequirementsFile <- file.path(appDir, requirementsFilename)
   if(file.exists(srcRequirementsFile) && !file.exists(dstRequirementsFile)) {
     file.copy(srcRequirementsFile, dstRequirementsFile)
   }
@@ -519,6 +520,30 @@ inferDependencies <- function(appMode, hasParameters, python, hasPythonRmd) {
   unique(deps)
 }
 
+isWindows <- function() {
+  Sys.info()[["sysname"]] == "Windows"
+}
+
+getCondaEnvPrefix <- function(python) {
+  prefix <- dirname(dirname(python))
+  if (!file.exists(file.path(prefix, "conda-meta"))) {
+    stop(paste("Python from", python, "does not look like a conda environment: cannot find `conda-meta`"))
+  }
+  prefix
+}
+
+getCondaExeForPrefix <- function(prefix) {
+  miniconda <- dirname(dirname(prefix))
+  conda <- file.path(miniconda, 'bin', 'conda')
+  if (isWindows()) {
+    conda <- paste(conda, ".exe", sep = "")
+  }
+  if (!file.exists(conda)) {
+    stop(paste("Conda env prefix", prefix, "does not have the `conda` command line interface."))
+  }
+  conda
+}
+
 inferPythonEnv <- function(workdir, python, compatibilityMode, forceGenerate) {
   # run the python introspection script
   env_py <- system.file("resources/environment.py", package = "rsconnect")
@@ -530,7 +555,15 @@ inferPythonEnv <- function(workdir, python, compatibilityMode, forceGenerate) {
   args <- c(args, shQuote(workdir))
 
   tryCatch({
-    output <- system2(command = python, args = args, stdout = TRUE, stderr = NULL, wait = TRUE)
+    if(require('reticulate') && reticulate::py_config()$anaconda && !compatibilityMode) {
+      prefix <- getCondaEnvPrefix(python)
+      conda <- getCondaExeForPrefix(prefix)
+      args <- c("run", "-p", prefix, python, args)
+      # conda run -p <prefix> python inst/resources/environment.py <flags> <dir>
+      output <- system2(command = conda, args = args, stdout = TRUE, stderr = NULL, wait = TRUE)
+    } else {
+      output <- system2(command = python, args = args, stdout = TRUE, stderr = NULL, wait = TRUE)
+    }
     environment <- jsonlite::fromJSON(output)
     if (is.null(environment$error)) {
       list(

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -282,7 +282,7 @@ writeManifest <- function(appDir = getwd(),
                           contentCategory = NULL,
                           python = NULL,
                           forceGeneratePythonEnvironment = FALSE,
-                          forceRequirementsTxtEnvironment = F) {
+                          forceRequirementsTxtEnvironment = FALSE) {
   if (is.null(appFiles)) {
     appFiles <- bundleFiles(appDir)
   } else {

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -555,7 +555,10 @@ inferPythonEnv <- function(workdir, python, compatibilityMode, forceGenerate) {
   args <- c(args, shQuote(workdir))
 
   tryCatch({
-    if(require('reticulate') && reticulate::py_config()$anaconda && !compatibilityMode) {
+    # First check for reticulate. Then see if python is loaded in reticulate space, verify anaconda presence,
+    # and verify that the user hasn't specified that they don't want their conda environment captured.
+    if(requireNamespace('reticulate', quietly = TRUE) && reticulate::py_available(initialize = FALSE) &&
+       reticulate::py_config()$anaconda && !compatibilityMode) {
       prefix <- getCondaEnvPrefix(python)
       conda <- getCondaExeForPrefix(prefix)
       args <- c("run", "-p", prefix, python, args)

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -333,6 +333,7 @@ writeManifest <- function(appDir = getwd(),
   writeLines(manifestJson, manifestPath, useBytes = TRUE)
 
   requirementsFilename <- manifest$python$package_manager$package_file
+  if (is.null(requirementsFilename)) { requirementsFilename <- "requirements.txt" }
   srcRequirementsFile <- file.path(bundleDir, requirementsFilename)
   dstRequirementsFile <- file.path(appDir, requirementsFilename)
   if(file.exists(srcRequirementsFile) && !file.exists(dstRequirementsFile)) {
@@ -557,7 +558,7 @@ inferPythonEnv <- function(workdir, python, compatibilityMode, forceGenerate) {
   tryCatch({
     # First check for reticulate. Then see if python is loaded in reticulate space, verify anaconda presence,
     # and verify that the user hasn't specified that they don't want their conda environment captured.
-    if(requireNamespace('reticulate', quietly = TRUE) && reticulate::py_available(initialize = FALSE) &&
+    if('reticulate' %in% rownames(installed.packages()) && reticulate::py_available(initialize = FALSE) &&
        reticulate::py_config()$anaconda && !compatibilityMode) {
       prefix <- getCondaEnvPrefix(python)
       conda <- getCondaExeForPrefix(prefix)

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -281,7 +281,7 @@ writeManifest <- function(appDir = getwd(),
                           appPrimaryDoc = NULL,
                           contentCategory = NULL,
                           python = NULL,
-                          forceGeneratePythonEnvironment = F,
+                          forceGeneratePythonEnvironment = FALSE,
                           forceRequirementsTxtEnvironment = F) {
   if (is.null(appFiles)) {
     appFiles <- bundleFiles(appDir)

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -117,7 +117,7 @@ deployApp <- function(appDir = getwd(),
                       forceUpdate = getOption("rsconnect.force.update.apps", FALSE),
                       python = NULL,
                       on.failure = NULL,
-                      forceGeneratePythonEnvironment = F,
+                      forceGeneratePythonEnvironment = FALSE,
                       forceRequirementsTxtEnvironment = F) {
 
   if (!isStringParam(appDir))
@@ -791,4 +791,3 @@ runStartupScripts <- function(appDir, logLevel) {
     }
   }
 }
-

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -64,6 +64,13 @@
 #'   If python = NULL, and RETICULATE_PYTHON is set in the environment, its
 #'   value will be used. The specified python binary will be invoked to determine
 #'   its version and to list the python packages installed in the environment.
+#' @param forceGeneratePythonEnvironment Optional. If an existing
+#'   `requirements.txt` or `environment.yml` file is found, it will
+#'   be overwritten when this argument is `TRUE`.
+#' @param forceRequirementsTxtEnvironment Optional. If rsconnect
+#'   detects you are running in a conda environment, it will write
+#'   `requirements.txt` instead of `environment.yml` when this
+#'   argument is `TRUE`.
 #' @examples
 #' \dontrun{
 #'
@@ -109,7 +116,9 @@ deployApp <- function(appDir = getwd(),
                       metadata = list(),
                       forceUpdate = getOption("rsconnect.force.update.apps", FALSE),
                       python = NULL,
-                      on.failure = NULL) {
+                      on.failure = NULL,
+                      forceGeneratePythonEnvironment = F,
+                      forceRequirementsTxtEnvironment = F) {
 
   if (!isStringParam(appDir))
     stop(stringParamErrorMessage("appDir"))
@@ -354,7 +363,8 @@ deployApp <- function(appDir = getwd(),
       # python is enabled on Connect but not on Shinyapps
       python <- getPythonForTarget(python, accountDetails)
       bundlePath <- bundleApp(target$appName, appDir, appFiles,
-                              appPrimaryDoc, assetTypeName, contentCategory, verbose, python)
+                              appPrimaryDoc, assetTypeName, contentCategory, verbose, python,
+                              forceRequirementsTxtEnvironment, forceGeneratePythonEnvironment)
 
       if (isShinyapps(accountDetails)) {
 

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -118,7 +118,7 @@ deployApp <- function(appDir = getwd(),
                       python = NULL,
                       on.failure = NULL,
                       forceGeneratePythonEnvironment = FALSE,
-                      forceRequirementsTxtEnvironment = F) {
+                      forceRequirementsTxtEnvironment = FALSE) {
 
   if (!isStringParam(appDir))
     stop(stringParamErrorMessage("appDir"))

--- a/inst/resources/environment.py
+++ b/inst/resources/environment.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
+import datetime
 import json
 import locale
 import os
 import re
 import subprocess
 import sys
-
 
 version_re = re.compile(r'\d+\.\d+(\.\d+)?')
 exec_dir = os.path.dirname(sys.executable)
@@ -15,7 +15,7 @@ class EnvironmentException(Exception):
     pass
 
 
-def detect_environment(dirname):
+def detect_environment(dirname, force_generate=False, compatibility_mode=False, conda=None):
     """Determine the python dependencies in the environment.
 
     `pip freeze` will be used to introspect the environment.
@@ -23,16 +23,46 @@ def detect_environment(dirname):
     Returns a dictionary containing the package spec filename
     and contents if successful, or a dictionary containing 'error'
     on failure.
+    :param: dirname Directory name
+    :param: force_generate Force the generation of an environment
+    :param: compatibility_mode Force the usage of `pip freeze` for older
+    connect versions which do not support conda.
     """
-    result = (output_file(dirname, 'requirements.txt', 'pip') or
-              pip_freeze(dirname))
+    if not compatibility_mode:
+        conda = get_conda(conda)
+    if conda:
+        if force_generate:
+            result = conda_env_export(conda)
+        else:
+            result = (output_file(dirname, 'environment.yml', 'conda')
+                      or conda_env_export(conda))
+    else:
+        if force_generate:
+            result = pip_freeze()
+        else:
+            result = (output_file(dirname, 'requirements.txt', 'pip')
+                      or pip_freeze())
 
     if result is not None:
         result['python'] = get_python_version()
         result['pip'] = get_version('pip')
+        if conda:
+            result['conda'] = get_conda_version(conda)
         result['locale'] = get_default_locale()
 
     return result
+
+
+def get_conda(conda=None):
+    """get_conda tries to find the conda executable if we're in
+    a conda environment. If not, or if we cannot find the executable,
+    return None.
+    :returns: conda string path to conda or None.
+    """
+    if os.environ.get('CONDA_PREFIX', None) is None and conda is None:
+        return None
+    else:
+        return conda or os.environ.get('CONDA_EXE', None)
 
 
 def get_python_version():
@@ -40,8 +70,23 @@ def get_python_version():
     return "%d.%d.%d" % (v[0], v[1], v[2])
 
 
-def get_default_locale():
-    return '.'.join(locale.getdefaultlocale())
+def get_conda_version(conda):
+    try:
+        args = [conda, '-V']
+        proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        stdout, stderr = proc.communicate()
+        match = version_re.search(stdout)
+        if match:
+            return match.group()
+        msg = "Failed to get version of conda from the output of: %s" % (' '.join(args))
+        raise EnvironmentException(msg)
+    except Exception as exception:
+        raise EnvironmentException("Error getting conda version: %s" % str(exception))
+
+
+def get_default_locale(locale_source=locale.getdefaultlocale):
+    result = '.'.join([item or '' for item in locale_source()])
+    return '' if result == '.' else result
 
 
 def get_version(module):
@@ -55,8 +100,8 @@ def get_version(module):
 
         msg = "Failed to get version of '%s' from the output of: %s" % (module, ' '.join(args))
         raise EnvironmentException(msg)
-    except Exception as exc:
-        raise EnvironmentException("Error getting '%s' version: %s" % (module, str(exc)))
+    except Exception as exception:
+        raise EnvironmentException("Error getting '%s' version: %s" % (module, str(exception)))
 
 
 def output_file(dirname, filename, package_manager):
@@ -75,7 +120,7 @@ def output_file(dirname, filename, package_manager):
             data = f.read()
 
         data = '\n'.join([line for line in data.split('\n')
-                                if 'rsconnect' not in line])
+                          if 'rsconnect' not in line])
 
         return {
             'filename': filename,
@@ -83,11 +128,11 @@ def output_file(dirname, filename, package_manager):
             'source': 'file',
             'package_manager': package_manager,
         }
-    except Exception as exc:
-        raise EnvironmentException('Error reading %s: %s' % (filename, str(exc)))
+    except Exception as exception:
+        raise EnvironmentException('Error reading %s: %s' % (filename, str(exception)))
 
 
-def pip_freeze(dirname):
+def pip_freeze():
     """Inspect the environment using `pip freeze`.
 
     Returns a dictionary containing the filename
@@ -101,8 +146,8 @@ def pip_freeze(dirname):
 
         pip_stdout, pip_stderr = proc.communicate()
         pip_status = proc.returncode
-    except Exception as exc:
-        raise EnvironmentException('Error during pip freeze: %s' % str(exc))
+    except Exception as exception:
+        raise EnvironmentException('Error during pip freeze: %s' % str(exception))
 
     if pip_status != 0:
         msg = pip_stderr or ('exited with code %d' % pip_status)
@@ -110,6 +155,8 @@ def pip_freeze(dirname):
 
     pip_stdout = '\n'.join([line for line in pip_stdout.split('\n')
                             if 'rsconnect' not in line])
+
+    pip_stdout = '# requirements.txt generated by rsconnect-python on '+str(datetime.datetime.utcnow())+'\n'+pip_stdout
 
     return {
         'filename': 'requirements.txt',
@@ -119,13 +166,52 @@ def pip_freeze(dirname):
     }
 
 
-if __name__ == '__main__':
+def conda_env_export(conda):
+    """Inspect the environment using `conda env export`
+    :param: conda path to the `conda` tool
+    :return: dictionary containing the key "environment.yml" and the data inside
+    """
+    try:
+        proc = subprocess.Popen(
+            [conda, 'env', 'export'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        conda_stdout, conda_stderr = proc.communicate()
+        conda_status = proc.returncode
+    except Exception as exception:
+        raise EnvironmentException('Error during conda env export: %s' % str(exception))
+
+    if conda_status != 0:
+        msg = conda_stderr or ('exited with code %d' % conda_status)
+        raise EnvironmentException('Error during conda env export: %s' % msg)
+
+    return {
+        'filename': 'environment.yml',
+        'contents': conda_stdout,
+        'source': 'conda_env_export',
+        'package_manager': 'conda'
+    }
+
+
+def main():
     try:
         if len(sys.argv) < 2:
-            raise EnvironmentException('Usage: %s DIRECTORY' % sys.argv[0])
-
-        result = detect_environment(sys.argv[1])
-    except EnvironmentException as exc:
-        result = dict(error=str(exc))
+            raise EnvironmentException('Usage: %s [-fc] DIRECTORY' % sys.argv[0])
+        # directory is always the last argument
+        directory = sys.argv[len(sys.argv)-1]
+        flags = ''
+        force_generate = False
+        compatibility_mode = False
+        if len(sys.argv) > 2:
+            flags = sys.argv[1]
+        if 'f' in flags:
+            force_generate = True
+        if 'c' in flags:
+            compatibility_mode = True
+        result = detect_environment(directory, force_generate, compatibility_mode)
+    except EnvironmentException as exception:
+        result = dict(error=str(exception))
 
     json.dump(result, sys.stdout, indent=4)
+
+
+if __name__ == '__main__':
+    main()

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -24,7 +24,9 @@ deployApp(
   metadata = list(),
   forceUpdate = getOption("rsconnect.force.update.apps", FALSE),
   python = NULL,
-  on.failure = NULL
+  on.failure = NULL,
+  forceGeneratePythonEnvironment = F,
+  forceRequirementsTxtEnvironment = F
 )
 }
 \arguments{
@@ -107,6 +109,15 @@ its version and to list the python packages installed in the environment.}
 
 \item{on.failure}{Function to be called if the deployment fails. If a
 deployment log URL is available, it's passed as a parameter.}
+
+\item{forceGeneratePythonEnvironment}{Optional. If an existing
+\code{requirements.txt} or \code{environment.yml} file is found, it will
+be overwritten when this argument is \code{TRUE}.}
+
+\item{forceRequirementsTxtEnvironment}{Optional. If rsconnect
+detects you are running in a conda environment, it will write
+\code{requirements.txt} instead of \code{environment.yml} when this
+argument is \code{TRUE}.}
 }
 \description{
 Deploy a \link[shiny:shiny-package]{shiny} application, an

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -25,8 +25,8 @@ deployApp(
   forceUpdate = getOption("rsconnect.force.update.apps", FALSE),
   python = NULL,
   on.failure = NULL,
-  forceGeneratePythonEnvironment = F,
-  forceRequirementsTxtEnvironment = F
+  forceGeneratePythonEnvironment = FALSE,
+  forceRequirementsTxtEnvironment = FALSE
 )
 }
 \arguments{

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -10,8 +10,8 @@ writeManifest(
   appPrimaryDoc = NULL,
   contentCategory = NULL,
   python = NULL,
-  forceGeneratePythonEnvironment = F,
-  forceRequirementsTxtEnvironment = F
+  forceGeneratePythonEnvironment = FALSE,
+  forceRequirementsTxtEnvironment = FALSE
 )
 }
 \arguments{

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -9,7 +9,9 @@ writeManifest(
   appFiles = NULL,
   appPrimaryDoc = NULL,
   contentCategory = NULL,
-  python = NULL
+  python = NULL,
+  forceGeneratePythonEnvironment = F,
+  forceRequirementsTxtEnvironment = F
 )
 }
 \arguments{
@@ -33,6 +35,15 @@ The specified python binary will be invoked to determine its version
 and to list the python packages installed in the environment.
 If python = NULL, and RETICULATE_PYTHON is set in the environment,
 its value will be used.}
+
+\item{forceGeneratePythonEnvironment}{Optional. If an existing
+\code{requirements.txt} or \code{environment.yml} file is found, it will
+be overwritten when this argument is \code{TRUE}.}
+
+\item{forceRequirementsTxtEnvironment}{Optional. If rsconnect
+detects you are running in a conda environment, it will write
+\code{requirements.txt} instead of \code{environment.yml} when this
+argument is \code{TRUE}.}
 }
 \description{
 Given a directory content targeted for deployment, write a manifest.json


### PR DESCRIPTION
Added two new args to `deployApp` (and therefore every `deploy` function that uses `deployApp` and passes args) and `writeManifest`:

- `forceGeneratePythonEnvironment`: write a python environment file even if it exists
- `forceRequirementsTxtEnvironment`: write a `requirements.txt` file even if we're in a conda environment

Updated `environment.py` to the latest version from https://github.com/rstudio/rsconnect-python/blob/2b8c5fe249e254e4b0dfdfa21301241375fbe49b/rsconnect/environment.py

# Review Notes

`environment.py` doesn't need to be reviewed a second time

`paste0` isn't used because it's not supported under our minimum version of R. (is there a tool we can use to give us these hints?)