### PR TITLE
lint different-case markdown links

### DIFF
--- a/tests/testthat/test-lint.R
+++ b/tests/testthat/test-lint.R
@@ -47,7 +47,14 @@ test_that("The linter identifies files not matching in case sensitivity", {
   result <- lint("shinyapp-with-absolute-paths")
   server.R <- result[["server.R"]]
   filepath.capitalization <- server.R[["filepath.capitalization"]]
-  expect_true(filepath.capitalization$indices == 31)
+  expect_equal(as.integer(filepath.capitalization$indices), 31)
+})
+
+test_that("The linter identifies files with Markdown links not matching in case sensitivity", {
+  result <- lint("test-rmd-bad-case")
+  index.Rmd <- result[["index.Rmd"]]
+  filepath.capitalization <- index.Rmd[["filepath.capitalization"]]
+  expect_equal(as.integer(filepath.capitalization$indices), 29)
 })
 
 test_that("The linter believes that the Shiny example apps are okay", {

--- a/tests/testthat/test-rmd-bad-case/RStudio.svg
+++ b/tests/testthat/test-rmd-bad-case/RStudio.svg
@@ -1,0 +1,1 @@
+<!-- this is a fake SVG meant to demonstrate linting of case-sensitive image links -->

--- a/tests/testthat/test-rmd-bad-case/index.Rmd
+++ b/tests/testthat/test-rmd-bad-case/index.Rmd
@@ -1,0 +1,34 @@
+---
+title: "rmarkdown with bad link case"
+---
+
+One of the embedded images uses `rstudio.svg` even though the on-disk filename
+is `RStudio.svg`. This will render fine on a Mac, for example, but will err
+when rendered on Linux.
+
+The Mac filesystem is case-preserving, but case-insensitive. The Linux
+filesystem is case-sensitive.
+
+The IDE and `rsconnect::deployDoc` attempt to deploy the as-linked filenames.
+With both `rstudio.svg` and `RStudio.svg` links, the bundle has two copies of
+the SVG!
+
+You can use `rsconnect::deployApp` directly to see the lint error in the R
+console:
+
+```r
+rsconnect::deployApp(
+  appDir = getwd(), 
+  appFiles = c("index.Rmd", "RStudio.svg"))
+```
+
+And now, the links!
+
+This one (line 29) is all lower-case and should trigger the error.
+
+![](rstudio.svg)
+
+This one is mixed-case and matches the on-disk filename.
+
+![](RStudio.svg)
+


### PR DESCRIPTION
Identifies text within ](...) and check for case problems against files in the project. Covers links and images.

fixes #388

Tested with:

```
rsconnect::deployApp(appDir = getwd(), appFiles = c("index.Rmd", "RStudio.svg"), ...)
```

This gives the lint complaint:

<img width="629" alt="image" src="https://user-images.githubusercontent.com/362187/115037231-4256be80-9e9c-11eb-922a-2bb81bc41e98.png">

Note: When an Rmd references the same image with two different names, `rsconnect::deployDoc()` and the IDE publish button attempt to self-resolve these case problems and create a bundle having both names:

<img width="285" alt="image" src="https://user-images.githubusercontent.com/362187/115037565-98c3fd00-9e9c-11eb-930e-be242fd1051d.png">

The actual bundle only contains one of those two filenames, which still causes server-side rendering problems.