### PR TITLE
warn on long user/group file ownership

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * Improve how large bundles (file size and count) are detected (#464)
 * The `RSCONNECT_TAR` environment variable can be used to select the tar implementation used to create bundles (#446)
+* Warn when files are owned by users or groups with long names, as this can cause the internal R tar implementation to produce invalid archives (#446)
 * Add support for syncing the deployment metadata with the server (#396)
 * Insist on ShinyApps accounts in `showUsers()` (#398)
 * Improve the regex used for the browser and browseURL lints to include a word boundary (#400)

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -270,8 +270,36 @@ writeBundle <- function(bundleDir, bundlePath, verbose = FALSE) {
 
   tarImplementation <- Sys.getenv("RSCONNECT_TAR", "internal")
   logger(sprintf("Using tar: %s", tarImplementation))
+
+  if (tarImplementation == "internal") {
+    detectLongNames(bundleDir)
+  }
+
   utils::tar(bundlePath, files = NULL, compression = "gzip", tar = tarImplementation)
 }
+
+# Scan the bundle directory looking for long user/group names.
+#
+# Warn that the internal tar implementation may produce invalid archives.
+# https://github.com/rstudio/rsconnect/issues/446
+# https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17871
+detectLongNames <- function(bundleDir, lengthLimit = 32) {
+  files <- list.files(bundleDir, recursive = TRUE, all.files = TRUE,
+                      include.dirs = TRUE, no.. = TRUE, full.names = FALSE)
+  for (f in files) {
+    info <- file.info(file.path(bundleDir,f))
+    cat(sprintf("f=%s; u=%s (%d); g=%s, (%d)\n", f, info$uname, nchar(info$uname), info$grname, nchar(info$grname)))
+    if (nchar(info$uname) > lengthLimit || nchar(info$grname) > lengthLimit) {
+      warning("The bundle contains files with user/group names having more than ", lengthLimit,
+              " characters: ", f, " is owned by ", info$uname, ":", info$grname, ". ",
+              "Long user and group names cause the internal R tar implementation to produce invalid archives. ",
+              "Set the RSCONNECT_TAR environment variable to use an external tar command.")
+      return(TRUE)
+    }
+  }
+  return(FALSE)
+}
+
 
 #' Create a manifest.json describing deployment requirements.
 #'

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -288,7 +288,6 @@ detectLongNames <- function(bundleDir, lengthLimit = 32) {
                       include.dirs = TRUE, no.. = TRUE, full.names = FALSE)
   for (f in files) {
     info <- file.info(file.path(bundleDir,f))
-    cat(sprintf("f=%s; u=%s (%d); g=%s, (%d)\n", f, info$uname, nchar(info$uname), info$grname, nchar(info$grname)))
     if (nchar(info$uname) > lengthLimit || nchar(info$grname) > lengthLimit) {
       warning("The bundle contains files with user/group names having more than ", lengthLimit,
               " characters: ", f, " is owned by ", info$uname, ":", info$grname, ". ",

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -293,10 +293,10 @@ detectLongNames <- function(bundleDir, lengthLimit = 32) {
               " characters: ", f, " is owned by ", info$uname, ":", info$grname, ". ",
               "Long user and group names cause the internal R tar implementation to produce invalid archives. ",
               "Set the RSCONNECT_TAR environment variable to use an external tar command.")
-      return(TRUE)
+      return(invisible(TRUE))
     }
   }
-  return(FALSE)
+  return(invisible(FALSE))
 }
 
 


### PR DESCRIPTION
The R tar implementation does not produce valid archives when file ownership uses long user/group names. Emit a warning about this problem. It appears that all R through 4.0.4 have this issue.

Follow-up to earlier work on #446, where we added support for an alternate tar in #447

Here is some example output when I force a low length limit and run it against the `rsconnect` repository.

```
rsconnect:::detectLongNames(".", lengthLimit = 3)
Warning message:
In rsconnect:::detectLongNames(".", lengthLimit = 3) :
  The bundle contains files with user/group names having more than 3 characters: _pkgdown.yml is owned by aron:staff. Long user and group names cause the internal R tar implementation to produce invalid archives. Set the RSCONNECT_TAR environment variable to use an external tar command.
```