### PR TITLE
fix "Error in readLines(contentFile) : 'con' is not a connection" error when JSON tracing enabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## 0.8.17 (in development)
 
+* Fixed issue where setting `options(rsconnect.http.trace.json = TRUE)` could cause deployment errors with some HTTP transports (#490)
 * Improve how large bundles (file size and count) are detected (#464)
 * The `RSCONNECT_TAR` environment variable can be used to select the tar implementation used to create bundles (#446)
 * Warn when files are owned by users or groups with long names, as this can cause the internal R tar implementation to produce invalid archives (#446)

--- a/R/http-libcurl.R
+++ b/R/http-libcurl.R
@@ -154,8 +154,12 @@ httpLibCurl <- function(protocol,
   }
 
   # emit JSON trace if requested
-  if (!is.null(file) && httpTraceJson() &&
-      identical(contentType, "application/json"))
+  jsonTracingEnabling <-
+    httpTraceJson() &&
+    !is.null(contentFile) &&
+    identical(contentType, "application/json")
+
+  if (jsonTracingEnabled)
     cat(paste0("<< ", paste(readLines(contentFile), collapse="\n"), "\n"))
 
   # Parse cookies from header; bear in mind that there may be multiple headers


### PR DESCRIPTION
The code was erroneously checking the null-ity of `file` rather than `contentFile`.