### PR TITLE
Add gitlab has known source from packrat records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 * Require `packrat` 0.5 or later (#434)
 * Fix error when handling empty application / content lists (#417, #395)
 * Calls to `writeManifest()` no longer reference `packrat` files in the generated `manifest.json`. The `packrat` entries were transient and only existed while computing dependencies. (#472)
+* GitLab is seen as a valid SCM source (#491)
 
 ## 0.8.16
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -834,7 +834,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
 
 validatePackageSource <- function(pkg) {
   msg <- NULL
-  if (!(pkg$Source %in% c("CRAN", "Bioconductor", "github"))) {
+  if (!(pkg$Source %in% c("CRAN", "Bioconductor", "github", "gitlab"))) {
     if (is.null(pkg$Repository)) {
       msg <- paste("The package was installed from an unsupported ",
                    "source '", pkg$Source, "'.", sep = "")

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -834,7 +834,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
 
 validatePackageSource <- function(pkg) {
   msg <- NULL
-  if (!(pkg$Source %in% c("CRAN", "Bioconductor", "github", "gitlab"))) {
+  if (!(pkg$Source %in% c("CRAN", "Bioconductor", "github", "gitlab", "bitbucket"))) {
     if (is.null(pkg$Repository)) {
       msg <- paste("The package was installed from an unsupported ",
                    "source '", pkg$Source, "'.", sep = "")

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -159,7 +159,7 @@ snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
 # source or comes from a source control system. This indicates that we will
 # not have a repostory URL; location is recorded elsewhere.
 isSCMSource <- function(source) {
-  tolower(source) %in% c("github", "bitbucket", "source")
+  tolower(source) %in% c("github", "gitlab", "bitbucket", "source")
 }
 
 # generate a random name prefixed with "repo_".


### PR DESCRIPTION
This should contribute to fix https://github.com/rstudio/packrat/issues/625 

To share what I have found @aronatkins - here the two places that I think this is missing. 

* **packrat** should add `source = 'gitlab'` in the lockfile.
* This means it should be seen as source remote package in `rsconnec::snapshotDependencies()`
https://github.com/rstudio/rsconnect/blob/833fb27ddfad149d94877b8e6b0f8d70ef8ab339/R/dependencies.R#L117-L128
* and in the bundle building
https://github.com/rstudio/rsconnect/blob/833fb27ddfad149d94877b8e6b0f8d70ef8ab339/R/bundle.R#L713-L719

Maybe there is other places I am mising ? 