### PR TITLE
fixed use of isShinyapps in showUsers

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -146,7 +146,7 @@ showUsers <- function(appDir=getwd(), appName=NULL, account = NULL,
   # resolve account
   accountDetails <- accountInfo(resolveAccount(account, server), server)
 
-  if (!isShinyapps(accountDetails)) {
+  if (!isShinyapps(accountDetails$server)) {
     stop("This method only works for ShinyApps servers.")
   }
 


### PR DESCRIPTION
in showUsers changed the paramater for isShinyapps from the full account details to just the server. This was causing a crash whenever calling showUsers