### PR TITLE
Fix `deployApp` -> `bundleApp` ignoring metadata for quarto purposes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,11 @@
 * Allow ShinyApps deployments to be private at creation time (#403)
 * Update the minimum `openssl` version to 2.0.0 to enable publishing for users
   on FIPS-compliant systems without the need for API keys. (#452)
+* Added Quarto support to `writeManifest`, which requires passing the absolute
+  path to a Quarto executable to its new `quarto` parameter
+* Added `quarto` parameter to `deployApp` to enable deploying Quarto documents
+  and websites by supplying the path to a Quarto executable
+* Added support for deploying Quarto content that uses only the `jupyter` runtime
 
 ## 0.8.25
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -405,7 +405,7 @@ writeManifest <- function(appDir = getwd(),
     appDir = appDir,
     appPrimaryDoc = appPrimaryDoc,
     quarto = quarto,
-    metadata = NULL
+    metadata = list()
   )
 
   appMode <- inferAppMode(
@@ -1170,9 +1170,9 @@ quartoInspect <- function(appDir = NULL, appPrimaryDoc = NULL, quarto = NULL) {
 
 # Attempt to gather Quarto version and engines, first from quarto inspect if a
 # quarto executable is provided, and then from metadata.
-inferQuartoInfo <- function(appDir, appPrimaryDoc, quarto, metadata = NULL) {
+inferQuartoInfo <- function(appDir, appPrimaryDoc, quarto, metadata = list()) {
   quartoInfo <- NULL
-  if (!is.null(metadata)) {
+  if (!is.null(metadata$quarto_version)) {
     # Prefer metadata, because that means someone already ran quarto inspect
     quartoInfo <- list(
       "version" = metadata[["quarto_version"]],

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -1170,7 +1170,7 @@ quartoInspect <- function(appDir = NULL, appPrimaryDoc = NULL, quarto = NULL) {
 
 # Attempt to gather Quarto version and engines, first from quarto inspect if a
 # quarto executable is provided, and then from metadata.
-inferQuartoInfo <- function(appDir, appPrimaryDoc, quarto, metadata = list()) {
+inferQuartoInfo <- function(appDir, appPrimaryDoc, quarto, metadata) {
   quartoInfo <- NULL
   if (!is.null(metadata$quarto_version)) {
     # Prefer metadata, because that means someone already ran quarto inspect

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -229,7 +229,7 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
     appDir = appDir,
     appPrimaryDoc = appPrimaryDoc,
     quarto = quarto,
-    metadata = NULL
+    metadata = metadata
   )
 
   logger("Inferring App mode and parameters")


### PR DESCRIPTION
### Intent

Fixes a bug in the `deployApp()` -> `bundleApp()` call chain — a copy-paste error with shared code used by `writeManifest()`. The bug caused Quarto deployments using `metadata` to succeed with the wrong app-mode.

### Approach

- Correctly passed the received metadata into the function in the `deployApp()` call.
    - The root cause of this bug was copying and pasting the *mostly-but-not-entirely* shared code into `bundleApp()` from `writeManifest()`, combined with the lack of tests for `deployApp()` and `bundleApp()`.
- Changed the way that the `inferQuartoInfo()` function detects Quarto information in metadata, to make it work properly with metadata that doesn't have Quarto information but is not `NULL`.
- Changed the default empty metadata value for the function to match its usage elsewhere.

### Automated Tests

There are currently, as far as I'm aware, no tests for `deployApp()` and `bundleApp()`. We should probably write some. Perhaps testing the inner `bundleApp()` would be more feasible than `deployApp()` without significant time and energy invested in test fixtures. I wanted to get this PR in quickly, but I'm open to adding test fixtures and tests before this PR merges.

### QA Notes

Install this build of `rsconnect` by checking out this branch and clicking "Install" in the IDE's "Build" tab in the top-right pane. Ensure you have the `quarto-r` package installed.

```r
remotes::install_github("quarto-dev/quarto-r")
```

Run the following code to deploy Quarto content to an RStudio instance.

```r
# Set the server variable to a server you have configured in the RStudio IDE
server <- "localhost"
quarto::quarto_publish_app("tests/testthat/quarto-website-r", server = "localhost", render = "server")
```

This should deploy with app mode `quarto-static`.

![Screen Shot 2022-04-06 at 12 23 42 PM@2x](https://user-images.githubusercontent.com/3117884/162022070-b587bfbc-5ce1-466b-9d47-573038b6b0f3.png)

Note: You should remove the `rsconnect` directory this will leave behind in the content directory. Back at the command line:

```bash
rm -r tests/testthat/quarto-website-r/rsconnect/
```