### PR TITLE
Added support for .rscignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ README.html
 *.Rcheck/
 *.tar.gz
 docs/
+.rscignore

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -89,6 +89,16 @@ maxDirectoryList <- function(dir, depth, totalFiles, totalSize) {
   # exclude renv files
   contents <- setdiff(contents, c("renv", "renv.lock"))
 
+
+  # checks for .rscignore file and excludes the files and directories listed
+  if (".rscignore" %in% contents) {
+    ignoreContents <- readLines(".rscignore")
+    contents <- setdiff(
+      x = contents,
+      y = ignoreContents
+    )
+  }
+
   # subdirContents contains all files encountered beneath this directory.
   # Returned paths are relative to this directory.
   subdirContents <- NULL

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -175,6 +175,10 @@ maxDirectoryList <- function(dir, depth, totalFiles, totalSize) {
 #' \item{Certain files and folders that don't need to be bundled, such as
 #'    those containing internal version control and RStudio state, are
 #'    excluded.}
+#' \item{In order to stop specific files in the working directory from being
+#'    listed in the bundle, the files must be listed in the .rscignore file.
+#'    This file must have one file or directory per line with no support for
+#'    wildcards.}
 #' }
 #'
 #' @return Returns a list containing the following elements:

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -4,6 +4,10 @@
 #' [RMarkdown][rmarkdown::rmarkdown-package] document, a plumber API, or HTML
 #' content to a server.
 #'
+#' In order to ignore specific files in the working directory while deploying,
+#' the files must be listed in the .rscignore file. This file must have one
+#' file or directory per line with no support for wildcards.'
+#'
 #' @param appDir Directory containing application. Defaults to current working
 #'   directory.
 #' @param appFiles The files and directories to bundle and deploy (only if

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# rsconnect <a href='https://rstudio.github.io/rstudioapi'><img src='man/figures/logo.png' align="right" height="139" /></a>
+# rsconnect <a href='https://rstudio.github.io/rstudioapi/'><img src='man/figures/logo.png' align="right" height="139" /></a>
 
 
 <!-- badges: start -->
@@ -22,7 +22,7 @@ knitr::opts_chunk$set(
 [![lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 <!-- badges: end -->
 
-An R package used for deploying applications to the [ShinyApps](https://shinyapps.io/) hosted service, 
+An R package used for deploying applications to the [ShinyApps](https://www.shinyapps.io/) hosted service, 
 or to [RStudio Connect](https://www.rstudio.com/products/connect/).
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# rsconnect <a href='https://rstudio.github.io/rstudioapi'><img src='man/figures/logo.png' align="right" height="139" /></a>
+# rsconnect <a href='https://rstudio.github.io/rstudioapi/'><img src='man/figures/logo.png' align="right" height="139" /></a>
 
 <!-- badges: start -->
 
@@ -13,7 +13,7 @@ Status](https://travis-ci.org/rstudio/rsconnect.svg?branch=master)](https://trav
 <!-- badges: end -->
 
 An R package used for deploying applications to the
-[ShinyApps](https://shinyapps.io/) hosted service, or to [RStudio
+[ShinyApps](https://www.shinyapps.io/) hosted service, or to [RStudio
 Connect](https://www.rstudio.com/products/connect/).
 
 ## Installation

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -118,6 +118,11 @@ Deploy a \link[shiny:shiny-package]{shiny} application, an
 \link[rmarkdown:rmarkdown-package]{RMarkdown} document, a plumber API, or HTML
 content to a server.
 }
+\details{
+In order to ignore specific files in the working directory while deploying,
+the files must be listed in the .rscignore file. This file must have one
+file or directory per line with no support for wildcards.'
+}
 \examples{
 \dontrun{
 

--- a/man/listBundleFiles.Rd
+++ b/man/listBundleFiles.Rd
@@ -35,5 +35,9 @@ bundle is controlled by the \code{rsconnect.max.bundle.files} option.}
 \item{Certain files and folders that don't need to be bundled, such as
 those containing internal version control and RStudio state, are
 excluded.}
+\item{In order to stop specific files in the working directory from being
+listed in the bundle, the files must be listed in the .rscignore file.
+This file must have one file or directory per line with no support for
+wildcards.}
 }
 }


### PR DESCRIPTION
Resolves #368 

This pull request adds a simple .rscignore file that lists the files that the user wished to ignore when writing a manifest or deploying the app. 

I don't know where to write documentation, it is quite simple so if anyone can help me out, it would be appriciated.

Looking forward to your responses.