### PR TITLE
warn when unable to locate a package repository URL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@
 * Added linter for different-case Markdown links (#388)
 * Use new Packrat release on CRAN, 0.6.0 (#501)
 * Fix incorrect linter messages referring to `shiny.R` instead of `server.R` (#509)
+* Warn, rather than err, when the repository URL for a package dependency
+  cannot be validated. This allows deployment when using archived CRAN
+  packages, or when using packages installed from source that are available on
+  the server. (#508)
 
 ## 0.8.17
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -745,7 +745,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
     #
     # That said, an incorrectly configured "repos" option is almost always the cause.
     packageMessages <- c(packageMessages,
-                         "Unable to determine the location for some packages. Packages should be installed from a package repository like CRAN or a source control system. Check that options('repos') refers to a package repository containing the needed package versions.")
+                         "Unable to determine the source location for some packages. Packages should be installed from a package repository like CRAN or a version control system. Check that options('repos') refers to a package repository containing the needed package versions.")
     warning(paste(formatUL(packageMessages, '\n*'), collapse = '\n'), call. = FALSE, immediate. = TRUE)
   }
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -145,10 +145,8 @@ snapshotDependencies <- function(appDir, implicit_dependencies=c()) {
         source <- package.repo$name
       }
       repository <- package.repo$url
-    } else {
-      warning(sprintf("Unable to determine the repository for package %s", pkg),
-              call. = FALSE, immediate. = TRUE)
     }
+    # validatePackageSource will emit a warning for packages with NA repository.
     data.frame(Source = source, Repository = repository)
   })
   records[, c("Source","Repository")] <- do.call("rbind", tmp)


### PR DESCRIPTION
Previously, we would err (and prohibit manifest creation and/or deployment)
when unable to locate a repository URL for a named package. Now, warn and
allow the operation to proceed.

Archived CRAN packages are not discoverable through available.packages.

Source-installed packages do not have repository URLs, but may have been
installed locally on the server (and configured as an external package
dependency).

This consolidates three separate checks against the package repository and source.

Fixes #508

Given a Shiny application with:

```r
# remotes::install_version("Kmisc", "0.5.0")
library(Kmisc)

# A locally-created, installed-from-source package.
library(silly)
```

Calling `rsconnect::writeManifest()` produces:

```
Warning: 
* May be unable to deploy package dependency 'Kmisc'; could not
   determine a repository URL for the source 'CRAN'.

* May be unable to deploy package dependency 'silly'; could not
   determine a repository URL for the source 'CRAN'.

* Unable to determine the source location for some packages. Packages
   should be installed from a package repository like CRAN or a
   version control system. Check that options('repos') refers to a
   package repository containing the needed package versions.
Warning message:
In FUN(X[[i]], ...) :
  Package 'silly 0.1.0' was installed from sources; Packrat will assume this package is available from a CRAN-like repository during future restores
```

That final message is triggered by `packrat` but not displayed immediately, so it shows up last.