### PR TITLE
maxDirectoryList tracks the running number of files and cumulative size

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## 0.8.17 (in development)
 
+* Improve how large bundles (file size and count) are detected (#464)
 * The `RSCONNECT_TAR` environment variable can be used to select the tar implementation used to create bundles (#446)
 * Add support for syncing the deployment metadata with the server (#396)
 * Insist on ShinyApps accounts in `showUsers()` (#398)

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -93,7 +93,7 @@ maxDirectoryList <- function(dir, topLevel, totalFiles, totalSize) {
   subdirContents <- NULL
 
   # Info for each file lets us know to recurse (directories) or aggregate (files).
-  infos <- file.info(file.path(dir, contents))
+  infos <- file.info(file.path(dir, contents), extra_cols = FALSE)
   row.names(infos) <- contents
 
   for (name in contents) {
@@ -101,7 +101,7 @@ maxDirectoryList <- function(dir, topLevel, totalFiles, totalSize) {
 
     if (info$isdir) {
       # Directories do not include their self-size in our counts.
-      
+
       # ignore knitr _cache directories
       if (isKnitrCacheDir(name, contents)) {
         next
@@ -116,7 +116,7 @@ maxDirectoryList <- function(dir, topLevel, totalFiles, totalSize) {
 
       # Directories are not included, only their files.
       subdirContents <- append(subdirContents, file.path(name, dirList$contents))
-      
+
     } else {
       # This is a file. It counts and is included in our listing.
 
@@ -128,11 +128,11 @@ maxDirectoryList <- function(dir, topLevel, totalFiles, totalSize) {
     # abort if we've reached the maximum size
     if (totalSize > getOption("rsconnect.max.bundle.size"))
       break
-    
+
     # abort if we've reached the maximum number of files
     if (totalFiles > getOption("rsconnect.max.bundle.files"))
       break
-  }    
+  }
 
   # totalSize - incoming size summed with all file sizes beneath this directory.
   # totalFiles - incoming count summed with file count beneath this directory.

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -60,71 +60,83 @@ isKnitrCacheDir <- function(subdir, contents) {
   }
 }
 
-maxDirectoryList <- function(dir, parent, totalSize) {
+# totalSize is a running total of our encountered file sizes.
+# totalFiles is a running count of our encountered files.
+maxDirectoryList <- function(dir, parent, totalFiles, totalSize) {
   # generate a list of files at this level
   contents <- list.files(dir, recursive = FALSE, all.files = TRUE,
                          include.dirs = TRUE, no.. = TRUE, full.names = FALSE)
 
-  # at the root level, exclude those with a forbidden extension
+  # At the root, some well-known files and directories are not included in the bundle.
   if (nchar(parent) == 0) {
     contents <- contents[!grepl(glob2rx("*.Rproj"), contents)]
-    contents <- contents[!grepl(glob2rx(".DS_Store"), contents)]
-    contents <- contents[!grepl(glob2rx(".gitignore"), contents)]
-    contents <- contents[!grepl(glob2rx(".Rhistory"), contents)]
-    contents <- contents[!grepl(glob2rx("manifest.json"), contents)]
+    contents <- setdiff(contents, c(
+                                      ".DS_Store",
+                                      ".gitignore",
+                                      ".Rhistory",
+                                      "manifest.json",
+                                      "rsconnect",
+                                      "packrat",
+                                      ".svn",
+                                      ".git",
+                                      ".Rproj.user"
+                                  ))
   }
 
   # exclude renv files
   contents <- setdiff(contents, c("renv", "renv.lock"))
 
-  # sum the size of the files in the directory
-  info <- file.info(file.path(dir, contents))
-  size <- sum(info$size)
-  if (is.na(size))
-    size <- 0
-  totalSize <- totalSize + size
+  # subdirContents contains all files encountered beneath this directory.
   subdirContents <- NULL
 
-  # if we haven't exceeded the maximum size, check each subdirectory
-  if (totalSize < getOption("rsconnect.max.bundle.size")) {
-    subdirs <- contents[info$isdir]
-    for (subdir in subdirs) {
+  # sum the size of the files in this directory
+  paths <- file.path(dir, contents)
+  infos <- file.info(paths)
 
-      # ignore known directories from the root
-      if (nchar(parent) == 0 && subdir %in% c(
-           "rsconnect", "packrat", ".svn", ".git", ".Rproj.user"))
-        next
+  for (path in paths) {
+    info <- infos[path,]
 
+    if (info$isdir) {
+      # Directories do not include their self-size in our counts.
+      
       # ignore knitr _cache directories
-      if (isKnitrCacheDir(subdir, contents))
+      if (isKnitrCacheDir(basename(path), contents)) {
         next
+      }
 
-      # get the list of files in the subdirectory
-      dirList <- maxDirectoryList(file.path(dir, subdir),
-                                  if (nchar(parent) == 0) subdir
-                                  else file.path(parent, subdir),
-                                  totalSize)
-      totalSize <- totalSize + dirList$size
+      # Recursively enumerate this directory.
+      dirList <- maxDirectoryList(path, dir, totalFiles, totalSize)
+
+      # Inherit the running totals from our child.
+      totalSize <- dirList$totalSize
+      totalFiles <- dirList$totalFiles
+
+      # Directories are not included, only their files.
       subdirContents <- append(subdirContents, dirList$contents)
+      
+    } else {
+      # This is a file. It counts and is included in our listing.
 
-      # abort if we've reached the maximum size
-      if (totalSize > getOption("rsconnect.max.bundle.size"))
-        break
-
-      # abort if we've reached the maximum number of files
-      if ((length(contents) + length(subdirContents)) >
-          getOption("rsconnect.max.bundle.files"))
-        break
+      totalSize <- totalSize + info$size
+      totalFiles <- totalFiles + 1
+      subdirContents <- append(subdirContents, path)
     }
-  }
+
+    # abort if we've reached the maximum size
+    if (totalSize > getOption("rsconnect.max.bundle.size"))
+      break
+    
+    # abort if we've reached the maximum number of files
+    if (totalFiles > getOption("rsconnect.max.bundle.files"))
+      break
+  }    
 
   # return the new size and accumulated contents
   list(
-    size = size,
-    totalSize = totalSize,
-    contents = append(if (nchar(parent) == 0) contents[!info$isdir]
-                      else file.path(parent, contents[!info$isdir]),
-                      subdirContents))
+      totalSize = totalSize,
+      totalFiles = totalFiles,
+      contents = subdirContents
+  )
 }
 
 #' List Files to be Bundled
@@ -158,7 +170,7 @@ maxDirectoryList <- function(dir, parent, totalSize) {
 #'
 #' @export
 listBundleFiles <- function(appDir) {
-  maxDirectoryList(appDir, "", 0)
+  maxDirectoryList(appDir, "", 0, 0)
 }
 
 bundleFiles <- function(appDir) {

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -61,16 +61,16 @@ isKnitrCacheDir <- function(subdir, contents) {
 }
 
 # dir is the path for this step on our recursive walk.
-# topLevel is TRUE only for the outermost directory of our walk.
+# depth is tracks the number of directories we have descended. depth==0 at the root.
 # totalSize is a running total of our encountered file sizes.
 # totalFiles is a running count of our encountered files.
-maxDirectoryList <- function(dir, topLevel, totalFiles, totalSize) {
+maxDirectoryList <- function(dir, depth, totalFiles, totalSize) {
   # generate a list of files at this level
   contents <- list.files(dir, recursive = FALSE, all.files = TRUE,
                          include.dirs = TRUE, no.. = TRUE, full.names = FALSE)
 
   # At the root, some well-known files and directories are not included in the bundle.
-  if (topLevel) {
+  if (depth==0) {
     contents <- contents[!grepl(glob2rx("*.Rproj"), contents)]
     contents <- setdiff(contents, c(
                                       ".DS_Store",
@@ -108,7 +108,7 @@ maxDirectoryList <- function(dir, topLevel, totalFiles, totalSize) {
       }
 
       # Recursively enumerate this directory.
-      dirList <- maxDirectoryList(file.path(dir, name), FALSE, totalFiles, totalSize)
+      dirList <- maxDirectoryList(file.path(dir, name), depth+1, totalFiles, totalSize)
 
       # Inherit the running totals from our child.
       totalSize <- dirList$totalSize
@@ -175,7 +175,7 @@ maxDirectoryList <- function(dir, topLevel, totalFiles, totalSize) {
 #'
 #' @export
 listBundleFiles <- function(appDir) {
-  maxDirectoryList(appDir, TRUE, 0, 0)
+  maxDirectoryList(appDir, 0, 0, 0)
 }
 
 bundleFiles <- function(appDir) {

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -68,8 +68,8 @@ test_that("bundle directories are recursively enumerated", {
   # Files are included in the list, count, and sizes, not directories.
   # Paths are enumerated relative to the target directory, not absolute paths.
   expect_identical(result$contents, files)
-  expect_identical(result$totalSize, totalSize)
-  expect_identical(result$totalFiles, totalFiles)
+  expect_equal(result$totalSize, totalSize)
+  expect_equal(result$totalFiles, totalFiles)
 })
 
 test_that("simple Shiny app bundle is runnable", {

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -35,6 +35,43 @@ test_that("simple Shiny app bundle includes correct files", {
   expect_identical(list.files(bundleTempDir), c("manifest.json", "packrat", "server.R", "ui.R"))
 })
 
+test_that("bundle directories are recursively enumerated", {
+  targetDir <- tempfile()
+  dir.create(targetDir)
+  on.exit(unlink(targetDir, recursive = TRUE))
+
+  # tree that resembles the case from https://github.com/rstudio/rsconnect/issues/464
+  files <- c(
+      "app.R",
+      "index.htm",
+      "models/abcd/a_b_pt1/a/b/c1/1.RDS",
+      "models/abcd/a_b_pt1/a/b/c1/2.RDS",
+      "models/abcd/a_b_pt1/a/b/c1/3.RDS",
+      "models/abcd/a_b_pt1/a/b/c1/4.RDS",
+      "models/abcd/a_b_pt1/a/b/c1/5.RDS"
+  )
+
+  # Create and write each file.
+  sapply(files, function(file) {
+    content <- c("this is the file named", file)
+    targetFile <- file.path(targetDir, file)
+    dir.create(dirname(targetFile), recursive = TRUE, showWarnings = FALSE)
+    writeLines(content, con = targetFile, sep = "\n")
+  })
+
+  infos <- file.info(file.path(targetDir, files))
+  totalSize <- sum(infos$size)
+  totalFiles <- length(files)
+
+  result <- listBundleFiles(targetDir)
+
+  # Files are included in the list, count, and sizes, not directories.
+  # Paths are enumerated relative to the target directory, not absolute paths.
+  expect_identical(result$contents, files)
+  expect_identical(result$totalSize, totalSize)
+  expect_identical(result$totalFiles, totalFiles)
+})
+
 test_that("simple Shiny app bundle is runnable", {
   skip_on_cran()
   bundleTempDir <- makeShinyBundleTempDir("simple_shiny", "shinyapp-simple",


### PR DESCRIPTION
Previously, maxDirectoryList would incorrectly report the total size, as it
returned only partial sums of sizes.

fixes #464
