### PR TITLE
Increase the default rsconnect timeout

### DIFF
--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -12,7 +12,7 @@
   # by default (primarily used by the IDE when validating server URLs)
   if (is.null(getOption("rsconnect.http.timeout"))) {
     windows <- identical(.Platform$OS.type, "windows")
-    options(rsconnect.http.timeout = ifelse(windows, 20, 5))
+    options(rsconnect.http.timeout = ifelse(windows, 20, 10))
   }
 
   if (is.null(getOption("rsconnect.metadata.sync.hours"))) {


### PR DESCRIPTION
If 5 seconds isn't enough, users can get stuck and it's not straightforward for someone who isn't familiar with the internal workings of `rsconnect` how to fix the issue.