### PR TITLE
Don't mention environment.yml in the docs (yet)

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -65,8 +65,8 @@
 #'   value will be used. The specified python binary will be invoked to determine
 #'   its version and to list the python packages installed in the environment.
 #' @param forceGeneratePythonEnvironment Optional. If an existing
-#'   `requirements.txt` or `environment.yml` file is found, it will
-#'   be overwritten when this argument is `TRUE`.
+#'   `requirements.txt` file is found, it will  be overwritten when this argument
+#'   is `TRUE`.
 #' @examples
 #' \dontrun{
 #'

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -65,7 +65,7 @@
 #'   value will be used. The specified python binary will be invoked to determine
 #'   its version and to list the python packages installed in the environment.
 #' @param forceGeneratePythonEnvironment Optional. If an existing
-#'   `requirements.txt` file is found, it will  be overwritten when this argument
+#'   `requirements.txt` file is found, it will be overwritten when this argument
 #'   is `TRUE`.
 #' @examples
 #' \dontrun{

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -110,8 +110,8 @@ its version and to list the python packages installed in the environment.}
 deployment log URL is available, it's passed as a parameter.}
 
 \item{forceGeneratePythonEnvironment}{Optional. If an existing
-\code{requirements.txt} or \code{environment.yml} file is found, it will
-be overwritten when this argument is \code{TRUE}.}
+\code{requirements.txt} file is found, it will  be overwritten when this argument
+is \code{TRUE}.}
 }
 \description{
 Deploy a \link[shiny:shiny-package]{shiny} application, an

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -110,7 +110,7 @@ its version and to list the python packages installed in the environment.}
 deployment log URL is available, it's passed as a parameter.}
 
 \item{forceGeneratePythonEnvironment}{Optional. If an existing
-\code{requirements.txt} file is found, it will  be overwritten when this argument
+\code{requirements.txt} file is found, it will be overwritten when this argument
 is \code{TRUE}.}
 }
 \description{


### PR DESCRIPTION
Part of un-releasing conda. We shouldn't mention environment.yml in the docs because it's not supported yet.