### PR TITLE
RSCONNECT_TAR specifies an alternate tar implementation as expected by utils::tar

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -235,7 +235,9 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
 
   on.exit(setwd(prevDir), add = TRUE)
   bundlePath <- tempfile("rsconnect-bundle", fileext = ".tar.gz")
-  utils::tar(bundlePath, files = ".", compression = "gzip", tar = "internal")
+  tarImplementation <- Sys.getenv("RSCONNECT_TAR", "internal")
+  logger(sprintf("Using tar: %s",tarImplementation))
+  utils::tar(bundlePath, files = ".", compression = "gzip", tar = tarImplementation)
   bundlePath
 }
 
@@ -267,7 +269,7 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
 #'   its value will be used.
 #'
 #' @param forceGeneratePythonEnvironment Optional. If an existing
-#'   `requirements.txt` file is found, it will be overwritten when 
+#'   `requirements.txt` file is found, it will be overwritten when
 #'   this argument is `TRUE`.
 #'
 #'

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -236,7 +236,7 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
   on.exit(setwd(prevDir), add = TRUE)
   bundlePath <- tempfile("rsconnect-bundle", fileext = ".tar.gz")
   tarImplementation <- Sys.getenv("RSCONNECT_TAR", "internal")
-  logger(sprintf("Using tar: %s",tarImplementation))
+  logger(sprintf("Using tar: %s", tarImplementation))
   utils::tar(bundlePath, files = ".", compression = "gzip", tar = tarImplementation)
   bundlePath
 }

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -231,14 +231,21 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
 
   # create the bundle and return its path
   logger("Compressing the bundle")
-  prevDir <- setwd(bundleDir)
-
-  on.exit(setwd(prevDir), add = TRUE)
   bundlePath <- tempfile("rsconnect-bundle", fileext = ".tar.gz")
+  writeBundle(bundleDir, bundlePath)
+  bundlePath
+}
+
+# Writes a tar.gz file located at bundlePath containing all files in bundleDir.
+writeBundle <- function(bundleDir, bundlePath, verbose = FALSE) {
+  logger <- verboseLogger(verbose)
+
+  prevDir <- setwd(bundleDir)
+  on.exit(setwd(prevDir), add = TRUE)
+
   tarImplementation <- Sys.getenv("RSCONNECT_TAR", "internal")
   logger(sprintf("Using tar: %s", tarImplementation))
-  utils::tar(bundlePath, files = ".", compression = "gzip", tar = tarImplementation)
-  bundlePath
+  utils::tar(bundlePath, files = NULL, compression = "gzip", tar = tarImplementation)
 }
 
 #' Create a manifest.json describing deployment requirements.

--- a/R/rpubs.R
+++ b/R/rpubs.R
@@ -90,7 +90,8 @@ rpubsUpload <- function(title,
 
     # create the tarball
     tarfile <- tempfile("package", fileext = ".tar.gz")
-    utils::tar(tarfile, files = ".", compression = "gzip", tar = "internal")
+    tarImplementation <- Sys.getenv("RSCONNECT_TAR", "internal")
+    utils::tar(bundlePath, files = ".", compression = "gzip", tar = tarImplementation)
 
     # return the full path to the tarball
     return(tarfile)

--- a/R/rpubs.R
+++ b/R/rpubs.R
@@ -83,15 +83,9 @@ rpubsUpload <- function(title,
     writeLines(packageJson, packageFile("package.json"))
     file.copy(contentFile, packageFile("index.html"))
 
-    # switch to the package dir for building
-    oldWd <- getwd()
-    setwd(packageDir)
-    on.exit(setwd(oldWd))
-
     # create the tarball
     tarfile <- tempfile("package", fileext = ".tar.gz")
-    tarImplementation <- Sys.getenv("RSCONNECT_TAR", "internal")
-    utils::tar(bundlePath, files = ".", compression = "gzip", tar = tarImplementation)
+    writeBundle(packageDir, tarfile)
 
     # return the full path to the tarball
     return(tarfile)


### PR DESCRIPTION
RSCONNECT_TAR is used when creating bundles for rpubs, shinyapps.io, and
RStudio Connect. When unset, "internal" is used.

Fixes #446

Use an alternate tar implementation by setting this environment variable; use either a full path or a binary in your PATH:

```r
Sys.setenv(RSCONNECT_TAR ="tar")
Sys.setenv(RSCONNECT_TAR ="/usr/bin/tar")
```

You can see what tar is used by deploying with a verbose logging level.

```r
rsconnect::deployApp(..., logLevel = "verbose")
```

When unset, you will see that "internal" is used:

```
[2020-07-28 14:45:07] Using tar: internal 
```

We report the tar executable when the environment variable is set:

```
[2020-07-28 14:45:25] Using tar: tar 
```

```
[2020-07-28 14:53:08] Using tar: /usr/bin/tar 
```

The environment variable applies both to `rsconnect::deploy*` calls from the R console and to deployment operations with output in the Deploy RStudio pane.