### PR TITLE
Better support for BioConductor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
     tools,
     yaml (>= 2.1.5)
 Suggests:
+    BiocManager,
     RCurl,
     callr,
     httpuv,

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -96,10 +96,7 @@ snapshotRDependencies <- function(appDir, implicit_dependencies=c(), verbose = F
     paste0("x",grep('BioC', names(options("repos")), perl = TRUE, value = TRUE)) == "x" ) {
     
     repos <- BiocManager::repositories() 
-    } 
-
-#    biocRepos <- biocRepos[startsWith(names(biocRepos),"BioC")]    
-  
+  } 
 
   repo.packages <- available.packages(
     contriburl = contrib.url(repos, type = "source"),

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -93,7 +93,7 @@ snapshotRDependencies <- function(appDir, implicit_dependencies=c(), verbose = F
   #   * the non-existence of any bioconductor repo in the CRAN like 
   #            repo definitions 
   if (requireNamespace("BiocManager", quietly = TRUE) &&
-    !any(grepl("BioC", names(getOption("repos"))) 
+    !any(grepl("BioC", names(getOption("repos"))))) 
   {
     repos <- BiocManager::repositories() 
   } 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -93,8 +93,8 @@ snapshotRDependencies <- function(appDir, implicit_dependencies=c(), verbose = F
   #   * the non-existence of any bioconductor repo in the CRAN like 
   #            repo definitions 
   if (requireNamespace("BiocManager", quietly = TRUE) &&
-    !any(grepl("BioC", names(getOption("repos"))) {
-    
+    !any(grepl("BioC", names(getOption("repos"))) 
+  {
     repos <- BiocManager::repositories() 
   } 
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -93,7 +93,7 @@ snapshotRDependencies <- function(appDir, implicit_dependencies=c(), verbose = F
   #   * the non-existence of any bioconductor repo in the CRAN like 
   #            repo definitions 
   if ("BiocManager" %in% installed.packages() && 
-    paste0("x",grep('BioC', names(options("repos")), perl = TRUE, value = TRUE)) == "x" ) {
+    !any(grepl("BioC", names(getOption("repos"))) {
     
     repos <- BiocManager::repositories() 
   } 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -87,17 +87,20 @@ snapshotRDependencies <- function(appDir, implicit_dependencies=c(), verbose = F
     default = c("duplicates")
   )
 
-  # get Bioconductor repos if any
-  biocRepos <- repos[grep('BioC', names(repos), perl = TRUE, value = TRUE)]
-  biocPackages <- if (length(biocRepos) > 0) {
-    available.packages(
-      contriburl = contrib.url(biocRepos, type = "source"),
-      type = "source",
-      filters = filters
-    )
-  }
+  # get Bioconductor repos if aniy
+  # We detect the presence of Bioconductor reopos by 
+  #   * existence of BiocManager amongst the installed packages
+  #   * the non-existence of any bioconductor repo in the CRAN like 
+  #            repo definitions 
+  if ("BiocManager" %in% installed.packages() && 
+    paste0("x",grep('BioC', names(options("repos")), perl = TRUE, value = TRUE)) == "x" ) {
+    
+    repos <- BiocManager::repositories() 
+    } 
 
-  # read available packages
+#    biocRepos <- biocRepos[startsWith(names(biocRepos),"BioC")]    
+  
+
   repo.packages <- available.packages(
     contriburl = contrib.url(repos, type = "source"),
     type = "source",
@@ -120,14 +123,7 @@ snapshotRDependencies <- function(appDir, implicit_dependencies=c(), verbose = F
     pkg <- records[i, "Package"]
     source <- records[i, "Source"]
     repository <- NA
-    # capture Bioconcutor repository
-    if (identical(source, "Bioconductor")) {
-      if (pkg %in% biocPackages) {
-        repository <- biocPackages[pkg, 'Repository']
-      }
-    } else if (isSCMSource(source)) {
-      # leave source+SCM packages alone.
-    } else if (pkg %in% rownames(repo.packages)) {
+    if (pkg %in% rownames(repo.packages)) {
       # capture CRAN-like repository
 
       # Find this package in the set of available packages then use its

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -92,7 +92,7 @@ snapshotRDependencies <- function(appDir, implicit_dependencies=c(), verbose = F
   #   * existence of BiocManager amongst the installed packages
   #   * the non-existence of any bioconductor repo in the CRAN like 
   #            repo definitions 
-  if ("BiocManager" %in% installed.packages() && 
+  if (requireNamespace("BiocManager", quietly = TRUE) &&
     !any(grepl("BioC", names(getOption("repos"))) {
     
     repos <- BiocManager::repositories() 


### PR DESCRIPTION
Many customers have issues when publishing artefacts (mainly shiny apps) that use BioConductor packages to Connect. This comes about due to the different structure of the repository and the different commands used to install packages (e.g. `BiocManager::install()`) 

`renv` that is used by a number of users support BioConductor quite well, also when publishing to Connect. 

Users that are not using `renv` however struggle with using `rsconnect`. They have to use various workarounds, including manually setting up repositories, e.g. `options(repos=BiocManager::repositories())`, before publishing. 

This PR is bringing more native support for BioConductor repositories to Connect. 

The approach is:

If `BiocManager` is installed and `Bioc*` repositories are not set manually, it will add the repositories automatically. 

The subsequent algorithm of extracting repository and source information of packages is becoming much simpler as a consequence.  