### PR TITLE
Skip R packages for Jupyter-only Quarto content

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -779,13 +779,21 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
       !identical(appMode, "tensorflow-saved-model")) {
 
     # detect dependencies including inferred dependencies
-    inferredDependencies <- inferRPackageDependencies(
+    inferredRDependencies <- inferRPackageDependencies(
       appMode = appMode,
       hasParameters = hasParameters,
       documentsHavePython = documentsHavePython,
       quartoInfo = quartoInfo
     )
-    deps = snapshotDependencies(appDir, inferredDependencies, verbose = verbose)
+
+    # Skip snapshotting R dependencies if an app only uses Python and does not use R.
+    if (appUsesPython(quartoInfo) && !appUsesR(quartoInfo)) {
+      deps <- data.frame()
+    } else {
+      # Some dependencies seem to be found based on the presence of Bioconductor
+      # packages in the user's environment.
+      deps <- snapshotRDependencies(appDir, inferredRDependencies, verbose = verbose)
+    }
 
     # construct package list from dependencies
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -247,7 +247,7 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
       appPrimaryDoc = appPrimaryDoc,
       appMode = appMode,
       contentCategory = contentCategory)
-  documentsHavePython <- anyDocumentsHavePythonChunks(
+  documentsHavePython <- detectPythonInDocuments(
       appDir = appDir,
       files = appFiles)
 
@@ -422,7 +422,7 @@ writeManifest <- function(appDir = getwd(),
       appPrimaryDoc = appPrimaryDoc,
       appMode = appMode,
       contentCategory = contentCategory)
-  documentsHavePython <- anyDocumentsHavePythonChunks(
+  documentsHavePython <- detectPythonInDocuments(
       appDir = appDir,
       files = appFiles)
 
@@ -493,7 +493,7 @@ documentHasPythonChunk <- function(filename) {
   return (length(matches) > 0)
 }
 
-anyDocumentsHavePythonChunks <- function(appDir, files) {
+detectPythonInDocuments <- function(appDir, files) {
   rmdFiles <- grep("^[^/\\\\]+\\.[rq]md$", files, ignore.case = TRUE, perl = TRUE,
                    value = TRUE)
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -786,13 +786,13 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
       quartoInfo = quartoInfo
     )
 
-    # Skip snapshotting R dependencies if an app only uses Python and does not use R.
-    if (appUsesPython(quartoInfo) && !appUsesR(quartoInfo)) {
-      deps <- data.frame()
-    } else {
-      # Some dependencies seem to be found based on the presence of Bioconductor
-      # packages in the user's environment.
+    # Skip snapshotting R dependencies if an app does not use R. Some
+    # dependencies seem to be found based on the presence of Bioconductor
+    # packages in the user's environment.
+    if (appUsesR(quartoInfo)) {
       deps <- snapshotRDependencies(appDir, inferredRDependencies, verbose = verbose)
+    } else {
+      deps <- data.frame()
     }
 
     # construct package list from dependencies

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -855,7 +855,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
       pyInfo$package_manager$contents <- NULL
     }
     else {
-      errorMessages <- c(errorMessages, paste("Error detecting python for reticulate:", pyInfo$error))
+      errorMessages <- c(errorMessages, paste("Error detecting python environment:", pyInfo$error))
     }
   }
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -838,17 +838,27 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
     }
   }
   if (length(packageMessages)) {
-    # Advice to help resolve installed packages that are not available using the current set of
-    # configured repositories. Each package with a missing repository has already been printed (see
-    # snapshotDependencies).
+    # Advice to help resolve installed packages that are not available using the
+    # current set of configured repositories. Each package with a missing
+    # repository has already been printed (see snapshotDependencizes).
     #
-    # This situation used to trigger an error (halting deployment), but was softened because:
-    #   * CRAN-archived packages are not visible to our available.packages scanning.
-    #   * Source-installed packages may be available after a manual server-side installation.
+    # This situation used to trigger an error (halting deployment), but was
+    # softened because:
+    #   * CRAN-archived packages are not visible to our available.packages
+    #     scanning.
+    #   * Source-installed packages may be available after a manual server-side
+    #     installation.
     #
-    # That said, an incorrectly configured "repos" option is almost always the cause.
+    # That said, an incorrectly configured "repos" option is almost always the
+    # cause.
     packageMessages <- c(packageMessages,
-                         "Unable to determine the source location for some packages. Packages should be installed from a package repository like CRAN or a version control system. Check that options('repos') refers to a package repository containing the needed package versions.")
+                         paste0(
+                           "Unable to determine the source location for some packages. ",
+                           "Packages should be installed from a package repository like ",
+                           "CRAN or a version control system. Check that ",
+                           "options('repos') refers to a package repository containing ",
+                           "the needed package versions."
+                         ))
     warning(paste(formatUL(packageMessages, '\n*'), collapse = '\n'), call. = FALSE, immediate. = TRUE)
   }
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -48,7 +48,7 @@ appDependencies <- function(appDir = getwd(), appFiles=NULL) {
   }
   bundleDir <- bundleAppDir(appDir, appFiles)
   on.exit(unlink(bundleDir, recursive = TRUE), add = TRUE)
