### PR TITLE
Remove Quarto compatibility shim code

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -222,7 +222,7 @@ enforceBundleLimits <- function(appDir, totalSize, totalFiles) {
 bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
                       contentCategory, verbose = FALSE, python = NULL,
                       condaMode = FALSE, forceGenerate = FALSE, quarto = NULL,
-                      serverRender = FALSE, isShinyApps = FALSE) {
+                      serverRender = NULL, isShinyApps = FALSE) {
   logger <- verboseLogger(verbose)
 
   logger("Inferring App mode and parameters")
@@ -258,9 +258,9 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
       appPrimaryDoc = appPrimaryDoc)
   on.exit(unlink(bundleDir, recursive = TRUE), add = TRUE)
 
-  # if this is quarto then disable server rendering if requested
-  if (!is.null(quarto) && !serverRender && getOption("rsconnect.server.noprerender", TRUE)) {
-    logger("Disabling server render for Quarto interactive document")
+  # disable server rendering if requested
+  if (isFALSE(serverRender)) {
+    logger("Disabling server rendering for interactive document")
     disablePrerender <- c(
       '### QUARTO: Disable Server Render',
       'Sys.setenv(RMARKDOWN_RUN_PRERENDER = "0")',
@@ -271,33 +271,6 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
       write(disablePrerender, file = rProfile, sep = "\n", append = TRUE)
     } else {
       writeLines(disablePrerender, rProfile, useBytes = TRUE)
-    }
-  }
-
-  # if this is quarto-shiny and there is no "runtime" yaml then inject it
-  # (provides compatibility w/ server: shiny)
-  if (appMode == "quarto-shiny" && getOption("rsconnect.server.qmd.compatibility", TRUE)) {
-    # rename appPrimaryDoc to use .Rmd extension
-    if (tolower(tools::file_ext(appPrimaryDoc)) == "qmd") {
-      renamedAppPrimaryDoc <- paste0(file_path_sans_ext(appPrimaryDoc), ".Rmd")
-      file.rename(
-        file.path(bundleDir, appPrimaryDoc),
-        file.path(bundleDir, renamedAppPrimaryDoc)
-      )
-      appPrimaryDoc <- renamedAppPrimaryDoc
-    }
-  }
-
-  # provide runtime: shinyrmd if necessary
-  if (appMode == "quarto-shiny" && getOption("rsconnect.server.yaml.compatibility", TRUE)) {
-    srcPath <- file.path(bundleDir, appPrimaryDoc)
-    yaml <- rmarkdown::yaml_front_matter(srcPath)
-    if (is.null(yaml$runtime)) {
-      opts = options(encoding = "native.enc")
-      on.exit(options(opts), add = TRUE)
-      src <- readLines(srcPath, encoding = "UTF-8", warn = FALSE)
-      src <- c("---", "runtime: shinyrmd", src[-1])
-      writeLines(enc2utf8(src), srcPath, useBytes = TRUE)
     }
   }
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -222,7 +222,7 @@ enforceBundleLimits <- function(appDir, totalSize, totalFiles) {
 bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
                       contentCategory, verbose = FALSE, python = NULL,
                       condaMode = FALSE, forceGenerate = FALSE, quarto = NULL,
-                      serverRender = NULL, isShinyApps = FALSE) {
+                      isShinyApps = FALSE) {
   logger <- verboseLogger(verbose)
 
   logger("Inferring App mode and parameters")
@@ -257,22 +257,6 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
       appFiles = appFiles,
       appPrimaryDoc = appPrimaryDoc)
   on.exit(unlink(bundleDir, recursive = TRUE), add = TRUE)
-
-  # disable server rendering if requested
-  if (isFALSE(serverRender)) {
-    logger("Disabling server rendering for interactive document")
-    disablePrerender <- c(
-      '### QUARTO: Disable Server Render',
-      'Sys.setenv(RMARKDOWN_RUN_PRERENDER = "0")',
-      '###'
-    )
-    rProfile <- file.path(bundleDir, ".Rprofile")
-    if (file.exists(rProfile)) {
-      write(disablePrerender, file = rProfile, sep = "\n", append = TRUE)
-    } else {
-      writeLines(disablePrerender, rProfile, useBytes = TRUE)
-    }
-  }
 
   # generate the manifest and write it into the bundle dir
   logger("Generate manifest.json")

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -387,9 +387,7 @@ deployApp <- function(appDir = getwd(),
       bundlePath <- bundleApp(target$appName, appDir, appFiles,
                               appPrimaryDoc, assetTypeName, contentCategory, verbose, python,
                               condaMode, forceGeneratePythonEnvironment,
-                              quarto,
-                              isTRUE(metadata$serverRender),
-                              isShinyapps(accountDetails$server))
+                              quarto, isShinyapps(accountDetails$server))
 
       if (isShinyapps(accountDetails$server)) {
 

--- a/rsconnect.Rproj
+++ b/rsconnect.Rproj
@@ -17,6 +17,7 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
+PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageCheckArgs: --as-cran
 PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
### Intent

Remove most of the Quarto compatibility shim code from `rsconnect`.

### Approach

I tested the current `main` version of `rsconnect` with some Shiny Quarto content, deploying both to ShinyApps.io and to local Connect instances which did not have prerendering enabled. The results of those tests are in a table at the bottom of this PR. They indicate that deploying things along with HTML makes deployments succeed everywhere — compatibility shim code seems not to make much of a difference.

~In this PR, I left a hook for `quarto::quarto_publish_app()` to alter server rendering behavior by passing in a `serverRender` boolean on its `metadata` list. I tested the effects of that property across all versions too — that table is included below.~ The `serverRender` metadata property now has no effect, as of [this commit](https://github.com/rstudio/rsconnect/pull/571/commits/49e3038d933194f4ec8e1b61ebf33bcb62e146ed).

### Open Question

The `quarto_publish_app()` function still has a `render` function that is specified as `render = c("local", "server", "none")`. The documentation for this parameter says:

```r
#' @param render `local` to render locally before publishing; `server` to
#'   render on the server; `none` to use whatever rendered content currently
#'   exists locally. (defaults to `local`)
```

This is inherited from `quarto_publish_doc`, for which it is correct. But this isn't how `render = "server"` works for apps published to Connect. Passing in `render = "local"` does run a local render before uploading, but the whole directory is passed to `rsconnect::deployApp()`, and Connect will regenerate the html, so without the shim code, publishing to Connect, this option doesn't really do anything.

At some point, we should submit a PR to `quarto-r` to remove [this line](https://github.com/quarto-dev/quarto-r/blob/e06d0967033346ffd700b2e43f249aa4deb49893/R/publish.R#L173), as the `serverRender` property on metadata doesn't do anything any more. However, its presence doesn't do anything bad.

### Automated Tests

No unit tests were changed yet. I'm going to let CI run before I do that. I don't think any tests exercised those compatibility options, so I don't think anything will need to be changed, but I'm not 100% sure of that.

### Appendix: Tables

The following table shows tests of the `main` version of `rsconnect`, varying compatibility shim options and the inclusion of the HTML.

version | compat_opts | include_html | run_success
-- | -- | -- | --
2021.08.2 | FALSE | FALSE | TRUE
2021.09.0 | FALSE | FALSE | TRUE
2021.10.0 | FALSE | FALSE | TRUE
2021.11.1 | FALSE | FALSE | FALSE
2021.12.0 | FALSE | FALSE | FALSE
2022.02.2 | FALSE | FALSE | FALSE
cloud | FALSE | FALSE | FALSE
2021.08.2 | FALSE | TRUE | TRUE
2021.09.0 | FALSE | TRUE | TRUE
2021.10.0 | FALSE | TRUE | TRUE
2021.11.1 | FALSE | TRUE | TRUE
2021.12.0 | FALSE | TRUE | TRUE
2022.02.2 | FALSE | TRUE | TRUE
cloud | FALSE | TRUE | TRUE
2021.08.2 | TRUE | FALSE | FALSE
2021.09.0 | TRUE | FALSE | FALSE
2021.10.0 | TRUE | FALSE | FALSE
2021.11.1 | TRUE | FALSE | FALSE
2021.12.0 | TRUE | FALSE | FALSE
2022.02.2 | TRUE | FALSE | FALSE
cloud | TRUE | FALSE | FALSE
2021.08.2 | TRUE | TRUE | TRUE
2021.09.0 | TRUE | TRUE | TRUE
2021.10.0 | TRUE | TRUE | TRUE
2021.11.1 | TRUE | TRUE | TRUE
2021.12.0 | TRUE | TRUE | TRUE
2022.02.2 | TRUE | TRUE | TRUE
cloud | TRUE | TRUE | TRUE

This table shows the results after removing the shim code.

version | include_html | run_success
-- | -- | --
2021.08.2 | FALSE | TRUE*
2021.09.0 | FALSE | TRUE*
2021.10.0 | FALSE | TRUE*
2021.11.1 | FALSE | FALSE
2021.12.0 | FALSE | FALSE
2022.02.2 | FALSE | FALSE
2021.08.2 | TRUE | TRUE
2021.09.0 | TRUE | TRUE
2021.10.0 | TRUE | TRUE
2021.11.1 | TRUE | TRUE
2021.12.0 | TRUE | TRUE
2022.02.2 | TRUE | TRUE

*Render finished but output was formatted incorrectly.

Basically, without the shim code, you must include the HTML to guarantee success for Shiny Quarto documents on all versions tested. Rendering passed my test function on 2021.08.2, 2021.09.0, 2021.10.0, which just checks for the presence of the content title, but upon visual inspection, the results were rendered incorrectly, because the .qmd is just parsed as an R Markdown file (I think) which ignores chunk options because of syntax differences between the two formats.

So, our guidance should be — if you're on one of these versions of Connect, Shiny+Quarto content must be deployed with the HTML included for correct results.