### PR TITLE
exclude packrat/* files from the manifest.json file listing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 * Increase default HTTP timeout on non-Windows platforms (#476)
 * Require `packrat` 0.5 or later (#434)
 * Fix error when handling empty application / content lists (#417, #395)
+* Calls to `writeManifest()` no longer reference `packrat` files in the generated `manifest.json`. The `packrat` entries were transient and only existed while computing dependencies. (#472)
 
 ## 0.8.16
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -246,7 +246,8 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
       condaMode = condaMode,
       forceGenerate = forceGenerate,
       python = python,
-      hasPythonRmd = hasPythonRmd)
+      hasPythonRmd = hasPythonRmd,
+      retainPackratDirectory = TRUE)
   manifestJson <- enc2utf8(toJSON(manifest, pretty = TRUE))
   manifestPath <- file.path(bundleDir, "manifest.json")
   writeLines(manifestJson, manifestPath, useBytes = TRUE)
@@ -387,7 +388,9 @@ writeManifest <- function(appDir = getwd(),
       condaMode = condaMode,
       forceGenerate = forceGeneratePythonEnvironment,
       python = python,
-      hasPythonRmd = hasPythonRmd)
+      hasPythonRmd = hasPythonRmd,
+      retainPackratDirectory = FALSE)
+
   manifestJson <- enc2utf8(toJSON(manifest, pretty = TRUE))
   manifestPath <- file.path(appDir, "manifest.json")
   writeLines(manifestJson, manifestPath, useBytes = TRUE)
@@ -657,7 +660,8 @@ inferPythonEnv <- function(workdir, python, condaMode, forceGenerate) {
 
 createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
                               appPrimaryDoc, assetTypeName, users, condaMode,
-                              forceGenerate, python = NULL, hasPythonRmd = FALSE) {
+                              forceGenerate, python = NULL, hasPythonRmd = FALSE,
+                              retainPackratDirectory = TRUE) {
 
   # provide package entries for all dependencies
   packages <- list()
@@ -738,6 +742,12 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
   }
 
   if (length(msg)) stop(paste(formatUL(msg, '\n*'), collapse = '\n'), call. = FALSE)
+
+  if (!retainPackratDirectory) {
+    # Optionally remove the packrat directory when it will not be included in
+    # deployments, such as manifest-only deployments.
+    unlink(file.path(appDir, "packrat"), recursive = TRUE)
+  }
 
   # build the list of files to checksum
   files <- list.files(appDir, recursive = TRUE, all.files = TRUE,

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -290,8 +290,9 @@ test_that("writeManifest: Rmd without a python block doesn't include reticulate 
   expect_equal(manifest$python, NULL)
   # Confirm that we have removed packrat entries from our file listing but
   # retain entries for other files.
-  expect_false(any(grepl("^packrat/", manifest$files)))
-  expect_true(any(grepl("simple.Rmd", manifest$files)))
+  filenames <- names(manifest$files)
+  expect_false(any(grepl("^packrat/", filenames, perl = TRUE)), filenames)
+  expect_true(any(grepl("simple.Rmd", filenames, fixed = TRUE)), filenames)
 })
 
 test_that("getPython handles null python by checking RETICULATE_PYTHON", {

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -288,6 +288,10 @@ test_that("writeManifest: Rmd without a python block doesn't include reticulate 
   expect_equal(manifest$metadata$appmode, "rmd-static")
   expect_equal(manifest$metadata$primary_rmd, "simple.Rmd")
   expect_equal(manifest$python, NULL)
+  # Confirm that we have removed packrat entries from our file listing but
+  # retain entries for other files.
+  expect_false(any(grepl("^packrat/", manifest$files)))
+  expect_true(any(grepl("simple.Rmd", manifest$files)))
 })
 
 test_that("getPython handles null python by checking RETICULATE_PYTHON", {


### PR DESCRIPTION
When bundling for writeManifest, remove the packrat tree before building
the set of files. Useful for writeManifest callers, who do not the
packrat directory we create while performing a bundle snapshot.

The manifest.json lacks packrat entries _only_ when creating a
standalone manifest, but in the future, we could suppress the packrat
entries when deploying to shinyapps.io, as well.