-  deps <- snapshotDependencies(bundleDir)
+  deps <- snapshotRDependencies(bundleDir)
   data.frame(package = deps[,"Package"],
              version = deps[,"Version"],
              source = deps[,"Source"],
@@ -56,7 +56,7 @@ appDependencies <- function(appDir = getwd(), appFiles=NULL) {
              stringsAsFactors=FALSE)
 }
 
-snapshotDependencies <- function(appDir, implicit_dependencies=c(), verbose = FALSE) {
+snapshotRDependencies <- function(appDir, implicit_dependencies=c(), verbose = FALSE) {
 
   # create a packrat "snapshot"
 

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -525,7 +525,7 @@ test_that("writeManifest: Quarto R + Python website includes quarto and python i
   expect_true("reticulate" %in% names(manifest$packages))
 })
 
-test_that("writeManifest: Quarto Python-only website lists jupyter as its engine", {
+test_that("writeManifest: Quarto Python-only website gets correct manifest data", {
   quarto <- quartoPathOrSkip()
   python <- Sys.which("python")
   skip_if(python == "", "python is not installed")
@@ -537,6 +537,7 @@ test_that("writeManifest: Quarto Python-only website lists jupyter as its engine
   expect_equal(manifest$quarto$engines, "jupyter")
   expect_equal(manifest$metadata$primary_rmd, "index.qmd")
 
+  # We expect Quarto and Python metadata, but no R packages.
   expect_true(all(c("quarto", "python") %in% names(manifest)))
-  # Once implemented, we should check for manifest$packages being null
+  expect_null(manifest$packages)
 })


### PR DESCRIPTION
## Intent

In https://github.com/rstudio/rsconnect/pull/572, Jupyter-only Quarto content incorrectly receives R package dependencies. This PR addresses that issue.

## Approach

The R package dependencies stem from `rsconnect` thinking that, because the Package contains Python chunks in an `.[R|q]md` file, it must require `reticulate`.

In reality, Quarto determines the execution engine on a file-by-file basis. By default, if a document has only Python chunks, it'll use `jupyter`, and if it has R alone or R + Python, it'll use `reticulate`. Users can also force a specific engine in YAML front matter.

`rsconnect` checks for Python Rmds in a small function, `appHasPythonRmd`. We only have Quarto engine info at the project level, and I wanted to avoid adding complexity by attempting to duplicate Quarto's engine binding rules in one conditional fork of that function. Instead, the code used a simpler heuristic: `appHasPythonRmd` will return `FALSE` if `quartoInfo$engines` includes `jupyter` and does not include `knitr`.

- This solves the problem of adding R `packages` in `jupyter`-only Quarto projects.
- This does not solve the problem of adding a `reticulate` dependency in `knitr` + `jupyter` Quarto projects where `knitr` does not execute Python code. However, this is probably somewhat of an edge case, should not cause major issues with environment restoration, and solving it would require either a `quarto` dependency of some sort or really brittle code trying to re-implement Quarto behavior.

This changed meant that I had to move where `pyInfo` is gathered and added to the `manifest` object in `createAppManifest`. Previously, it occurred when looping over the `packrat` snapshot, if the name of the current package was `reticulate`. This meant that `jupyter`-only Quarto projects didn't get `python` information. Now, it occurs after the loop, if `reticulate` is among the packages or if `jupyter` is among Quarto engines.

## Automated Tests

- The final tests in `test-bundle.R` were modified to cover this functionality. 
 
## QA Notes

The code changes in this bundle are localized within `bundle.R`, but affect `writeManifest()` and `deployApp()`. however, the changes in those workflows are identical changes to duplicated code. I *think* it's reasonable to focus on testing `writeManifest()`.

The only changes this PR should see from the initial PR with `writeManifest()` Quarto support  (https://github.com/rstudio/rsconnect/pull/572) is that manifests for Python-only Quarto content should not contain a `packages` object. This in turn should mean that deploying that content to Connect should not require an R environment restore.

No changes should occur in other Quarto content (with the `knitr` engine). No changes should occur to other `reticulated` Python content.

### Testing `writeManifest` changes

You can use the method I described in the prior PR (https://github.com/rstudio/rsconnect/pull/572) to diff changes between versions. You can work with content from the `tests/testthat` directory of this repo, but because you'll want to compare between different branches of this repo, it's easier to copy it to a new directory. I compressed what I think are the relevant subset of those items here: [qa-content.zip](https://github.com/rstudio/rsconnect/files/8383021/qa-content.zip)

1. Extract those items to a new directory. In a terminal, `cd` to that directory and run `git init`. I'll refer to this directory as `qa-content`.
2. Install the version of `rsconnect` from the previous PR (https://github.com/rstudio/rsconnect/pull/572). To do so, open the project in the RStudio IDE, and click the "Install" button in the "Build" tab of the top right pane.
3. In the terminal in `qa-content`, open a new R session. Run the following to write manifests:

```r
# If quarto::quarto_path() doesn't find Quarto, you need to use the IDE quarto
QUARTO_PATH <- "/Applications/RStudio.app/Contents/MacOS/quarto/bin/quarto"
PYTHON <- Sys.which("python")

rsconnect::writeManifest("quarto-doc-none", quarto = QUARTO_PATH)
rsconnect::writeManifest("quarto-proj-r-shiny", quarto = QUARTO_PATH)
rsconnect::writeManifest("quarto-website-py", quarto = QUARTO_PATH, python = PYTHON)
rsconnect::writeManifest("quarto-website-r", quarto = QUARTO_PATH)
rsconnect::writeManifest("quarto-website-r-py", quarto = QUARTO_PATH, python = PYTHON)
rsconnect::writeManifest("shiny-rmds")
rsconnect::writeManifest("shinyapp-simple")
# You'll need RETICULATE_PYTHON configured for this one.
rsconnect::writeManifest("test-reticulate-rmds", , python = PYTHON)
rsconnect::writeManifest("test-rmd-bad-case")
rsconnect::writeManifest("test-rmds")
```

Commit the manifests in this directory.

4. Install _this_ build of `rsconnect. Check out this branch of that repo, and repeat step 2.
5. Start a new R session in `qa-content`. Run the same R commands.
6. Use `git diff` to inspect the changes.

#### Expected changes

- The only change you should see is that `quarto-website-py` should lose its unnecessary `packages` object.
- You should be able to successfully deploy content to RStudio Connect by calling `deployApp()` with the same arguments as `rsconnect` is called above.

### Testing `deployApp` changes

In the directory of content you created above, run the following from an R session.

```r
# Assuming you have a server named "localhost" configured in the IDE / in the rsconnect package
server <- "localhost"

rsconnect::deployApp("quarto-website-py", quarto = quarto::quarto_path(), server = server)
```

This content shouldn't see an R environment restore when deployed with this branch.

The following content items should still see an R environment restore.

```r
# If quarto::quarto_path() doesn't find Quarto, you need to use the IDE quarto
QUARTO_PATH <- "/Applications/RStudio.app/Contents/MacOS/quarto/bin/quarto"

# Assuming you have a server named "localhost" configured in the IDE / in the rsconnect package
server <- "localhost"

rsconnect::deployApp("quarto-proj-r-shiny", quarto = QUARTO_PATH, server = server)
rsconnect::deployApp("quarto-website-r", quarto = QUARTO_PATH, server = server)
rsconnect::deployApp("quarto-website-r-py", quarto = QUARTO_PATH, server = server)
rsconnect::deployApp("shiny-rmds", server = server)
rsconnect::deployApp("shinyapp-simple", server = server)
# You'll need RETICULATE_PYTHON configured for this one, server = server.
rsconnect::deployApp("test-reticulate-rmds", python = Sys.getenv("RETICULATE_PYTHON"), server = server)
rsconnect::deployApp("test-rmd-bad-case", server = server)
rsconnect::deployApp("test-rmds", server = server)
```