### PR TITLE
use skip rather than returning

### DIFF
--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -25,11 +25,7 @@ test_that("Users API", {
 
   skip_on_cran()
   skip_on_os("windows")
-
-  if (!isConnectRunning()) {
-    cat("No running 'connect' instance detected -- tests skipped.\n")
-    return()
-  }
+  skip_if(!isConnectRunning())
 
   ## rm db/*.db
   server <- getDefaultServer(local = TRUE)


### PR DESCRIPTION
better testthat output. 

Now

```
══ Testing test-connect.R ══════════════════════════════════════════════════════
[ FAIL 0 | WARN 0 | SKIP 1 | PASS 0 ]

── Skip (test-connect.R:28:3): Users API ───────────────────────────────────────
Reason: !isConnectRunning() is TRUE

[ FAIL 0 | WARN 0 | SKIP 1 | PASS 0 ]
```

Previously

```
══ Testing test-connect.R ══════════════════════════════════════════════════════
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 0 ]No running 'connect' instance detected -- tests skipped.
[ FAIL 0 | WARN 0 | SKIP 1 | PASS 0 ]

── Skip (test-connect.R:24:1): Users API ───────────────────────────────────────
Reason: empty test
```