### PR TITLE
do not use nested metadata fields; quarto is a top-level manifest field

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -884,12 +884,13 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
                                       contentCategory, NA)
   metadata$has_parameters <- hasParameters
 
-  # indicate whether this is a quarto app/doc
-  metadata$quarto <- quarto
-
   # add metadata
   manifest$metadata <- metadata
 
+  # indicate whether this is a quarto app/doc
+  if (!is.null(quarto)) {
+    manifest$quarto <- quarto
+  }
   # if there is python info for reticulate, attach it
   if (!is.null(pyInfo)) {
     manifest$python <- pyInfo

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -360,10 +360,11 @@ deployApp <- function(appDir = getwd(),
 
       # python is enabled on Connect but not on Shinyapps
       python <- getPythonForTarget(python, accountDetails)
+      quarto <- getQuartoManifestDetails(metadata)
       bundlePath <- bundleApp(target$appName, appDir, appFiles,
                               appPrimaryDoc, assetTypeName, contentCategory, verbose, python,
                               condaMode, forceGeneratePythonEnvironment,
-                              metadata[["quarto"]],
+                              quarto,
                               isTRUE(metadata$serverRender))
 
       if (isShinyapps(accountDetails$server)) {
@@ -494,6 +495,16 @@ getPythonForTarget <- function(path, accountDetails) {
   else {
     NULL
   }
+}
+
+getQuartoManifestDetails <- function(metadata = list()) {
+  if (!is.null(metadata[["quarto_version"]])) {
+    return(list(
+        "version" = metadata[["quarto_version"]],
+        "engines" = metadata[["quarto_engines"]]
+    ))
+  }
+  return(NULL)
 }
 
 # calculate the deployment target based on the passed parameters and


### PR DESCRIPTION
rsconnect cannot cope with nested metadata fields. also, promote the quarto doc to top-level in the manifest.

https://github.com/rstudio/rsconnect/blob/f13241bd108d2974896d01d044eca01a10d70447/R/deployments.R#L238-L251

```
Error in (function (..., row.names = NULL, check.rows = FALSE, check.names = TRUE, : 
arguments imply differing number of rows: 0, 1
```

See also: https://github.com/rstudio/rstudio/issues/9641