### PR TITLE
let packrat use renv for dependency analysis

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -1130,9 +1130,13 @@ performPackratSnapshot <- function(bundleDir, verbose = FALSE) {
   on.exit(packrat::opts$snapshot.recommended.packages(srp, persist = FALSE),
           add = TRUE)
 
-  # use renv dependency scanning within packrat.
-  old <- options("packrat.dependency.discovery.renv" = TRUE)
-  on.exit(options(old), add = TRUE)
+  # Force renv dependency scanning within packrat unless the option has been
+  # explicitly configured. This is a no-op for older versions of packrat.
+  renvDiscovery = getOption("packrat.dependency.discovery.renv")
+  if (is.null(renvDiscovery)) {
+    oldDiscovery <- options("packrat.dependency.discovery.renv" = TRUE)
+    on.exit(options(oldDiscovery), add = TRUE)
+  }
 
   # attempt to eagerly load the BiocInstaller or BiocManaager package if installed, to work around
   # an issue where attempts to load the package could fail within a 'suppressMessages()' context

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -1130,6 +1130,10 @@ performPackratSnapshot <- function(bundleDir, verbose = FALSE) {
   on.exit(packrat::opts$snapshot.recommended.packages(srp, persist = FALSE),
           add = TRUE)
 
+  # use renv dependency scanning within packrat.
+  old <- options("packrat.dependency.discovery.renv" = TRUE)
+  on.exit(options(old), add = TRUE)
+
   # attempt to eagerly load the BiocInstaller or BiocManaager package if installed, to work around
   # an issue where attempts to load the package could fail within a 'suppressMessages()' context
   packages <- c("BiocManager", "BiocInstaller")


### PR DESCRIPTION
requires https://github.com/rstudio/packrat/pull/647

Automatically enables the `packrat.dependency.discovery.renv` option, requesting that packrat use renv for dependency analysis. An existing value for `packrat.dependency.discovery.renv` is left alone.