### PR TITLE
Add option to select `tar` implementation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@
   and websites by supplying the path to a Quarto executable
 * Added support for deploying Quarto content that uses only the `jupyter` runtime
 * Added support for selecting a target `image` in the bundle manifest
+* Added the `rsconnect.tar` option, which can be used to specify the path to a
+  `tar` implementation instead of R's internal implementation. The previous
+  method, using the `RSCONNECT_TAR` environment variable, still works, and will
+  take precedence over the `rsconnect.tar` option.
 
 ## 0.8.25
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,8 +14,8 @@
 * The `showLogs` function takes a `server` parameter. (#57)
 * Added the `rsconnect.tar` option, which can be used to specify the path to a
   `tar` implementation instead of R's internal implementation. The previous
-  method, using the `RSCONNECT_TAR` environment variable, still works, and will
-  take precedence over the `rsconnect.tar` option.
+  method, using the `RSCONNECT_TAR` environment variable, still works, but the
+  new option will take precedence if both are set.
 
 ## 0.8.25
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -320,11 +320,11 @@ writeBundle <- function(bundleDir, bundlePath, verbose = FALSE) {
 getTarImplementation <- function() {
   # Check the RSCONNECT_TAR environment variable first. If that is unset, check
   # the rsconnect.tar option. If neither are set, use "internal"
-  tarImplementation <- Sys.getenv("RSCONNECT_TAR", unset = NA)
-  if (is.na(tarImplementation)) {
-    tarImplementation <- getOption("rsconnect.tar", default = NA)
+  tarImplementation <- getOption("rsconnect.tar", default = NA)
+  if (is.na(tarImplementation) || !nzchar(tarImplementation)) {
+    tarImplementation <- Sys.getenv("RSCONNECT_TAR", unset = NA)
   }
-  if (is.na(tarImplementation)) {
+  if (is.na(tarImplementation) || !nzchar(tarImplementation)) {
     tarImplementation <- "internal"
   }
   return(tarImplementation)

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -356,8 +356,8 @@ detectLongNames <- function(bundleDir, lengthLimit = 32) {
       warning("The bundle contains files with user/group names having more than ", lengthLimit,
               " characters: ", f, " is owned by ", info$uname, ":", info$grname, ". ",
               "Long user and group names cause the internal R tar implementation to produce invalid archives. ",
-              "Set the rsconnect.tar option or the RSCONNECT_TAR environment variable ",
-              "to use an external tar command.")
+              "Set the rsconnect.tar option or the RSCONNECT_TAR environment variable to the path to ",
+              "a tar executable to use that implementation.")
       return(invisible(TRUE))
     }
   }

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -318,8 +318,8 @@ writeBundle <- function(bundleDir, bundlePath, verbose = FALSE) {
 
 
 getTarImplementation <- function() {
-  # Check the RSCONNECT_TAR environment variable first. If that is unset, check
-  # the rsconnect.tar option. If neither are set, use "internal"
+  # Check the rsconnect.tar option first. If that is unset, check the
+  # RSCONNECT_TAR environment var. If neither are set, use "internal".
   tarImplementation <- getOption("rsconnect.tar", default = NA)
   if (is.na(tarImplementation) || !nzchar(tarImplementation)) {
     tarImplementation <- Sys.getenv("RSCONNECT_TAR", unset = NA)

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -306,7 +306,7 @@ writeBundle <- function(bundleDir, bundlePath, verbose = FALSE) {
   prevDir <- setwd(bundleDir)
   on.exit(setwd(prevDir), add = TRUE)
 
-  tarImplementation <- Sys.getenv("RSCONNECT_TAR", "internal")
+  tarImplementation <- getTarImplementation()
   logger(sprintf("Using tar: %s", tarImplementation))
 
   if (tarImplementation == "internal") {
@@ -315,6 +315,21 @@ writeBundle <- function(bundleDir, bundlePath, verbose = FALSE) {
 
   utils::tar(bundlePath, files = NULL, compression = "gzip", tar = tarImplementation)
 }
+
+
+getTarImplementation <- function() {
+  # Check the RSCONNECT_TAR environment variable first. If that is unset, check
+  # the rsconnect.tar option. If neither are set, use "internal"
+  tarImplementation <- Sys.getenv("RSCONNECT_TAR", unset = NA)
+  if (is.na(tarImplementation)) {
+    tarImplementation <- getOption("rsconnect.tar", default = NA)
+  }
+  if (is.na(tarImplementation)) {
+    tarImplementation <- "internal"
+  }
+  return(tarImplementation)
+}
+
 
 # uname/grname is not always available.
 # https://github.com/wch/r-source/blob/8cf68878a1361d00ff2125db2e1ac7dc8f6c8009/src/library/utils/R/tar.R#L539-L549
@@ -341,7 +356,8 @@ detectLongNames <- function(bundleDir, lengthLimit = 32) {
       warning("The bundle contains files with user/group names having more than ", lengthLimit,
               " characters: ", f, " is owned by ", info$uname, ":", info$grname, ". ",
               "Long user and group names cause the internal R tar implementation to produce invalid archives. ",
-              "Set the RSCONNECT_TAR environment variable to use an external tar command.")
+              "Set the rsconnect.tar option or the RSCONNECT_TAR environment variable ",
+              "to use an external tar command.")
       return(invisible(TRUE))
     }
   }

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -55,3 +55,6 @@ reference:
     - rpubsUpload
     - taskLog
     - tasks
+
+articles:
+- title: Troubleshooting

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -55,6 +55,3 @@ reference:
     - rpubsUpload
     - taskLog
     - tasks
-
-articles:
-- title: Troubleshooting

--- a/man/options.Rd
+++ b/man/options.Rd
@@ -24,7 +24,7 @@ Supported global options include:
    \item{\code{rsconnect.http.trace}}{When \code{TRUE}, trace http calls (prints the method, path, and total milliseconds for each http request)}
    \item{\code{rsconnect.http.trace.json}}{When \code{TRUE}, trace JSON content (shows JSON payloads sent to and received from the server))}
    \item{\code{rsconnect.http.verbose}}{When \code{TRUE}, print verbose output for http connections (useful only for debugging SSL certificate or http connection problems)}
-   \item{\code{rsconnect.tar}}{Path to a \{tar} executable used to compress bundles for upload. If the environment variable \code{RSCONNECT_TAR} is specified, it will will be used instead of this option. Leave undefined to use R's internal \{tar} implementation.}
+   \item{\code{rsconnect.tar}}{Path to a \code{tar} executable used to compress bundles for upload. If the environment variable \code{RSCONNECT_TAR} is specified, it will will be used instead of this option. Leave undefined to use R's internal \code{tar} implementation.}
    \item{\code{rsconnect.rcurl.options}}{A named list of additional cURL options to use when using the RCurl HTTP implementation in R. Run \code{RCurl::curlOptions()} to see available options.}
    \item{\code{rsconnect.libcurl.options}}{A named list of additional cURL options to use when using the curl HTTP implementation in R. Run \code{curl::curl_options()} to see available options.}
    \item{\code{rsconnect.error.trace}}{{When \code{TRUE}, print detailed stack traces for errors occurring during deployment.}}

--- a/man/options.Rd
+++ b/man/options.Rd
@@ -24,7 +24,7 @@ Supported global options include:
    \item{\code{rsconnect.http.trace}}{When \code{TRUE}, trace http calls (prints the method, path, and total milliseconds for each http request)}
    \item{\code{rsconnect.http.trace.json}}{When \code{TRUE}, trace JSON content (shows JSON payloads sent to and received from the server))}
    \item{\code{rsconnect.http.verbose}}{When \code{TRUE}, print verbose output for http connections (useful only for debugging SSL certificate or http connection problems)}
-   \item{\code{rsconnect.tar}}{Path to a \code{tar} executable used to compress bundles for upload. If the environment variable \code{RSCONNECT_TAR} is specified, it will will be used instead of this option. Leave undefined to use R's internal \code{tar} implementation.}
+   \item{\code{rsconnect.tar}}{Path to a \code{tar} executable used to compress bundles for upload. This option can also be specified in the environment variable \code{RSCONNECT_TAR}. Leave undefined to use R's internal \code{tar} implementation.}
    \item{\code{rsconnect.rcurl.options}}{A named list of additional cURL options to use when using the RCurl HTTP implementation in R. Run \code{RCurl::curlOptions()} to see available options.}
    \item{\code{rsconnect.libcurl.options}}{A named list of additional cURL options to use when using the curl HTTP implementation in R. Run \code{curl::curl_options()} to see available options.}
    \item{\code{rsconnect.error.trace}}{{When \code{TRUE}, print detailed stack traces for errors occurring during deployment.}}

--- a/man/options.Rd
+++ b/man/options.Rd
@@ -24,7 +24,7 @@ Supported global options include:
    \item{\code{rsconnect.http.trace}}{When \code{TRUE}, trace http calls (prints the method, path, and total milliseconds for each http request)}
    \item{\code{rsconnect.http.trace.json}}{When \code{TRUE}, trace JSON content (shows JSON payloads sent to and received from the server))}
    \item{\code{rsconnect.http.verbose}}{When \code{TRUE}, print verbose output for http connections (useful only for debugging SSL certificate or http connection problems)}
-   \item{\code{rsconnect.tar}}{Path to a \code{tar} executable used to compress bundles for upload. This option can also be specified in the environment variable \code{RSCONNECT_TAR}. Leave undefined to use R's internal \code{tar} implementation.}
+   \item{\code{rsconnect.tar}}{By default, \code{rsconnect} uses R's internal \code{tar} implementation to compress content bundles. This may cause invalid bundles in some environments. In those cases, use this option to specify a path to an alternate \code{tar} executable. This option can also be specified in the environment variable \code{RSCONNECT_TAR}. Leave undefined to use the default \code{tar} implementation.}
    \item{\code{rsconnect.rcurl.options}}{A named list of additional cURL options to use when using the RCurl HTTP implementation in R. Run \code{RCurl::curlOptions()} to see available options.}
    \item{\code{rsconnect.libcurl.options}}{A named list of additional cURL options to use when using the curl HTTP implementation in R. Run \code{curl::curl_options()} to see available options.}
    \item{\code{rsconnect.error.trace}}{{When \code{TRUE}, print detailed stack traces for errors occurring during deployment.}}

--- a/man/options.Rd
+++ b/man/options.Rd
@@ -24,6 +24,7 @@ Supported global options include:
    \item{\code{rsconnect.http.trace}}{When \code{TRUE}, trace http calls (prints the method, path, and total milliseconds for each http request)}
    \item{\code{rsconnect.http.trace.json}}{When \code{TRUE}, trace JSON content (shows JSON payloads sent to and received from the server))}
    \item{\code{rsconnect.http.verbose}}{When \code{TRUE}, print verbose output for http connections (useful only for debugging SSL certificate or http connection problems)}
+   \item{\code{rsconnect.tar}}{Path to a \{tar} executable used to compress bundles for upload. If the environment variable \code{RSCONNECT_TAR} is specified, it will will be used instead of this option. Leave undefined to use R's internal \{tar} implementation.}
    \item{\code{rsconnect.rcurl.options}}{A named list of additional cURL options to use when using the RCurl HTTP implementation in R. Run \code{RCurl::curlOptions()} to see available options.}
    \item{\code{rsconnect.libcurl.options}}{A named list of additional cURL options to use when using the curl HTTP implementation in R. Run \code{curl::curl_options()} to see available options.}
    \item{\code{rsconnect.error.trace}}{{When \code{TRUE}, print detailed stack traces for errors occurring during deployment.}}

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -569,3 +569,29 @@ test_that("writeManifest: Sets environment.image in the manifest if one is provi
   manifest <- makeManifest(appDir, appPrimaryDoc = NULL)
   expect_null(manifest$environment)
 })
+
+test_that("tarImplementation: checks environment variable and option before using default", {
+  # Environment variable only set should use environment varaible
+  Sys.setenv("RSCONNECT_TAR" = "envvar")
+  options("rsconnect.tar" = NULL)
+  tarImplementation <- getTarImplementation()
+  expect_equal(tarImplementation, "envvar")
+
+  # Option only set should use option
+  Sys.unsetenv("RSCONNECT_TAR")
+  options("rsconnect.tar" = "option")
+  tarImplementation <- getTarImplementation()
+  expect_equal(tarImplementation, "option")
+
+  # Both environment variable and option set should use environment variable
+  Sys.setenv("RSCONNECT_TAR" = "envvar")
+  options("rsconnect.tar" = "option")
+  tarImplementation <- getTarImplementation()
+  expect_equal(tarImplementation, "envvar")
+
+  # Neither set should use "internal"
+  Sys.unsetenv("RSCONNECT_TAR")
+  options("rsconnect.tar" = NULL)
+  tarImplementation <- getTarImplementation()
+  expect_equal(tarImplementation, "internal")
+})

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -490,7 +490,8 @@ test_that("inferQuartoInfo returns NULL when content cannot be rendered by Quart
   quartoInfo <- inferQuartoInfo(
     appDir = "shinyapp-simple",
     appPrimaryDoc = NULL,
-    quarto = quarto
+    quarto = quarto,
+    metadata = list()
   )
   expect_null(quartoInfo)
 })
@@ -573,6 +574,13 @@ test_that("writeManifest: Sets environment.image in the manifest if one is provi
 })
 
 test_that("tarImplementation: checks environment variable and option before using default", {
+  option_value <- getOption("rsconnect.tar")
+  envvar_value <- Sys.getenv("RSCONNECT_TAR", unset = NA)
+  on.exit({
+    options("rsconnect.tar" = option_value)
+    Sys.setenv("RSCONNECT_TAR" = envvar_value)
+  }, add = TRUE, after = FALSE)
+
   # Environment variable only set should use environment varaible
   Sys.setenv("RSCONNECT_TAR" = "envvar")
   options("rsconnect.tar" = NULL)

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -583,11 +583,11 @@ test_that("tarImplementation: checks environment variable and option before usin
   tarImplementation <- getTarImplementation()
   expect_equal(tarImplementation, "option")
 
-  # Both environment variable and option set should use environment variable
+  # Both environment variable and option set should use option
   Sys.setenv("RSCONNECT_TAR" = "envvar")
   options("rsconnect.tar" = "option")
   tarImplementation <- getTarImplementation()
-  expect_equal(tarImplementation, "envvar")
+  expect_equal(tarImplementation, "option")
 
   # Neither set should use "internal"
   Sys.unsetenv("RSCONNECT_TAR")

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -439,7 +439,8 @@ test_that("inferQuartoInfo correctly detects info when quarto is provided alone"
   quartoInfo <- inferQuartoInfo(
     appDir = "quarto-doc-none",
     appPrimaryDoc = "quarto-doc-none.qmd",
-    quarto = quarto
+    quarto = quarto,
+    metadata = list()
   )
   expect_named(quartoInfo, c("version", "engines"))
   expect_equal(quartoInfo$engines, I(c("markdown")))
@@ -447,7 +448,8 @@ test_that("inferQuartoInfo correctly detects info when quarto is provided alone"
   quartoInfo <- inferQuartoInfo(
     appDir = "quarto-website-r",
     appPrimaryDoc = NULL,
-    quarto = quarto
+    quarto = quarto,
+    metadata = list()
   )
   expect_named(quartoInfo, c("version", "engines"))
   expect_equal(quartoInfo$engines, I(c("knitr")))


### PR DESCRIPTION
### Intent

Document `RSCONNECT_TAR` more comprehensively.

Fixes https://github.com/rstudio/connect/issues/21307

### Approach

This value could only be set via an environment variable. I added an option, `rsconnect.tar`, which brings it in line with other similar values, like `rsconnect.http` and `rsconnect.ca.bundle`. I don't think this will eliminate *all* possible confusion, because not all users will know about options, or will know how to get the path to a `tar` implementation. I'm not sure that we need to solve for that here.

The approach in detail:

- Move the `tar` lookup into its own function, `getTarImplementation()`. This function first checks the environment variable, since this was the previous only supported option. If that is empty, it checks for an `rsconnect.tar` option. It returns the first non-empty result found, and returns `"internal"` if both are empty.
- Adds a test of the new function.
- Alters the error message displayed if a long filename is detected to mention the option as well.
- Adds an entry to the `options.Rd` file about this option that also mentions the environment variable.
- Updated `NEWS.md`.

### Automated Tests

Added a test to `test-bundle.R` to confirm that all permutations of settings behave as expected.

### QA Notes

Note: #589 is based on this branch, and its verification just requires a simple deployment, so you can probably do this verification on that branch to get both at the same time.

After installing this package, you can verify that the new option works by setting it to a `tar` implementation that does not exist. After this, trying to deploy any content will fail.

```r
> library(rsconnect)
> options("rsconnect.tar" = "does/not/exist")
> rsconnect::deployApp(appDir = "tests/testthat/shinyapp-simple", server = "localhost")
Preparing to deploy application...DONE
Uploading bundle for application: 251...sh: does/not/exist: No such file or directory
Error: The file does not exist: /var/folders/q7/1b7h_nx931q6mc70r3w8k_2c0000gn/T//Rtmp41ZFwC/rsconnect-bundle6e817e8bcdf2.tar.gz
In addition: Warning message:
In system(cmd) :
 Error: The file does not exist: /var/folders/q7/1b7h_nx931q6mc70r3w8k_2c0000gn/T//Rtmp41ZFwC/rsconnect-bundle6e817e8bcdf2.tar.gz
```

If you also set an environment variable, it will not be used until you unset the option.

```r
> Sys.setenv("RSCONNECT_TAR" = "does/not/exist/envvar")
> rsconnect::deployApp(appDir = "tests/testthat/shinyapp-simple", server = "localhost")
Preparing to deploy application...DONE
Uploading bundle for application: 251...sh: does/not/exist: No such file or directory
Error: The file does not exist: /var/folders/q7/1b7h_nx931q6mc70r3w8k_2c0000gn/T//Rtmp41ZFwC/rsconnect-bundle6e8140dde813.tar.gz
In addition: Warning message:
In system(cmd) :
 Error: The file does not exist: /var/folders/q7/1b7h_nx931q6mc70r3w8k_2c0000gn/T//Rtmp41ZFwC/rsconnect-bundle6e8140dde813.tar.gz 
> options("rsconnect.tar" = NULL)
> rsconnect::deployApp(appDir = "tests/testthat/shinyapp-simple", server = "localhost")
Preparing to deploy application...DONE
Uploading bundle for application: 251...sh: does/not/exist/envvar: No such file or directory
Error: The file does not exist: /var/folders/q7/1b7h_nx931q6mc70r3w8k_2c0000gn/T//Rtmp41ZFwC/rsconnect-bundle6e813ed0ef63.tar.gz
In addition: Warning message:
In system(cmd) :
 Error: The file does not exist: /var/folders/q7/1b7h_nx931q6mc70r3w8k_2c0000gn/T//Rtmp41ZFwC/rsconnect-bundle6e813ed0ef63.tar.gz
```

If you unset both, deployment should succeed.

```r
> Sys.unsetenv("RSCONNECT_TAR")
> rsconnect::deployApp(appDir = "tests/testthat/shinyapp-simple", server = "localhost")
Preparing to deploy application...DONE
Uploading bundle for application: 251...DONE
Deploying bundle: 331 for application: 251 ...
[Connect] Building Shiny application...
[Connect] Bundle created with R version 3.6.3 is compatible with environment Local with R version 3.6.3 from /opt/R/3.6.3/bin/R 
```

If, like in these examples, you deployed using something in the `tests/testthat` folder, you delete the folder that `rsconnect` leaves. In R:

```r
> unlink("tests/testthat/shinyapp-simple/rsconnect", recursive = TRUE)
```