### PR TITLE
NA is not an app mode and causes downstream problems.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
   cannot be validated. This allows deployment when using archived CRAN
   packages, or when using packages installed from source that are available on
   the server. (#508)
+* Err when the app-mode cannot be inferred; seen with empty directories/file-sets (#512)
 
 ## 0.8.17
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -551,7 +551,7 @@ inferAppMode <- function(appDir, appPrimaryDoc, files) {
   }
 
   # there doesn't appear to be any content here we can use
-  return(NA)
+  stop("No content to deploy; cannot detect content type.")
 }
 
 inferAppPrimaryDoc <- function(appPrimaryDoc, appFiles, appMode) {


### PR DESCRIPTION
Were inferAppMode to return NA, it would immediately cause inferAppPrimaryDoc
to err, as it cannot cope with an NA value for appMode.

fixes #512

```r
empty <- file.path(tempdir(), "empty")
dir.create(empty)
setwd(empty)

rsconnect::writeManifest()
# =>  Error in inferAppMode(appDir = appDir, appPrimaryDoc = appPrimaryDoc,  : 
# =>   No content to deploy; cannot detect content type. 
```