### PR TITLE
err when packages have no repository and do not come from an SCM

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -628,7 +628,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
                                 'Repository')])
 
       if (is.na(info$Repository)) {
-        if (is.scm.source(info$Source)) {
+        if (isSCMSource(info$Source)) {
           # ignore source+SCM packages
         } else {
           missing_url_sources <- unique(c(missing_url_sources, info$Source))

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -628,7 +628,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
                                 'Repository')])
 
       if (is.na(info$Repository)) {
-        if (tolower(info$Source) %in% c("github", "bitbucket", "source")) {
+        if (is.scm.source(info$Source)) {
           # ignore source+SCM packages
         } else {
           missing_url_sources <- unique(c(missing_url_sources, info$Source))

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -666,7 +666,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
     # It's possible we cannot find a repository URL for other reasons, including when folks locally
     # build and install packages from source. An incorrectly configured "repos" option is almost
     # always the cause.
-    msg <- c(msg, sprintf("Unable to determine the location for some packages. Packages must come from a package repository like CRAN or a source control system. Check that options(“repos”) refers to a package repository containing the needed package versions."))
+    msg <- c(msg, sprintf("Unable to determine the location for some packages. Packages must come from a package repository like CRAN or a source control system. Check that options('repos') refers to a package repository containing the needed package versions."))
   }
 
   if (length(msg)) stop(paste(formatUL(msg, '\n*'), collapse = '\n'), call. = FALSE)

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -593,6 +593,8 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
 
   # provide package entries for all dependencies
   packages <- list()
+  # non-SCM repository sources without URLs
+  missing_url_sources <- NULL
   # potential error messages
   msg      <- NULL
   pyInfo   <- NULL
@@ -625,6 +627,14 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
       info <- as.list(deps[i, c('Source',
                                 'Repository')])
 
+      if (is.na(info$Repository)) {
+        if (tolower(info$Source) %in% c("github", "bitbucket", "source")) {
+          # ignore source+SCM packages
+        } else {
+          missing_url_sources <- unique(c(missing_url_sources, info$Source))
+        }
+      }
+
       # include github package info
       info <- c(info, as.list(deps[i, grep('Github', colnames(deps), perl = TRUE, value = TRUE)]))
 
@@ -649,6 +659,16 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
       packages[[name]] <- info
     }
   }
+  if (length(missing_url_sources)) {
+    # Err when packages lack repository URL. We emit a warning about each package (see
+    # snapshotDependencies) before issuing an error with this resolution advice.
+    #
+    # It's possible we cannot find a repository URL for other reasons, including when folks locally
+    # build and install packages from source. An incorrectly configured "repos" option is almost
+    # always the cause.
+    msg <- c(msg, sprintf("Unable to determine the location for some packages. Packages must come from a package repository like CRAN or a source control system. Check that options(“repos”) refers to a package repository containing the needed package versions."))
+  }
+
   if (length(msg)) stop(paste(formatUL(msg, '\n*'), collapse = '\n'), call. = FALSE)
 
   # build the list of files to checksum

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -131,7 +131,9 @@ snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
   return(records)
 }
 
-# Return TRUE when the source indicates that a package comes from a source control system.
+# Return TRUE when the source indicates that a package was installed from
+# source or comes from a source control system. This indicates that we will
+# not have a repostory URL; location is recorded elsewhere.
 isSCMSource <- function(source) {
   tolower(source) %in% c("github", "bitbucket", "source")
 }

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -101,7 +101,7 @@ snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
       if (pkg %in% biocPackages) {
         repository <- biocPackages[pkg, 'Repository']
       }
-    } else if (tolower(source) %in% c("github", "bitbucket", "source")) {
+    } else if (is.scm.source(source)) {
       # leave source+SCM packages alone.
     } else if (pkg %in% rownames(repo.packages)) {
       # capture CRAN-like repository
@@ -129,6 +129,11 @@ snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
   })
   records[, c("Source","Repository")] <- do.call("rbind", tmp)
   return(records)
+}
+
+# Return TRUE when the source indicates that a package comes from a source control system.
+is.scm.source <- function(source) {
+  tolower(source) %in% c("github", "bitbucket", "source")
 }
 
 # generate a random name prefixed with "repo_".

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -122,8 +122,8 @@ snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
       }
       repository <- package.repo$url
     } else {
-      warning(sprintf("Unable to find repository URL for package %s", pkg),
-              immediate. = TRUE)
+      warning(sprintf("Unable to determine the repository for package %s", pkg),
+              call. = FALSE, immediate. = TRUE)
     }
     data.frame(Source = source, Repository = repository)
   })

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -101,7 +101,7 @@ snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
       if (pkg %in% biocPackages) {
         repository <- biocPackages[pkg, 'Repository']
       }
-    } else if (is.scm.source(source)) {
+    } else if (isSCMSource(source)) {
       # leave source+SCM packages alone.
     } else if (pkg %in% rownames(repo.packages)) {
       # capture CRAN-like repository
@@ -132,7 +132,7 @@ snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
 }
 
 # Return TRUE when the source indicates that a package comes from a source control system.
-is.scm.source <- function(source) {
+isSCMSource <- function(source) {
   tolower(source) %in% c("github", "bitbucket", "source")
 }
 


### PR DESCRIPTION
This change replaces #410, as it does not err when a package
has an SCM source.

The warning in `snapshotDependencies` has been rewritten, noting
that we cannot determine the repository for the package.

The error in `createAppManifest` suggests that the "repos" option
might need adjusting.

Example output when a specific package cannot be found.

```
Warning: Unable to determine the repository for package ferris
 Error: 
* Unable to determine the location for some packages. Packages must come from a package
   repository like CRAN or a source control system. Check that options('repos') refers to
   a package repository containing the needed package versions. 
```