### PR TITLE
Allow selecting a target `image` in the bundle manifest

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * Added `quarto` parameter to `deployApp` to enable deploying Quarto documents
   and websites by supplying the path to a Quarto executable
 * Added support for deploying Quarto content that uses only the `jupyter` runtime
+* Added support for selecting a target `image` in the bundle manifest
 
 ## 0.8.25
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -934,7 +934,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
 
   # if there is a target image, attach it to the environment
   if (!is.null(image)) {
-    manifest$environment$image <- image
+    manifest$environment <- list(image = image)
   }
 
   # indicate whether this is a quarto app/doc

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -222,7 +222,7 @@ enforceBundleLimits <- function(appDir, totalSize, totalFiles) {
 bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
                       contentCategory, verbose = FALSE, python = NULL,
                       condaMode = FALSE, forceGenerate = FALSE, quarto = NULL,
-                      isShinyApps = FALSE, metadata = list()) {
+                      isShinyApps = FALSE, metadata = list(), image = NULL) {
   logger <- verboseLogger(verbose)
 
   quartoInfo <- inferQuartoInfo(
@@ -282,6 +282,7 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
       retainPackratDirectory = TRUE,
       quartoInfo = quartoInfo,
       isShinyApps = isShinyApps,
+      image = image,
       verbose = verbose)
   manifestJson <- enc2utf8(toJSON(manifest, pretty = TRUE))
   manifestPath <- file.path(bundleDir, "manifest.json")
@@ -380,6 +381,10 @@ detectLongNames <- function(bundleDir, lengthLimit = 32) {
 #'   content. The provided Quarto binary will be used to run `quarto inspect`
 #'   to gather information about the content.
 #'
+#' @param image Optional. The name of the image to use when building and
+#'   executing this content. If none is provided, RStudio Connect will
+#'   attempt to choose an image based on the content requirements.
+#'
 #' @param verbose If TRUE, prints progress messages to the console
 #'
 #'
@@ -391,6 +396,7 @@ writeManifest <- function(appDir = getwd(),
                           python = NULL,
                           forceGeneratePythonEnvironment = FALSE,
                           quarto = NULL,
+                          image = NULL,
                           verbose = FALSE) {
 
   condaMode <- FALSE
@@ -451,6 +457,7 @@ writeManifest <- function(appDir = getwd(),
       retainPackratDirectory = FALSE,
       quartoInfo = quartoInfo,
       isShinyApps = FALSE,
+      image = image,
       verbose = verbose)
   manifestJson <- enc2utf8(toJSON(manifest, pretty = TRUE))
   manifestPath <- file.path(appDir, "manifest.json")
@@ -763,6 +770,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
                               retainPackratDirectory = TRUE,
                               quartoInfo = NULL,
                               isShinyApps = FALSE,
+                              image = NULL,
                               verbose = FALSE) {
 
   # provide package entries for all dependencies
@@ -853,7 +861,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
     warning(paste(formatUL(packageMessages, '\n*'), collapse = '\n'), call. = FALSE, immediate. = TRUE)
   }
 
-  needsPyInfo <- appUsesPython(quartoInfo) || "reticulate" %in% names(packages) 
+  needsPyInfo <- appUsesPython(quartoInfo) || "reticulate" %in% names(packages)
   if (needsPyInfo && !is.null(python)) {
     pyInfo <- inferPythonEnv(appDir, python, condaMode, forceGenerate)
     if (is.null(pyInfo$error)) {
@@ -923,6 +931,11 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
 
   # add metadata
   manifest$metadata <- metadata
+
+  # if there is a target image, attach it to the environment
+  if (!is.null(image)) {
+    manifest$environment$image <- image
+  }
 
   # indicate whether this is a quarto app/doc
   if (!is.null(quartoInfo) && !isShinyApps) {

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -62,9 +62,9 @@
 #'   `getOption("rsconnect.force.update.apps", FALSE)`.
 #' @param python Full path to a python binary for use by `reticulate`.
 #'   Required if `reticulate` is a dependency of the app being deployed.
-#'   If python = NULL, and RETICULATE_PYTHON or RETICULATE_PYTHON_FALLBACK is 
-#'   set in the environment, its value will be used. The specified python binary 
-#'   will be invoked to determine its version and to list the python packages 
+#'   If python = NULL, and RETICULATE_PYTHON or RETICULATE_PYTHON_FALLBACK is
+#'   set in the environment, its value will be used. The specified python binary
+#'   will be invoked to determine its version and to list the python packages
 #'   installed in the environment.
 #' @param forceGeneratePythonEnvironment Optional. If an existing
 #'   `requirements.txt` file is found, it will be overwritten when this argument
@@ -75,6 +75,9 @@
 #' @param appVisibility One of `NULL`, "private"`, or `"public"`; the
 #'   visibility of the deployment. When `NULL`, no change to visibility is
 #'   made. Currently has an effect only on deployments to shinyapps.io.
+#' @param image Optional. The name of the image to use when building and
+#'   executing this content. If none is provided, RStudio Connect will
+#'   attempt to choose an image based on the content requirements.
 #' @examples
 #' \dontrun{
 #'
@@ -96,7 +99,7 @@
 #'
 #' # deploy but don't launch a browser when completed
 #' deployApp(launch.browser = FALSE)
-#' 
+#'
 #' # deploy a Quarto website, using the quarto package to
 #' # find the Quarto binary
 #' deployApp("~/projects/quarto/site1", quarto = quarto::quarto_path())
@@ -127,7 +130,8 @@ deployApp <- function(appDir = getwd(),
                       python = NULL,
                       forceGeneratePythonEnvironment = FALSE,
                       quarto = NULL,
-                      appVisibility = NULL
+                      appVisibility = NULL,
+                      image = NULL
                       ) {
 
   condaMode <- FALSE
@@ -394,7 +398,7 @@ deployApp <- function(appDir = getwd(),
       bundlePath <- bundleApp(target$appName, appDir, appFiles,
                               appPrimaryDoc, assetTypeName, contentCategory, verbose, python,
                               condaMode, forceGeneratePythonEnvironment, quarto,
-                              isShinyapps(accountDetails$server), metadata)
+                              isShinyapps(accountDetails$server), metadata, image)
 
       if (isShinyapps(accountDetails$server)) {
 
@@ -505,7 +509,7 @@ deployApp <- function(appDir = getwd(),
 
 getPython <- function(path) {
   if (is.null(path)) {
-    path <- Sys.getenv("RETICULATE_PYTHON", 
+    path <- Sys.getenv("RETICULATE_PYTHON",
                        unset = Sys.getenv("RETICULATE_PYTHON_FALLBACK"))
     if (path == "") {
       return(NULL)

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -27,7 +27,8 @@ deployApp(
   python = NULL,
   forceGeneratePythonEnvironment = FALSE,
   quarto = NULL,
-  appVisibility = NULL
+  appVisibility = NULL,
+  image = NULL
 )
 }
 \arguments{
@@ -123,6 +124,10 @@ to gather information about the content.}
 
 \item{appVisibility}{One of \code{NULL}, "private"\verb{, or }"public"\verb{; the visibility of the deployment. When }NULL`, no change to visibility is
 made. Currently has an effect only on deployments to shinyapps.io.}
+
+\item{image}{Optional. The name of the image to use when building and
+executing this content. If none is provided, RStudio Connect will
+attempt to choose an image based on the content requirements.}
 }
 \description{
 Deploy a \link[shiny:shiny-package]{shiny} application, an

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -12,6 +12,7 @@ writeManifest(
   python = NULL,
   forceGeneratePythonEnvironment = FALSE,
   quarto = NULL,
+  image = NULL,
   verbose = FALSE
 )
 }
@@ -42,6 +43,10 @@ is \code{TRUE}.}
 \item{quarto}{Optional. Full path to a Quarto binary for use deploying Quarto
 content. The provided Quarto binary will be used to run \verb{quarto inspect}
 to gather information about the content.}
+
+\item{image}{Optional. The name of the image to use when building and
+executing this content. If none is provided, RStudio Connect will
+attempt to choose an image based on the content requirements.}
 
 \item{verbose}{If TRUE, prints progress messages to the console}
 }

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -9,8 +9,8 @@ makeShinyBundleTempDir <- function(appName, appDir, appPrimaryDoc, python = NULL
   bundleTempDir
 }
 
-makeManifest <- function(appDir, appPrimaryDoc, python = NULL, quarto = NULL) {
-  writeManifest(appDir, NULL, appPrimaryDoc, NULL, python = python, quarto = quarto)
+makeManifest <- function(appDir, appPrimaryDoc, python = NULL, quarto = NULL, image = NULL) {
+  writeManifest(appDir, NULL, appPrimaryDoc, NULL, python = python, quarto = quarto, image = image)
   manifestFile <-file.path(appDir, "manifest.json")
   data <- readLines(manifestFile, warn = FALSE, encoding = "UTF-8")
   manifestJson <- jsonlite::fromJSON(data)
@@ -558,4 +558,14 @@ test_that("writeManifest: Quarto Python-only website gets correct manifest data"
   # We expect Quarto and Python metadata, but no R packages.
   expect_true(all(c("quarto", "python") %in% names(manifest)))
   expect_null(manifest$packages)
+})
+
+test_that("writeManifest: Sets environment.image in the manifest if one is provided", {
+  appDir <- "quarto-proj-r-shiny"
+
+  manifest <- makeManifest(appDir, appPrimaryDoc = NULL, image = "rstudio/content-base:latest")
+  expect_equal(manifest$environment$image, "rstudio/content-base:latest")
+
+  manifest <- makeManifest(appDir, appPrimaryDoc = NULL)
+  expect_null(manifest$environment)
 })


### PR DESCRIPTION
### Approach

Updates `writeManifest` and `deployApp` with an optional `image` parameter which is used to set the `environment.image` field of the generated content manifest.

### Automated Tests

Added a new `writeManifest` testcase in `test-bundle.R` 

### QA Notes

1. `rsconnect::writeManifest(..., image = "test-image")` should generate a manifest in the bundle directory with an `environment.image` field.

```
{
  "version": 1,
  "locale": "en_US",
  "platform": "4.1.2",
  "metadata": {
    "appmode": "shiny",
    "primary_rmd": null,
    "primary_html": null,
    "content_category": null,
    "has_parameters": false
  },
  "environment": {
    "image": "test-image"
  },
...
```

Omitting the `image` parameter should generate a `manifest.json` with no `environment` field.

2. Push button deploy from the IDE should work for all R application types but will not allow you to select a target image.

3. The following functions should now accept an `image` argument to use during build/execution on the server:
`rsconnect::deployApp(..., image = "test-image")` 
`rsconnect::deployAPI(..., image = "test-image")`
`rsconnect::deployDoc(..., image = "test-image")`
`rsconnect::deploySite(..., image = "test-image")`
