### PR TITLE
Add verbose option to writeManifest()

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -1000,12 +1000,14 @@ performPackratSnapshot <- function(bundleDir, verbose = FALSE) {
   }
 
   # generate a snapshot
-  packrat::.snapshotImpl(project = bundleDir,
-                         snapshot.sources = FALSE,
-                         fallback.ok = TRUE,
-                         verbose = verbose,
-                         implicit.packrat.dependency = FALSE,
-                         infer.dependencies = TRUE
+  suppressMessages(
+    packrat::.snapshotImpl(project = bundleDir,
+                           snapshot.sources = FALSE,
+                           fallback.ok = TRUE,
+                           verbose = verbose,
+                           implicit.packrat.dependency = FALSE,
+                           infer.dependencies = TRUE
+                           )
   )
 
   # TRUE just to indicate success

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -1000,15 +1000,13 @@ performPackratSnapshot <- function(bundleDir, verbose = FALSE) {
   }
 
   # generate a snapshot
-  # suppressMessages(
-    packrat::.snapshotImpl(project = bundleDir,
-                           snapshot.sources = FALSE,
-                           fallback.ok = TRUE,
-                           verbose = verbose,
-                           implicit.packrat.dependency = FALSE,
-                           infer.dependencies = TRUE
-                           )
-  # )
+  packrat::.snapshotImpl(project = bundleDir,
+                         snapshot.sources = FALSE,
+                         fallback.ok = TRUE,
+                         verbose = verbose,
+                         implicit.packrat.dependency = FALSE,
+                         infer.dependencies = TRUE
+  )
 
   # TRUE just to indicate success
   TRUE

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -403,6 +403,7 @@ writeManifest <- function(appDir = getwd(),
       condaMode = condaMode,
       forceGenerate = forceGeneratePythonEnvironment,
       python = python,
+      hasPythonRmd = hasPythonRmd,
       retainPackratDirectory = FALSE,
       verbose = verbose)
   manifestJson <- enc2utf8(toJSON(manifest, pretty = TRUE))
@@ -864,12 +865,10 @@ snapshotLockFile <- function(appDir) {
 
 addPackratSnapshot <- function(bundleDir, implicit_dependencies = c(), verbose = FALSE) {
 
-  # logger <- verboseLogger(verbose)
+  logger <- verboseLogger(verbose)
 
   # if we discovered any extra dependencies, write them to a file for packrat to
   # discover when it creates the snapshot
-
-  # if (verbose) logger(" - starting to add packrat snapshot")
 
   tempDependencyFile <- file.path(bundleDir, "__rsconnect_deps.R")
   if (length(implicit_dependencies) > 0) {
@@ -899,7 +898,7 @@ addPackratSnapshot <- function(bundleDir, implicit_dependencies = c(), verbose =
   }
 
   # generate the packrat snapshot
-  # if (verbose) logger(" - starting to perform packrat snapshot")
+  if (verbose) logger("Starting to perform packrat snapshot")
   tryCatch({
     performPackratSnapshot(bundleDir, verbose = verbose)
   }, error = function(e) {
@@ -916,7 +915,7 @@ addPackratSnapshot <- function(bundleDir, implicit_dependencies = c(), verbose =
     # rethrow error so we still halt deployment
     stop(e)
   })
-  # if (verbose) logger(" - done performing packrat snapshot")
+  if (verbose) logger("Completed performing packrat snapshot")
 
   # if we emitted a temporary dependency file for packrat's benefit, remove it
   # now so it isn't included in the bundle sent to the server
@@ -978,9 +977,6 @@ explodeFiles <- function(dir, files) {
 }
 
 performPackratSnapshot <- function(bundleDir, verbose = FALSE) {
-
-  # logger <- verboseLogger(verbose)
-  # if (verbose) logger (" - performing packrat snapshot")
 
   # move to the bundle directory
   owd <- getwd()

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -56,10 +56,11 @@ appDependencies <- function(appDir = getwd(), appFiles=NULL) {
              stringsAsFactors=FALSE)
 }
 
-snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
+snapshotDependencies <- function(appDir, implicit_dependencies=c(), verbose = FALSE) {
 
   # create a packrat "snapshot"
-  addPackratSnapshot(appDir, implicit_dependencies)
+
+  addPackratSnapshot(appDir, implicit_dependencies, verbose = verbose)
 
   # TODO: should we care about lockfile version or packrat version?
   lockFilePath <- snapshotLockFile(appDir)
@@ -115,6 +116,8 @@ snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
 
   # if the package is in a named CRAN-like repository capture it
   tmp <- lapply(seq.int(nrow(records)), function(i) {
+
+
     pkg <- records[i, "Package"]
     source <- records[i, "Source"]
     repository <- NA

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -10,7 +10,8 @@ writeManifest(
   appPrimaryDoc = NULL,
   contentCategory = NULL,
   python = NULL,
-  forceGeneratePythonEnvironment = FALSE
+  forceGeneratePythonEnvironment = FALSE,
+  verbose = FALSE
 )
 }
 \arguments{
@@ -38,6 +39,8 @@ its value will be used.}
 \item{forceGeneratePythonEnvironment}{Optional. If an existing
 \code{requirements.txt} file is found, it will be overwritten when
 this argument is \code{TRUE}.}
+
+\item{verbose}{If TRUE, prints progress messages to the console}
 }
 \description{
 Given a directory content targeted for deployment, write a manifest.json


### PR DESCRIPTION
Add `verbose = FALSE` argument to writeManifest(), and pass this through to createAppManifest(), in order to benefit from improved verbose logging in packrat.