### PR TITLE
Add a SHA-256 checksum to requests via the HTTP Digest header

### DIFF
--- a/R/http.R
+++ b/R/http.R
@@ -409,6 +409,7 @@ signatureHeaders <- function(authInfo, method, path, file) {
   headers$`X-Auth-Token` <- authInfo$token
   headers$`X-Auth-Signature` <- signature
   headers$`X-Content-Checksum` <- md5
+  headers$Digest <- fileDigestHeader(file)
   headers
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -237,3 +237,20 @@ fileMD5.as.string <- function(path) {
 md5.as.string <- function(md5) {
   paste(md5, collapse = "")
 }
+
+# Returns a valid RFC3230 "Digest" header with an SHA-256 checksum for the given
+# path. Note that the digest output is base64-encoded in the header, as per RFC
+# 3230.
+#
+# SHA-256 has the advantage of working on FIPS-compliant systems, while MD5
+# does not.
+#
+# If path is NULL, this returns the equivalent of the header for an empty file.
+fileDigestHeader <- function(path) {
+  if (is.null(path)) {
+    # Generated with openssl::base64_encode(openssl::sha256(charToRaw(""))).
+    return("sha-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=")
+  }
+  hash <- openssl::sha256(file(path))
+  sprintf("sha-256=%s", openssl::base64_encode(hash))
+}

--- a/tests/testthat/test-hashes.R
+++ b/tests/testthat/test-hashes.R
@@ -74,3 +74,19 @@ test_that("we can hash when not supplied a filename", {
   expect_equal(missingMD5, expectedMissingMD5)
   expect_type(missingMD5, "character")
 })
+
+test_that("fileDigestHeader works as expected", {
+  empty <- "sha-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
+  content <- "sha-256=Vv1RHeQlO2HoA0QIQlOk2PRSWS+0JUAcr7G6XmaAVD4="
+
+  # No content should have a well-known output.
+  header <- fileDigestHeader(emptyFile)
+  expect_equal(header, empty)
+
+  # Well-known content should have a well-known output.
+  header <- fileDigestHeader(contentsFile)
+  expect_equal(header, content)
+
+  # No filename should be like no content.
+  expect_equal(fileDigestHeader(NULL), fileDigestHeader(emptyFile))
+})


### PR DESCRIPTION
MD5 checksums are not all that secure, and cause problems on FIPS-compliant systems in particular, so we'd ideally move to SHA-256. This is tracked already in #363.

In order to someday deprecate the use of MD5 while also continuing to work with older versions of Connect that may require it, we have two broad options:

1. Determine whether the upstream server supports another checksum mechanism, likely by checking its version; or

2. Keep the existing checksum support in place but send an additional non-MD5 checksum for use by servers that support it.

This commit implements the second approach: we send an additional header with a SHA-256 checksum in addition to the existing MD5 one. Rather than use another custom header, I've opted to use the `Digest` header specified in RFC 3230, which is consistent with the semantics we're after anyway.

Unit tests are included but I have not done any end-to-end testing, hence the draft status.