### PR TITLE
Check RETICULATE_PYTHON_FALLBACK and use in manifest

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -62,9 +62,10 @@
 #'   `getOption("rsconnect.force.update.apps", FALSE)`.
 #' @param python Full path to a python binary for use by `reticulate`.
 #'   Required if `reticulate` is a dependency of the app being deployed.
-#'   If python = NULL, and RETICULATE_PYTHON is set in the environment, its
-#'   value will be used. The specified python binary will be invoked to determine
-#'   its version and to list the python packages installed in the environment.
+#'   If python = NULL, and RETICULATE_PYTHON or RETICULATE_PYTHON_FALLBACK is 
+#'   set in the environment, its value will be used. The specified python binary 
+#'   will be invoked to determine its version and to list the python packages 
+#'   installed in the environment.
 #' @param forceGeneratePythonEnvironment Optional. If an existing
 #'   `requirements.txt` file is found, it will be overwritten when this argument
 #'   is `TRUE`.
@@ -499,7 +500,8 @@ deployApp <- function(appDir = getwd(),
 
 getPython <- function(path) {
   if (is.null(path)) {
-    path <- Sys.getenv("RETICULATE_PYTHON")
+    path <- Sys.getenv("RETICULATE_PYTHON", 
+                       unset=Sys.getenv("RETICULATE_PYTHON_FALLBACK"))
     if (path == "") {
       return(NULL)
     }

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -501,7 +501,7 @@ deployApp <- function(appDir = getwd(),
 getPython <- function(path) {
   if (is.null(path)) {
     path <- Sys.getenv("RETICULATE_PYTHON", 
-                       unset=Sys.getenv("RETICULATE_PYTHON_FALLBACK"))
+                       unset = Sys.getenv("RETICULATE_PYTHON_FALLBACK"))
     if (path == "") {
       return(NULL)
     }

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -104,9 +104,10 @@ asking. If \code{FALSE}, ask to update. If unset, defaults to the value of
 
 \item{python}{Full path to a python binary for use by \code{reticulate}.
 Required if \code{reticulate} is a dependency of the app being deployed.
-If python = NULL, and RETICULATE_PYTHON is set in the environment, its
-value will be used. The specified python binary will be invoked to determine
-its version and to list the python packages installed in the environment.}
+If python = NULL, and RETICULATE_PYTHON or RETICULATE_PYTHON_FALLBACK is
+set in the environment, its value will be used. The specified python binary
+will be invoked to determine its version and to list the python packages
+installed in the environment.}
 
 \item{on.failure}{Function to be called if the deployment fails. If a
 deployment log URL is available, it's passed as a parameter.}

--- a/man/deploySite.Rd
+++ b/man/deploySite.Rd
@@ -58,9 +58,10 @@ record. These fields will be returned on subsequent calls to
 
 \item{python}{Full path to a python binary for use by \code{reticulate}.
 Required if \code{reticulate} is a dependency of the app being deployed.
-If python = NULL, and RETICULATE_PYTHON is set in the environment, its
-value will be used. The specified python binary will be invoked to determine
-its version and to list the python packages installed in the environment.}
+If python = NULL, and RETICULATE_PYTHON or RETICULATE_PYTHON_FALLBACK is
+set in the environment, its value will be used. The specified python binary
+will be invoked to determine its version and to list the python packages
+installed in the environment.}
 
 \item{...}{Additional arguments to \code{\link[=deployApp]{deployApp()}}. Do not supply \code{appDir},
 \code{appFiles}, or \code{appSourceDoc}; these three parameters are automatically

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -306,10 +306,19 @@ test_that("getPython handles null python by checking RETICULATE_PYTHON", {
   Sys.unsetenv("RETICULATE_PYTHON")
 })
 
-test_that("getPython handles null python and empty RETICULATE_PYTHON", {
+test_that("getPython handles null python and empty RETICULATE_PYTHON by checking RETICULATE_PYTHON_FALLBACK", {
   skip_on_cran()
 
   Sys.unsetenv("RETICULATE_PYTHON")
+  Sys.setenv(RETICULATE_PYTHON_FALLBACK="/usr/local/bin/python")
+  expect_equal(getPython(NULL), "/usr/local/bin/python")
+})
+
+test_that("getPython handles null python, empty RETICULATE_PYTHON, and empty RETICULATE_PYTHON_FALLBACK", {
+  skip_on_cran()
+
+  Sys.unsetenv("RETICULATE_PYTHON")
+  Sys.unsetenv("RETICULATE_PYTHON_FALLBACK")
   expect_equal(getPython(NULL), NULL)
 })
 


### PR DESCRIPTION
....when `RETICULATE_PYTHON` unset

Addresses [rstudio#10736](https://github.com/rstudio/rstudio/issues/10736) and [connect#20879](https://github.com/rstudio/connect/issues/20879)

Tested by deploying site after rebuilding `rsconnect` package.

Deploy logs show: 
```
[Connect] 2022/03/10 22:00:10.777366461 [rsc-quarto] Using Python binary: /opt/Python/3.9.7/bin/python3.9
[Connect] 2022/03/10 22:00:10.777405223 [rsc-quarto] Configuring PATH from /opt/Python/3.9.7/bin/python3.9: /opt/Python/3.9.7/bin:/opt/R/3.6.3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
[Connect] 2022/03/10 22:00:10.777411676 [rsc-quarto] Using bundle Python binary: /opt/rstudio-connect/mnt/app/python/env/bin/python
[Connect] 2022/03/10 22:00:10.777779626 [rsc-quarto] Configuring PATH from /opt/rstudio-connect/mnt/app/python/env/bin/python: /opt/rstudio-connect/mnt/app/python/env/bin:/opt/Python/3.9.7/bin:/opt/R/3.6.3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
```

And manifest.json now includes: 
```
"python": {
    "version": "3.9.10",
    "package_manager": {
      "name": "pip",
      "version": "21.3.1",
      "package_file": "requirements.txt"
    }
  },
  ```