### PR TITLE
Fixed bug in applications.R, isConnectInfo takes account details not …

### DIFF
--- a/R/applications.R
+++ b/R/applications.R
@@ -43,7 +43,7 @@ applications <- function(account = NULL, server = NULL) {
   serverDetails <- serverInfo(accountDetails$server)
   client <- clientForAccount(accountDetails)
 
-  isConnect <- isConnectInfo(accountDetails$server)
+  isConnect <- isConnectInfo(accountInfo = accountDetails)
 
   # retrieve applications
   apps <- client$listApplications(accountDetails$accountId)


### PR DESCRIPTION
…server

Fixed bug in applications.R where the account details are sent to isConnectInfo() instead of the server name. isConnectInfo takes either parameter but accountDetails is the first parameter. Named the parameter in the function call for clarity.