### PR TITLE
some fixes ahead of CRAN

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,7 +1,7 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
-^examples/
-
+^examples$
+^R/\.editorconfig$
 ^\.travis\.yml$
 ^README\.Rmd$
 ^_pkgdown\.yml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Suggests:
     testthat,
     xtable
 License: GPL-2
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)
 URL: https://github.com/rstudio/rsconnect
 BugReports: https://github.com/rstudio/rsconnect/issues

--- a/R/deployTFModel.R
+++ b/R/deployTFModel.R
@@ -20,14 +20,14 @@
 #' [keras::export_savedmodel.keras.engine.training.Model()] or the TensorFlow
 #' method [tensorflow::export_savedmodel()]. If using the TensorFlow package for
 #' R, the official [TensorFlow guide for saving and restoring models](
-#' <https://www.tensorflow.org/programmers_guide/saved_model#overview_of_saving_and_restoring_models>)
+#' <https://www.tensorflow.org/guide/saved_model>)
 #' may be useful.
 #'
 #' @param modelDir Path to the saved model directory. MUST contain
 #'   *saved_model.pb* or *saved_model.pbtxt*
 #' @param ... Additional arguments to [deployApp()].
 #'
-#' @references <https://www.tensorflow.org/programmers_guide/saved_model#overview_of_saving_and_restoring_models>
+#' @references <https://www.tensorflow.org/guide/saved_model>
 #'
 #'
 #' @details

--- a/R/imports.R
+++ b/R/imports.R
@@ -1,5 +1,5 @@
 
 
 #' @importFrom stats na.omit setNames
-#' @importFrom utils available.packages contrib.url file_test formatUL getFromNamespace glob2rx packageVersion read.csv
+#' @importFrom utils available.packages installed.packages contrib.url file_test formatUL getFromNamespace glob2rx packageVersion read.csv
 NULL

--- a/R/packages.R
+++ b/R/packages.R
@@ -1,7 +1,7 @@
 #' Using Packages with rsconnect
 #'
 #' @description
-#' Deployed applications can depend on any package available on CRAN as well as any package hosted in a public \href{https://www.github.com/}{GitHub} repository.
+#' Deployed applications can depend on any package available on CRAN as well as any package hosted in a public \href{https://github.com/}{GitHub} repository.
 #'
 #' When an application is deployed it's source code is scanned for dependencies using the [appDependencies()] function. The list of dependencies is sent to the server along with the application source code and these dependencies are then installed alongside the application.
 #'

--- a/R/packages.R
+++ b/R/packages.R
@@ -1,7 +1,7 @@
 #' Using Packages with rsconnect
 #'
 #' @description
-#' Deployed applications can depend on any package available on CRAN as well as any package hosted in a public \href{https://www.github.com}{GitHub} repository.
+#' Deployed applications can depend on any package available on CRAN as well as any package hosted in a public \href{https://www.github.com/}{GitHub} repository.
 #'
 #' When an application is deployed it's source code is scanned for dependencies using the [appDependencies()] function. The list of dependencies is sent to the server along with the application source code and these dependencies are then installed alongside the application.
 #'

