### PR TITLE
check fixing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,8 @@ Suggests:
     testthat,
     xtable
 License: GPL-2
-RoxygenNote: 7.1.1
+Encoding: UTF-8
+RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 URL: https://github.com/rstudio/rsconnect
 BugReports: https://github.com/rstudio/rsconnect/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
     openssl,
     packrat (>= 0.6),
     rstudioapi (>= 0.5),
+    tools,
     yaml (>= 2.1.5)
 Suggests:
     RCurl,

--- a/R/config.R
+++ b/R/config.R
@@ -106,10 +106,11 @@ oldApplicationConfigDir <- function(appName) {
 #' @keywords internal
 applicationConfigDir <- function()  {
 
-  if (getRversion() >= "4.0.0") {
-    # In newer versions of R, we can ask R itself where configuration should be
-    # stored.
-    tools::R_user_dir("rsconnect", "config")
+  if (exists("R_user_dir", envir = asNamespace("tools"))) {
+    # In newer versions of R (>=4.0), we can ask R itself where configuration should be stored.
+    # Load from the namespace to avoid check warnings with old R.
+    f <- get("R_user_dir", envir = asNamespace("tools"))
+    f("rsconnect", "config")
   } else {
     # In older versions of R, use an implementation derived from R_user_dir
     home <- Sys.getenv("HOME", unset = normalizePath("~"))


### PR DESCRIPTION
Fix two complaints when running `R CMD check` locally with R-3.6.3.

```
Warning: roxygen2 requires Encoding: UTF-8
```

```
N  checking dependencies in R code (1.4s)
   Missing or unexported object: ‘tools::R_user_dir’
```