### PR TITLE
Allow finding packages with nonstandard contrib URLs

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -109,7 +109,8 @@ snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
       # Find this package in the set of available packages then use its
       # contrib.url to map back to the configured repositories.
       package.contrib <- repo.packages[pkg, 'Repository']
-      package.repo <- repo.lookup[repo.lookup$contrib.url == package.contrib, ][1, ]
+      package.repo.index <- vapply(repo.lookup$contrib.url, function(url) grepl(url, package.contrib), logical(1))
+      package.repo <- repo.lookup[package.repo.index, ][1, ]
       # If the incoming package comes from CRAN, keep the CRAN name in place
       # even if that means using a different name than the repos list.
       #

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -76,11 +76,19 @@ snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
   # get Bioconductor repos if any
   biocRepos = repos[grep('BioC', names(repos), perl=TRUE, value=TRUE)]
   if (length(biocRepos) > 0) {
-    biocPackages = available.packages(contriburl = contrib.url(biocRepos, type = "source"), type = "source", filters = c("duplicates"))
+    biocPackages = available.packages(
+      contriburl = contrib.url(biocRepos, type = "source"),
+      type = "source",
+      filters = c("R_version", "duplicates")
+      )
   } else {
     biocPackages = c()
   }
-  repo.packages <- available.packages(contriburl = contrib.url(repos, type = "source"), type = "source", filters = c("R_version", "duplicates"))
+  repo.packages <- available.packages(
+    contriburl = contrib.url(repos, type = "source"),
+    type = "source",
+    filters = c("R_version", "duplicates")
+  )
   named.repos <- name.all.repos(repos)
   repo.lookup <- data.frame(
     name = names(named.repos),
@@ -109,7 +117,7 @@ snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
       # Find this package in the set of available packages then use its
       # contrib.url to map back to the configured repositories.
       package.contrib <- repo.packages[pkg, 'Repository']
-      package.repo.index <- vapply(repo.lookup$contrib.url, 
+      package.repo.index <- vapply(repo.lookup$contrib.url,
                                    function(url) grepl(url, package.contrib, fixed = TRUE), logical(1))
       package.repo <- repo.lookup[package.repo.index, ][1, ]
       # If the incoming package comes from CRAN, keep the CRAN name in place

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -80,7 +80,7 @@ snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
   } else {
     biocPackages = c()
   }
-  repo.packages <- available.packages(contriburl = contrib.url(repos, type = "source"), type = "source", filters = c("duplicates"))
+  repo.packages <- available.packages(contriburl = contrib.url(repos, type = "source"), type = "source", filters = c("R_version", "duplicates"))
   named.repos <- name.all.repos(repos)
   repo.lookup <- data.frame(
     name = names(named.repos),

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -109,7 +109,8 @@ snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
       # Find this package in the set of available packages then use its
       # contrib.url to map back to the configured repositories.
       package.contrib <- repo.packages[pkg, 'Repository']
-      package.repo.index <- vapply(repo.lookup$contrib.url, function(url) grepl(url, package.contrib), logical(1))
+      package.repo.index <- vapply(repo.lookup$contrib.url, 
+                                   function(url) grepl(url, package.contrib, fixed = TRUE), logical(1))
       package.repo <- repo.lookup[package.repo.index, ][1, ]
       # If the incoming package comes from CRAN, keep the CRAN name in place
       # even if that means using a different name than the repos list.


### PR DESCRIPTION
For certain packages, there are multiple entries on CRAN. Some of these have nonstandard contrib URLs that don't exactly match to the contrib URLS for any of the configured `repos`, even when configured correctly. 

For example, the `Matrix` package appears twice, once with contrib URL https://colorado.rstudio.com/rspm/all/latest/src/contrib and once with contrib URL https://colorado.rstudio.com/rspm/all/latest/src/contrib/4.1.0/Recommended. If that second URL comes back, exact URL matching silently fails. 

I'm not sure if this is the best way to fix, but it enables manifest writing that was formerly breaking.