### PR TITLE
Shiny Rmd takes precedence over server.R

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -444,9 +444,21 @@ inferAppMode <- function(appDir, appPrimaryDoc, files) {
     return("shiny")
   }
 
-  # shiny directory
-  shinyFiles <- grep("^(server|app).r$", files, ignore.case = TRUE, perl = TRUE)
-  if (length(shinyFiles) > 0) {
+  # Shiny application or ShinyRmd using server.R
+  serverR <- grep("^server.r$", files, ignore.case = TRUE, perl = TRUE)
+  if (length(serverR) > 0) {
+    # Shiny server.R and UI.Rmd
+    uiRmd <- grep("^ui.rmd$", files, ignore.case = TRUE, perl = TRUE)
+    if (length(uiRmd) > 0) {
+      return("rmd-shiny")
+    }
+    # Simple Shiny app
+    return("shiny")
+  }
+
+  # Shiny application using single-file app.R style.
+  appR <- grep("^app.r$", files, ignore.case = TRUE, perl = TRUE)
+  if (length(appR) > 0) {
     return("shiny")
   }
 

--- a/tests/testthat/test-cert.R
+++ b/tests/testthat/test-cert.R
@@ -1,7 +1,8 @@
 context("certificates")
 
 cert_test_that <- function(test, expr) {
-  config_dir <- tempdir()
+  config_dir <- tempfile()
+  dir.create(config_dir)
 
   # preserve old values
   home <- Sys.getenv("HOME")

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -27,7 +27,7 @@ test_that("Users API", {
   skip_on_os("windows")
 
   if (!isConnectRunning()) {
-    cat("No running 'connect' instance detected -- tests skipped.")
+    cat("No running 'connect' instance detected -- tests skipped.\n")
     return()
   }
 

--- a/tests/testthat/test-detection.R
+++ b/tests/testthat/test-detection.R
@@ -5,3 +5,115 @@ test_that("Shiny R Markdown files are detected correctly", {
   expect_true(isShinyRmd("./shiny-rmds/shiny-rmd-dots.Rmd"))
   expect_false(isShinyRmd("./shiny-rmds/non-shiny-rmd.Rmd"))
 })
+
+# fileContent is a named list with file content. When content is NA, the
+# name of the file is used as its content.
+#
+# Each file is written with its content to a temporary directory.
+# Returns the result of inferAppMode when run against that directory.
+# The temporary directory is removed on exit.
+inferAppModeFromFiles <- function(fileContent) {
+  targetDir <- tempfile()
+  dir.create(targetDir)
+  on.exit(unlink(targetDir, recursive = TRUE))
+
+  for (file in names(fileContent)) {
+    content <- fileContent[[file]]
+    # Write the filename as its content when we are not given content.
+    if (all(is.na(content))) {
+      content <- c(file)
+    }
+    targetFile <- file.path(targetDir, file)
+    writeLines(content, con = targetFile, sep = "\n")
+  }
+
+  files <- list.files(targetDir, recursive = FALSE, all.files = FALSE, include.dirs = FALSE, no.. = TRUE, full.names = FALSE)
+  appMode <- inferAppMode(targetDir, NULL, files)
+  return(appMode)
+}
+
+test_that("inferAppMode", {
+  # Plumber API identification
+  expect_identical("api", inferAppModeFromFiles(list(
+    "plumber.R" = NA
+  )))
+  expect_identical("api", inferAppModeFromFiles(list(
+    "entrypoint.R" = NA
+  )))
+  expect_identical("api", inferAppModeFromFiles(list(
+    "plumber.R" = NA,
+    "helper.R" = NA
+  )))
+
+  # Shiny application identification
+  expect_identical("shiny", inferAppModeFromFiles(list(
+    "app.R" = NA
+  )))
+  expect_identical("shiny", inferAppModeFromFiles(list(
+    "server.R" = NA
+  )))
+  expect_identical("shiny", inferAppModeFromFiles(list(
+    "server.R" = NA,
+    "ui.R" = NA
+  )))
+  expect_identical("shiny", inferAppModeFromFiles(list(
+    "server.R" = NA,
+    "ui.R" = NA,
+    "global.R" = NA
+  )))
+
+  # Static R Markdown identification (rendered documents)
+  expect_identical("rmd-static", inferAppModeFromFiles(list(
+    "index.Rmd" = NA
+  )))
+  expect_identical("rmd-static", inferAppModeFromFiles(list(
+    "index.Rmd" = NA,
+    "alpha.Rmd" = NA,
+    "bravo.Rmd" = NA
+  )))
+  expect_identical("rmd-static", inferAppModeFromFiles(list(
+    "alpha.Rmd" = NA,
+    "bravo.Rmd" = NA
+  )))
+
+  rmdRuntimeShiny <- c(
+    "---",
+    "runtime: shiny",
+    "---"
+  )
+  rmdRuntimeShinyRmd <- c(
+    "---",
+    "runtime: shinyrmd",
+    "---"
+  )
+  rmdRuntimeShinyPrerendered <- c(
+    "---",
+    "runtime: shiny_prerendered",
+    "---"
+  )
+  # Shiny R Markdown identification
+  expect_identical("rmd-shiny", inferAppModeFromFiles(list(
+    "index.Rmd" = rmdRuntimeShiny
+  )))
+  expect_identical("rmd-shiny", inferAppModeFromFiles(list(
+    "index.Rmd" = rmdRuntimeShinyRmd
+  )))
+  expect_identical("rmd-shiny", inferAppModeFromFiles(list(
+    "index.Rmd" = rmdRuntimeShinyPrerendered
+  )))
+  # Shiny Rmd with other Rmd
+  expect_identical("rmd-shiny", inferAppModeFromFiles(list(
+    "shiny.Rmd" = rmdRuntimeShinyPrerendered,
+    "other.Rmd" = NA
+  )))
+  # Shiny Rmd with other R script
+  expect_identical("rmd-shiny", inferAppModeFromFiles(list(
+    "shiny.Rmd" = rmdRuntimeShinyPrerendered,
+    "helper.R" = NA
+  )))
+  # Shiny Rmd with server.R script
+  expect_identical("rmd-shiny", inferAppModeFromFiles(list(
+    "shiny.Rmd" = rmdRuntimeShinyPrerendered,
+    "server.R" = NA
+  )))
+})


### PR DESCRIPTION
Requires changes from https://github.com/rstudio/rmarkdown/pull/1926 to test deploys.

```console
R -e 'remotes::install_github("rstudio/rmarkdown", ref="feature/shinyrmd-server-r")'
```
