### PR TITLE
packrat 0.6.0 is on CRAN; ask for it.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Imports:
     digest,
     jsonlite,
     openssl,
-    packrat (>= 0.5),
+    packrat (>= 0.6),
     rstudioapi (>= 0.5),
     yaml (>= 2.1.5)
 Suggests:


### PR DESCRIPTION
@jmcphers - should this change also include an updated rsconnect version? Are you already handling that?