### PR TITLE
Bump the minimum `openssl` package version in the DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     curl,
     digest,
     jsonlite,
-    openssl,
+    openssl (>= 2.0.0),
     packrat (>= 0.6),
     rstudioapi (>= 0.5),
     tools,

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 ## 0.8.26 (in development)
 
 * Allow ShinyApps deployments to be private at creation time (#403)
+* Update the minimum `openssl` version to 2.0.0 to enable publishing for users
+  on FIPS-compliant systems without the need for API keys. (#452)
 
 ## 0.8.25
 


### PR DESCRIPTION
The 2.0.0 release contains a change that fixes publishing on FIPS systems, so requiring this minimum version should insulate users from this issue on new installs. See #452 for discussion.

Fixes #452 and #489.