--- a/R/usage.R
+++ b/R/usage.R
@@ -60,10 +60,10 @@ showUsage <- function(appDir=getwd(), appName=NULL, account = NULL, server=NULL,
 #'
 #' Show application metrics of a currently deployed application
 #' @param metricSeries Metric series to query. Refer to the
-#'   [shinyapps.io documentation](<http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics>)
+#'   [shinyapps.io documentation](<https://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics>)
 #'   for available series.
 #' @param metricNames Metric names in the series to query. Refer to the
-#'   [shinyapps.io documentation](<http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics>)
+#'   [shinyapps.io documentation](<https://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics>)
 #'   for available metrics.
 #' @param appName Name of application
 #' @param appDir Directory containing application. Defaults to

--- a/R/usage.R
+++ b/R/usage.R
@@ -60,10 +60,10 @@ showUsage <- function(appDir=getwd(), appName=NULL, account = NULL, server=NULL,
 #'
 #' Show application metrics of a currently deployed application
 #' @param metricSeries Metric series to query. Refer to the
-#'   [shinyapps.io documentation](http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics)
+#'   [shinyapps.io documentation](<http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics>)
 #'   for available series.
 #' @param metricNames Metric names in the series to query. Refer to the
-#'   [shinyapps.io documentation](http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics)
+#'   [shinyapps.io documentation](<http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics>)
 #'   for available metrics.
 #' @param appName Name of application
 #' @param appDir Directory containing application. Defaults to

--- a/man/deployTFModel.Rd
+++ b/man/deployTFModel.Rd
@@ -30,11 +30,11 @@ A saved model directory might look like this:\preformatted{./1/
 For information on creating saved models, see the Keras method
 \code{\link[keras:export_savedmodel.keras.engine.training.Model]{keras::export_savedmodel.keras.engine.training.Model()}} or the TensorFlow
 method \code{\link[tensorflow:export_savedmodel]{tensorflow::export_savedmodel()}}. If using the TensorFlow package for
-R, the official \href{https://www.tensorflow.org/programmers_guide/saved_model#overview_of_saving_and_restoring_models}{TensorFlow guide for saving and restoring models}
+R, the official \href{https://www.tensorflow.org/guide/saved_model}{TensorFlow guide for saving and restoring models}
 may be useful.
 }
 \references{
-\url{https://www.tensorflow.org/programmers_guide/saved_model#overview_of_saving_and_restoring_models}
+\url{https://www.tensorflow.org/guide/saved_model}
 }
 \seealso{
 Other Deployment functions: 

--- a/man/rsconnectPackages.Rd
+++ b/man/rsconnectPackages.Rd
@@ -4,7 +4,7 @@
 \alias{rsconnectPackages}
 \title{Using Packages with rsconnect}
 \description{
-Deployed applications can depend on any package available on CRAN as well as any package hosted in a public \href{https://www.github.com/}{GitHub} repository.
+Deployed applications can depend on any package available on CRAN as well as any package hosted in a public \href{https://github.com/}{GitHub} repository.
 
 When an application is deployed it's source code is scanned for dependencies using the \code{\link[=appDependencies]{appDependencies()}} function. The list of dependencies is sent to the server along with the application source code and these dependencies are then installed alongside the application.
 

--- a/man/rsconnectPackages.Rd
+++ b/man/rsconnectPackages.Rd
@@ -4,7 +4,7 @@
 \alias{rsconnectPackages}
 \title{Using Packages with rsconnect}
 \description{
-Deployed applications can depend on any package available on CRAN as well as any package hosted in a public \href{https://www.github.com}{GitHub} repository.
+Deployed applications can depend on any package available on CRAN as well as any package hosted in a public \href{https://www.github.com/}{GitHub} repository.
 
 When an application is deployed it's source code is scanned for dependencies using the \code{\link[=appDependencies]{appDependencies()}} function. The list of dependencies is sent to the server along with the application source code and these dependencies are then installed alongside the application.
 
@@ -21,7 +21,7 @@ If a locally installed package was not obtained from CRAN (e.g. was installed fr
 \section{GitHub Packages}{
 
 
-It's also possible to depend on packages hosted in public GitHub repositories, so long as they are installed via the \code{\link[devtools:install_github]{devtools::install_github()}} function from the \pkg{devtools} package.
+It's also possible to depend on packages hosted in public GitHub repositories, so long as they are installed via the \code{\link[devtools:remote-reexports]{devtools::install_github()}} function from the \pkg{devtools} package.
 
 This works because \code{install_github} records the exact Github commit that was installed locally, making it possible to download and install the same source code on the deployment server.
 

--- a/man/showMetrics.Rd
+++ b/man/showMetrics.Rd
@@ -18,11 +18,11 @@ showMetrics(
 }
 \arguments{
 \item{metricSeries}{Metric series to query. Refer to the
-\href{http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics}{shinyapps.io documentation}
+\href{https://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics}{shinyapps.io documentation}
 for available series.}
 
 \item{metricNames}{Metric names in the series to query. Refer to the
-\href{http://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics}{shinyapps.io documentation}
+\href{https://docs.rstudio.com/shinyapps.io/metrics.html#ApplicationMetrics}{shinyapps.io documentation}
 for available metrics.}
 
 \item{appDir}{Directory containing application. Defaults to

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -36,7 +36,7 @@ If python = NULL, and RETICULATE_PYTHON is set in the environment,
 its value will be used.}
 
 \item{forceGeneratePythonEnvironment}{Optional. If an existing
-\code{requirements.txt} file is found, it will be overwritten when 
+\code{requirements.txt} file is found, it will be overwritten when
 this argument is \code{TRUE}.}
 }
 \description{


### PR DESCRIPTION
* Ignore the entire examples tree; avoids creating an empty dir that is subsequently ignored
* Ignore the R/.editorconfig
* Update TF links
* Add installed.packages to imports
* Fix GitHub link; now with trailing slash!

The shinyapps.io links are still reported as wrong; anchors are ignored?!
GitHub is still reported as without a trailing slash!?