### PR TITLE
When getting Python executable, check `RETICULATE_PYTHON_FALLBACK` if `RETICULATE_PYTHON` is empty

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -501,6 +501,9 @@ getPython <- function(path) {
   if (is.null(path)) {
     path <- Sys.getenv("RETICULATE_PYTHON")
     if (path == "") {
+      path <- Sys.getenv("RETICULATE_PYTHON_FALLBACK")
+    }
+    if (path == "") {
       return(NULL)
     }
   }

--- a/rsconnect.Rproj
+++ b/rsconnect.Rproj
@@ -17,6 +17,7 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
+PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageCheckArgs: --as-cran
 PackageRoxygenize: rd,collate,namespace

--- a/rsconnect.Rproj
+++ b/rsconnect.Rproj
@@ -17,7 +17,7 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
-PackageCleanBeforeInstall: Yes
+PackageCleanBeforeInstall: No
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageCheckArgs: --as-cran
 PackageRoxygenize: rd,collate,namespace

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -306,10 +306,20 @@ test_that("getPython handles null python by checking RETICULATE_PYTHON", {
   Sys.unsetenv("RETICULATE_PYTHON")
 })
 
-test_that("getPython handles null python and empty RETICULATE_PYTHON", {
+test_that("getPython handles null python and empty RETICULATE_PYTHON by checking RETICULATE_PYTHON_FALLBACK", {
   skip_on_cran()
 
   Sys.unsetenv("RETICULATE_PYTHON")
+  Sys.setenv(RETICULATE_PYTHON_FALLBACK="/usr/local/bin/python")
+  expect_equal(getPython(NULL), "/usr/local/bin/python")
+  expect_equal(getPython(NULL), NULL)
+})
+
+test_that("getPython handles null python, empty RETICULATE_PYTHON, and empty RETICULATE_PYTHON_FALLBACK", {
+  skip_on_cran()
+
+  Sys.unsetenv("RETICULATE_PYTHON")
+  Sys.unsetenv("RETICULATE_PYTHON_FALLBACK")
   expect_equal(getPython(NULL), NULL)
 })
 


### PR DESCRIPTION
### Intent

This resolves the IDE issue https://github.com/rstudio/rstudio/issues/10736.

A change to the IDE in [src/cpp/session/modules/SessionRSConnect.cpp](https://github.com/rstudio/rstudio/blob/e1e8a2dd70868a625348355e634631414795efa9/src/cpp/session/modules/SessionRSConnect.cpp) changed the state of the environment that `rsconnect::deployApp()` runs in during push-button deployment to Connect, if `RETICULATE_PYTHON` is not set in the user's environment.

As I understand it: Previously, whatever Python was discovered would be set to `RETICULATE_PYTHON` when that function ran during push-button deployment. The recent change meant that if `RETICULATE_PYTHON` was not set by the user, the executable path would be located in the `RETICULATE_PYTHON_FALLBACK` variable instead.

The `rsconnect:::getPython()` function would only check `RETICULATE_PYTHON`, which led to deployments with manifests that didn't contain a `python` object. This resulted in different outcomes in different environments. In my local dev environment, deployment failed. On beta.rstudioconnect.com, code would run using the wrong Python.

### Approach

`rsconnect:::getPython()` will now check `RETICULATE_PYTHON_FALLBACK` if `RETICULATE_PYTHON` is empty. If `RETICULATE_PYTHON_FALLBACK` is also empty, the function returns NULL, as before.

I added one new test and modified another to account for this new behavior.

With this change, the reproducible example I attached to the IDE issue succeeds — the `manifest.json` contains the expected Python info.

### Notes

I also committed a change to `rsconnect.Rproj`. Whenever I hit "Install" in the IDE's Build tab, the IDE will modify the Rproj file to include the state of the "Clean before install" checkbox in the "Build Tools" pane of Project Options. It seems to default to "Yes", so that's what I recorded.