### PR TITLE
Change curl to use -T -X POST instead of data-binary.

### DIFF
--- a/R/http-curl.R
+++ b/R/http-curl.R
@@ -45,8 +45,9 @@ httpCurl <- function(protocol,
 
   if (!is.null(contentFile)) {
     command <- paste(command,
-                     "--data-binary",
-                     shQuote(paste("@", contentFile, sep="")),
+                     "-T",
+                     shQuote(contentFile),
+                     "-X", "POST",
                      "--header", paste('"' ,"Content-Type: ",contentType, '"', sep=""),
                      "--header", paste('"', "Content-Length: ", fileLength, '"', sep=""))
   }


### PR DESCRIPTION
When uploading a large bundle (many GB) to RStudio Connect we have to set `options(rsconnect.http = "curl")` to use the curl uploader. The code currently uses `--data-binary` which tells curl to load the entire file into memory at once before uploading. Obviously this can cause problems if the size of the bundle is larger than memory, so instead we should use the `-T <file>` and `-X POST` options.

I haven't done extensive testing, but from my reading of the curl man page these options should be equivalent to `--data-binary`. As far as portability goes, both options exist on curl as old as 7.15.5.