### PR TITLE
Add `skip()` conditions for tests requiring packages in Suggests

### DIFF
--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -74,6 +74,7 @@ test_that("bundle directories are recursively enumerated", {
 
 test_that("simple Shiny app bundle is runnable", {
   skip_on_cran()
+  skip_if_not_installed("shiny")
   bundleTempDir <- makeShinyBundleTempDir("simple_shiny", "shinyapp-simple",
                                           NULL)
   on.exit(unlink(bundleTempDir, recursive = TRUE))
@@ -82,6 +83,7 @@ test_that("simple Shiny app bundle is runnable", {
 
 test_that("app.R Shiny app bundle is runnable", {
   skip_on_cran()
+  skip_if_not_installed("shiny")
   bundleTempDir <- makeShinyBundleTempDir("app_r_shiny", "shinyapp-appR",
                                           NULL)
   on.exit(unlink(bundleTempDir, recursive = TRUE))
@@ -90,6 +92,7 @@ test_that("app.R Shiny app bundle is runnable", {
 
 test_that("single-file Shiny app bundle is runnable", {
   skip_on_cran()
+  skip_if_not_installed("shiny")
   bundleTempDir <- makeShinyBundleTempDir("app_r_shiny", "shinyapp-singleR",
                                           "single.R")
   on.exit(unlink(bundleTempDir, recursive = TRUE))

--- a/tests/testthat/test-http.R
+++ b/tests/testthat/test-http.R
@@ -1,7 +1,17 @@
 context("http")
 
+skip_if_not_installed("callr")
+skip_if_not_installed("httpuv")
+
 # The list of HTTP transports to check
-transports <- c("libcurl", "rcurl", "curl", "internal")
+transports <- c("libcurl", "internal")
+
+if (requireNamespace("RCurl", quietly = TRUE)) {
+  transports <- c(transports, "rcurl")
+}
+if (Sys.which("curl") != "") {
+  transports <- c(transports, "curl")
+}
 
 # Temporary file to cache the output (request) to HTTP methods
 output <- tempfile(fileext = ".rds")
@@ -231,3 +241,7 @@ test_that("api key authinfo sets headers", {
                     request$HEADERS, "', with transport ", transport))
   }
 })
+
+# These are purely to alert users that some tests have been skipped.
+skip_if(Sys.which("curl") == "", "curl is not installed")
+skip_if_not_installed("RCurl")


### PR DESCRIPTION
Many of the existing unit tests check for optional packages (i.e. those in `Suggests`), but I noticed a few were missing when I tried to run the test suite in a new R environment.

This PR adds a few more of these checks, and should make running the test suite a little easier.