### PR TITLE
Add ragg as a dependency to shiny apps (if it's installed locally)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## 0.8.27 (in development)
 
+* If the `ragg` package is installed locally, it is now added as an implicit dependency to `shiny` apps since `shiny::renderPlot()` now uses it by default (when available). This way, `shiny` apps won't have to add `library(ragg)` to get consistent (higher-quality) PNG images when deployed. (#598)  
 
 ## 0.8.26
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -500,13 +500,13 @@ inferRPackageDependencies <- function(appMode, hasParameters, documentsHavePytho
   }
   if (appMode == "quarto-shiny") {
     # Quarto Shiny documents are executed with rmarkdown::run
-    deps <- c(deps, "rmarkdown", "shiny")
+    deps <- c(deps, "rmarkdown", shinyDeps())
   }
   if (appMode == "rmd-shiny") {
-    deps <- c(deps, "rmarkdown", "shiny")
+    deps <- c(deps, "rmarkdown", shinyDeps())
   }
   if (appMode == "shiny") {
-    deps <- c(deps, "shiny")
+    deps <- c(deps, shinyDeps())
   }
   if (appMode == "api") {
     deps <- c(deps, "plumber")
@@ -515,6 +515,14 @@ inferRPackageDependencies <- function(appMode, hasParameters, documentsHavePytho
     deps <- c(deps, "reticulate")
   }
   unique(deps)
+}
+
+# shiny::renderPlot() now uses ragg for png rendering if it's installed,
+# so include it if it's installed locally (this way users will get consistent
+# PNG results without needing to add library(ragg) to the app).
+# https://github.com/rstudio/shiny/pull/3654
+shinyDeps <- function() {
+  c("shiny", if (system.file(package = "ragg") != "") "ragg")
 }
 
 isWindows <- function() {

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -546,9 +546,8 @@ inferRPackageDependencies <- function(appMode, hasParameters, documentsHavePytho
 # will get consistent PNG results without needing to add library(ragg) to the
 # app). https://github.com/rstudio/shiny/pull/3654
 shinyDeps <- function() {
-  has_ragg <- system.file(package = "ragg") != ""
-  new_shiny <- packageVersion("shiny") >= "1.7.2"
-  c("shiny", if (has_ragg && new_shiny) "ragg")
+  include_ragg <- isAvailable("ragg") && isAvailable("shiny", "1.7.2")
+  c("shiny", if (include_ragg) "ragg")
 }
 
 isWindows <- function() {

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -517,12 +517,14 @@ inferRPackageDependencies <- function(appMode, hasParameters, documentsHavePytho
   unique(deps)
 }
 
-# With shiny v1.7.2 or higher, renderPlot() will default to ragg for png
-# rendering (if it's installed), so include it if it's installed locally (this
-# way users will get consistent PNG results without needing to add library(ragg)
-# to the app). https://github.com/rstudio/shiny/pull/3654
+# With shiny v1.7.2 or higher, renderPlot() defaults to ragg for png rendering
+# (if it's installed), so include it if it's installed locally (this way users
+# will get consistent PNG results without needing to add library(ragg) to the
+# app). https://github.com/rstudio/shiny/pull/3654
 shinyDeps <- function() {
-  c("shiny", if (system.file(package = "ragg") != "") "ragg")
+  has_ragg <- system.file(package = "ragg") != ""
+  new_shiny <- packageVersion("shiny") >= "1.7.2"
+  c("shiny", if (has_ragg && new_shiny) "ragg")
 }
 
 isWindows <- function() {

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -546,7 +546,7 @@ inferRPackageDependencies <- function(appMode, hasParameters, documentsHavePytho
 # will get consistent PNG results without needing to add library(ragg) to the
 # app). https://github.com/rstudio/shiny/pull/3654
 shinyDeps <- function() {
-  include_ragg <- isAvailable("ragg") && isAvailable("shiny", "1.7.2")
+  include_ragg <- isAvailable("ragg") && isAvailable("shiny", "1.7.1.9000")
   c("shiny", if (include_ragg) "ragg")
 }
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -517,10 +517,10 @@ inferRPackageDependencies <- function(appMode, hasParameters, documentsHavePytho
   unique(deps)
 }
 
-# shiny::renderPlot() now uses ragg for png rendering if it's installed,
-# so include it if it's installed locally (this way users will get consistent
-# PNG results without needing to add library(ragg) to the app).
-# https://github.com/rstudio/shiny/pull/3654
+# With shiny v1.7.2 or higher, renderPlot() will default to ragg for png
+# rendering (if it's installed), so include it if it's installed locally (this
+# way users will get consistent PNG results without needing to add library(ragg)
+# to the app). https://github.com/rstudio/shiny/pull/3654
 shinyDeps <- function() {
   c("shiny", if (system.file(package = "ragg") != "") "ragg")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -237,3 +237,11 @@ fileMD5.as.string <- function(path) {
 md5.as.string <- function(md5) {
   paste(md5, collapse = "")
 }
+
+isAvailable <- function(package, version = NULL) {
+  installed <- nzchar(system.file(package = package))
+  if (is.null(version)) {
+    return(installed)
+  }
+  installed && isTRUE(utils::packageVersion(package) >= version)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -238,10 +238,18 @@ md5.as.string <- function(md5) {
   paste(md5, collapse = "")
 }
 
-isAvailable <- function(package, version = NULL) {
+# Returns true if the package is installed and satisfies the version constraint.
+isAvailable <- function(package, min_version = NULL) {
   installed <- nzchar(system.file(package = package))
-  if (is.null(version)) {
-    return(installed)
+  if (!installed) {
+    # Not installed.
+    return(FALSE)
   }
-  installed && isTRUE(utils::packageVersion(package) >= version)
+  if (is.null(min_version)) {
+    # No version constraint; installation indicates availability.
+    return(TRUE)
+  }
+  # When installed and we have a version constraint, make sure
+  # the package has at least that version.
+  return(utils::packageVersion(package) >= min_version)
 }


### PR DESCRIPTION
For more context, see https://github.com/rstudio/shiny/pull/3654