### PR TITLE
Use temporary directory for config during tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # NEWS
 
+## 0.8.18 (in development)
+
+* Fixed issue causing configuration directory to be left behind after `R CMD CHECK`
+* Fixed incorrect subdirectory nesting when storing configuration in `R_USER_CONFIG_DIR`
+
 ## 0.8.17
 
 Released to CRAN on 2020-04-02

--- a/R/config.R
+++ b/R/config.R
@@ -27,7 +27,10 @@ applicationConfigDir <- function(appName, subDir = NULL, create = TRUE) {
   # check for R specific config dir
   configDir <- Sys.getenv("R_USER_CONFIG_DIR")
 
-  if (nchar(configDir) < 1) {
+  if (nzchar(configDir)) {
+    # R specific config dir, append app name only
+    configDir <- file.path(configDir, appName)
+  } else {
     # no R specific config dir; determine application config dir (platform specific)
     sysName <- Sys.info()[['sysname']]
     if (identical(sysName, "Windows"))

--- a/R/title.R
+++ b/R/title.R
@@ -23,9 +23,10 @@
 #' can be disabled by setting `unique = FALSE`.
 #'
 #' @examples
+#' \dontrun{
 #' # Generate a short name for a sample application
 #' generateAppName("My Father's Country", "~/fathers-country", "myacct")
-#'
+#' }
 #' @export
 
 generateAppName <- function(appTitle, appPath = NULL, account = NULL, unique = TRUE) {

--- a/man/generateAppName.Rd
+++ b/man/generateAppName.Rd
@@ -35,7 +35,8 @@ name will also be unique among locally known deployments of the directory
 can be disabled by setting \code{unique = FALSE}.
 }
 \examples{
+\dontrun{
 # Generate a short name for a sample application
 generateAppName("My Father's Country", "~/fathers-country", "myacct")
-
+}
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,12 +1,18 @@
 library(testthat)
 library(rsconnect)
 
-# set temp config dir so the tests don't pollute it
-temp_config_dir <- file.path(tempdir(), "rsconnect-test-config")
-Sys.setenv(R_USER_CONFIG_DIR = temp_config_dir)
+run_tests <- function() {
+  # set temp config dir so the tests don't pollute it
+  temp_config_dir <- file.path(tempdir(), "rsconnect-test-config")
+  Sys.setenv(R_USER_CONFIG_DIR = temp_config_dir)
 
-# perform tests
-test_check("rsconnect")
+  # clean up temp dir after tests are run
+  on.exit({
+    unlink(temp_config_dir, recursive = TRUE)
+  }, add = TRUE)
 
-# clean up temporary configuration
-unlink(temp_config_dir, recursive = TRUE)
+  # perform tests
+  test_check("rsconnect")
+}
+
+run_tests()

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,13 +1,12 @@
 library(testthat)
 library(rsconnect)
 
-# record whether the configuration directory exists
-configDir <- rsconnect:::rsconnectConfigDir()
-configDirExists <- file.exists(configDir)
+# set temp config dir so the tests don't pollute it
+temp_config_dir <- file.path(tempdir(), "rsconnect-test-config")
+Sys.setenv(R_USER_CONFIG_DIR = temp_config_dir)
 
+# perform tests
 test_check("rsconnect")
 
-# if the configuration directory did not exist before running the tests, clean it up.
-if (!configDirExists) {
-  unlink(configDir, recursive = TRUE)
-}
+# clean up temporary configuration
+unlink(temp_config_dir, recursive = TRUE)


### PR DESCRIPTION
This PR contains two changes:

1. The `R_USER_CONFIG_DIR` directory now hosts the `rsconnect` folder (formerly if specified we'd create `accounts` right underneath `R_USER_CONFIG_DIR` which is not desirable)
2. The tests now always operate on a temporary configuration set specified by `R_USER_CONFIG_DIR`. This both avoids the tests being affected by the machine's extant configuration set and makes it easy to clean up the config afterwards. 

Both of these changes were requested by CRAN maintainers.