### PR TITLE
Revert conda change- use requirements.txt in all cases

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -270,10 +270,6 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
 #'   `requirements.txt` or `environment.yml` file is found, it will
 #'   be overwritten when this argument is `TRUE`.
 #'
-#' @param forceRequirementsTxtEnvironment Optional. If rsconnect
-#'   detects you are running in a conda environment, it will write
-#'   `requirements.txt` instead of `environment.yml` when this
-#'   argument is `TRUE`.
 #'
 #' @export
 writeManifest <- function(appDir = getwd(),
@@ -281,8 +277,10 @@ writeManifest <- function(appDir = getwd(),
                           appPrimaryDoc = NULL,
                           contentCategory = NULL,
                           python = NULL,
-                          forceGeneratePythonEnvironment = FALSE,
-                          forceRequirementsTxtEnvironment = FALSE) {
+                          forceGeneratePythonEnvironment = FALSE) {
+  # TODO: Temporarily disable conda environment capture until it is supported.
+  forceRequirementsTxtEnvironment <- TRUE
+
   if (is.null(appFiles)) {
     appFiles <- bundleFiles(appDir)
   } else {

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -67,10 +67,6 @@
 #' @param forceGeneratePythonEnvironment Optional. If an existing
 #'   `requirements.txt` or `environment.yml` file is found, it will
 #'   be overwritten when this argument is `TRUE`.
-#' @param forceRequirementsTxtEnvironment Optional. If rsconnect
-#'   detects you are running in a conda environment, it will write
-#'   `requirements.txt` instead of `environment.yml` when this
-#'   argument is `TRUE`.
 #' @examples
 #' \dontrun{
 #'
@@ -117,8 +113,9 @@ deployApp <- function(appDir = getwd(),
                       forceUpdate = getOption("rsconnect.force.update.apps", FALSE),
                       python = NULL,
                       on.failure = NULL,
-                      forceGeneratePythonEnvironment = FALSE,
-                      forceRequirementsTxtEnvironment = FALSE) {
+                      forceGeneratePythonEnvironment = FALSE) {
+  # TODO: Temporarily disable conda environment capture until it is supported.
+  forceRequirementsTxtEnvironment <- TRUE
 
   if (!isStringParam(appDir))
     stop(stringParamErrorMessage("appDir"))

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -25,8 +25,7 @@ deployApp(
   forceUpdate = getOption("rsconnect.force.update.apps", FALSE),
   python = NULL,
   on.failure = NULL,
-  forceGeneratePythonEnvironment = FALSE,
-  forceRequirementsTxtEnvironment = FALSE
+  forceGeneratePythonEnvironment = FALSE
 )
 }
 \arguments{
@@ -113,11 +112,6 @@ deployment log URL is available, it's passed as a parameter.}
 \item{forceGeneratePythonEnvironment}{Optional. If an existing
 \code{requirements.txt} or \code{environment.yml} file is found, it will
 be overwritten when this argument is \code{TRUE}.}
-
-\item{forceRequirementsTxtEnvironment}{Optional. If rsconnect
-detects you are running in a conda environment, it will write
-\code{requirements.txt} instead of \code{environment.yml} when this
-argument is \code{TRUE}.}
 }
 \description{
 Deploy a \link[shiny:shiny-package]{shiny} application, an

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -10,8 +10,7 @@ writeManifest(
   appPrimaryDoc = NULL,
   contentCategory = NULL,
   python = NULL,
-  forceGeneratePythonEnvironment = FALSE,
-  forceRequirementsTxtEnvironment = FALSE
+  forceGeneratePythonEnvironment = FALSE
 )
 }
 \arguments{
@@ -39,11 +38,6 @@ its value will be used.}
 \item{forceGeneratePythonEnvironment}{Optional. If an existing
 \code{requirements.txt} or \code{environment.yml} file is found, it will
 be overwritten when this argument is \code{TRUE}.}
-
-\item{forceRequirementsTxtEnvironment}{Optional. If rsconnect
-detects you are running in a conda environment, it will write
-\code{requirements.txt} instead of \code{environment.yml} when this
-argument is \code{TRUE}.}
 }
 \description{
 Given a directory content targeted for deployment, write a manifest.json


### PR DESCRIPTION
This change retains the new `environment.py` but suppresses conda environment export functionality until such time as it is stable in connect.