### PR TITLE
support launch.browser argument in connectUser()

### DIFF
--- a/R/accounts.R
+++ b/R/accounts.R
@@ -168,6 +168,8 @@ connectUser <- function(account = NULL, server = NULL, quiet = FALSE,
 
   if (isTRUE(launch.browser))
     utils::browseURL(token$claim_url)
+  else if (is.function(launch.browser))
+    launch.browser(token$claim_url)
 
   # keep trying to authenticate until we're successful
   repeat {

--- a/R/accounts.R
+++ b/R/accounts.R
@@ -112,6 +112,10 @@ connectApiUser <- function(account = NULL, server = NULL, apiKey = NULL, quiet =
 #' manage applications on behalf of the account.
 #'
 #' @param account A name for the account to connect. Optional.
+#' @param launch.browser If true, the system's default web browser will be
+#'   launched automatically after the app is started. Defaults to `TRUE` in
+#'   interactive sessions only. If a function is passed, it will be called
+#'   after the app is started, with the app URL as a paramter.
 #' @param server The server to connect to. Optional if there is only one server
 #'   registered.
 #' @param quiet Whether or not to show messages and prompts while connecting the
@@ -126,7 +130,8 @@ connectApiUser <- function(account = NULL, server = NULL, apiKey = NULL, quiet =
 #'
 #' @family Account functions
 #' @export
-connectUser <- function(account = NULL, server = NULL, quiet = FALSE) {
+connectUser <- function(account = NULL, server = NULL, quiet = FALSE,
+                        launch.browser = getOption("rsconnect.launch.browser", interactive())) {
   # if server isn't specified, look up the default
   if (is.null(server)) {
     target <- getDefaultServer(local = TRUE)
@@ -160,7 +165,9 @@ connectUser <- function(account = NULL, server = NULL, quiet = FALSE) {
             "manually by visiting ", token$claim_url, ".")
     message("Waiting for authentication...")
   }
-  utils::browseURL(token$claim_url)
+
+  if (isTRUE(launch.browser))
+    utils::browseURL(token$claim_url)
 
   # keep trying to authenticate until we're successful
   repeat {

--- a/man/connectUser.Rd
+++ b/man/connectUser.Rd
@@ -4,7 +4,12 @@
 \alias{connectUser}
 \title{Connect User Account}
 \usage{
-connectUser(account = NULL, server = NULL, quiet = FALSE)
+connectUser(
+  account = NULL,
+  server = NULL,
+  quiet = FALSE,
+  launch.browser = getOption("rsconnect.launch.browser", interactive())
+)
 }
 \arguments{
 \item{account}{A name for the account to connect. Optional.}
@@ -14,6 +19,11 @@ registered.}
 
 \item{quiet}{Whether or not to show messages and prompts while connecting the
 account.}
+
+\item{launch.browser}{If true, the system's default web browser will be
+launched automatically after the app is started. Defaults to \code{TRUE} in
+interactive sessions only. If a function is passed, it will be called
+after the app is started, with the app URL as a paramter.}
 }
 \description{
 Connect a user account to the package so that it can be used to deploy and


### PR DESCRIPTION
When trying to connect to an RStudio Connect instance on a system with no browser available (e.g., command-line only on a cluster), the URL to visit is printed. But then `connectUser()` immediately exits when `browseURL` fails rather than waiting for `getAuthedUser()`. The result is that the user vists the URL and authenticates, making it seem like everything's ok, but the connection is not actually made.

This simply adds the ability to specify `launch.browser = FALSE` like in other functions to avoid exiting the function early.