### PR TITLE
Don't deploy `app_cache/` subdirectory

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -79,6 +79,7 @@ maxDirectoryList <- function(dir, depth, totalFiles, totalSize) {
                                       "manifest.json",
                                       "rsconnect",
                                       "packrat",
+                                      "app_cache",
                                       ".svn",
                                       ".git",
                                       ".Rproj.user"


### PR DESCRIPTION
The `app_cache/` subdirectory is used by the sass and bslib packages for storing cached files, and we are also recommending that Shiny users use that subdirectory.