### PR TITLE
Use curl -T for file uploads

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.8.25 (in development)
 
-* Changed curl to use -T flag for uploading to avoid out of memory errors
+* Use the `curl` option `-T` when uploading files to avoid out of memory errors with large files. (#544)
 
 ## 0.8.24
 

--- a/R/http-curl.R
+++ b/R/http-curl.R
@@ -47,7 +47,6 @@ httpCurl <- function(protocol,
     command <- paste(command,
                      "-T",
                      shQuote(contentFile),
-                     "-X", "POST",
                      "--header", paste('"' ,"Content-Type: ",contentType, '"', sep=""),
                      "--header", paste('"', "Content-Length: ", fileLength, '"', sep=""))
   }


### PR DESCRIPTION
Replaces https://github.com/rstudio/rsconnect/pull/544

Reminder when testing: Use "curl" for transfers, which is not the default.

```r
options(rsconnect.http = "curl")
```