### PR TITLE
Infer Quarto info for single-document deployments without an appPrimaryDoc specified

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,9 +8,9 @@
 * fix typo for `.rscignore` (#599)
 * Quarto deployments specifying only an `appDir` and `quarto` binary but not an
   `appPrimaryDoc` work more consistently. A directory containing a `.qmd` file
-  will deploy as Quarto content instead of faling, and a directory containing an
-  `.Rmd` file will successfully deploy as Quarto content instead of falling back
-  to R Markdown.
+  will deploy as Quarto content instead of failing, and a directory containing
+  an `.Rmd` file will successfully deploy as Quarto content instead of falling
+  back to R Markdown.
 
 ## 0.8.26
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@
   Quarto metadata is missing or cannot be gathered. Functions will error,
   requesting the path to a Quarto binary in the `quarto` argument. (#594)
 * fix typo for `.rscignore` (#599)
+* Quarto deployments specifying only an `appDir` and `quarto` binary but not an
+  `appPrimaryDoc` work more consistently. A directory containing a `.qmd` file
+  will deploy as Quarto content instead of faling, and a directory containing an
+  `.Rmd` file will successfully deploy as Quarto content instead of falling back
+  to R Markdown.
 
 ## 0.8.26
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -419,8 +419,8 @@ inferAppMode <- function(appDir, appPrimaryDoc, files, quartoInfo) {
   # *or* _quarto.yml was causing deployment failures in static content.
   # https://github.com/rstudio/rstudio/issues/11444
   hasQuartoYaml <- any(grepl("^_quarto.y(a)?ml$", x = files, ignore.case = TRUE, perl = TRUE))
-  hasQuartoSupportedFiles <- any(length(qmdFiles) > 0, length(rmdFiles > 0))
-  requiresQuarto <- (hasQuartoSupportedFiles && hasQuartoYaml) || length(qmdFiles) > 0
+  hasQuartoCompatibleFiles <- any(length(qmdFiles) > 0, length(rmdFiles > 0))
+  requiresQuarto <- (hasQuartoCompatibleFiles && hasQuartoYaml) || length(qmdFiles) > 0
 
   # We gate the deployment of content that appears to be Quarto behind the
   # presence of Quarto metadata. Rmd files can still be deployed as Quarto
@@ -476,8 +476,10 @@ inferAppMode <- function(appDir, appPrimaryDoc, files, quartoInfo) {
 }
 
 inferAppPrimaryDoc <- function(appPrimaryDoc, appFiles, appMode) {
-  # if deploying an R Markdown app or static content, infer a primary document
-  # if not already specified
+  # If deploying an R Markdown, Quarto, or static content, infer a primary
+  # document if one is not already specified.
+  # Note: functionality in inferQuartoInfo() depends on primary doc inference
+  # working the same across app modes.
   docAppModes <- c(
       "static",
       "rmd-shiny",
@@ -930,7 +932,7 @@ quartoInspect <- function(appDir = NULL, appPrimaryDoc = NULL, quarto = NULL) {
 
 # Attempt to gather Quarto version and engines, first from quarto inspect if a
 # quarto executable is provided, and then from metadata.
-inferQuartoInfo <- function(appDir, appPrimaryDoc, quarto, metadata) {
+inferQuartoInfo <- function(appDir, appPrimaryDoc, appFiles, quarto, metadata) {
   quartoInfo <- NULL
   if (!is.null(metadata$quarto_version)) {
     # Prefer metadata, because that means someone already ran quarto inspect
@@ -941,6 +943,22 @@ inferQuartoInfo <- function(appDir, appPrimaryDoc, quarto, metadata) {
   }
   if (is.null(quartoInfo) && !is.null(quarto)) {
     # If we don't yet have Quarto details, run quarto inspect ourselves
+
+    # If no appPrimaryDoc has been provided, we will use the file that will be
+    # chosen if this deployment ends up with an R Markdown or Quarto app mode.
+    # This works because:
+
+    # - App modes are only used to gate primary doc inference; the behavior does
+    #   not differ between app modes.
+    # - inferAppPrimaryDoc() returns appPrimaryDoc() if it is not null.
+    tryCatch({
+      appPrimaryDoc <- inferAppPrimaryDoc(
+        appPrimaryDoc = appPrimaryDoc,
+        appFiles = appFiles,
+        appMode = "quarto-static"
+      )
+    }, error = function(e) {}
+    )
     inspect <- quartoInspect(
       appDir = appDir,
       appPrimaryDoc = appPrimaryDoc,

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -520,6 +520,7 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
   quartoInfo <- inferQuartoInfo(
     appDir = appDir,
     appPrimaryDoc = appPrimaryDoc,
+    appFiles = appFiles,
     quarto = quarto,
     metadata = metadata
   )

--- a/R/writeManifest.R
+++ b/R/writeManifest.R
@@ -59,6 +59,7 @@ writeManifest <- function(appDir = getwd(),
   quartoInfo <- inferQuartoInfo(
     appDir = appDir,
     appPrimaryDoc = appPrimaryDoc,
+    appFiles = appFiles,
     quarto = quarto,
     metadata = list()
   )

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -439,6 +439,7 @@ test_that("inferQuartoInfo correctly detects info when quarto is provided alone"
   quartoInfo <- inferQuartoInfo(
     appDir = "quarto-doc-none",
     appPrimaryDoc = "quarto-doc-none.qmd",
+    appFiles = bundleFiles("quarto-doc-none"),
     quarto = quarto,
     metadata = list()
   )
@@ -448,6 +449,7 @@ test_that("inferQuartoInfo correctly detects info when quarto is provided alone"
   quartoInfo <- inferQuartoInfo(
     appDir = "quarto-website-r",
     appPrimaryDoc = NULL,
+    appFiles = bundleFiles("quarto-website-r"),
     quarto = quarto,
     metadata = list()
   )
@@ -463,6 +465,7 @@ test_that("inferQuartoInfo extracts info from metadata when it is provided alone
   quartoInfo <- inferQuartoInfo(
     appDir = "quarto-website-r",
     appPrimaryDoc = NULL,
+    appFiles = bundleFiles("quarto-website-r"),
     quarto = NULL,
     metadata = metadata
   )
@@ -478,6 +481,7 @@ test_that("inferQuartoInfo prefers using metadata over running quarto inspect it
   quartoInfo <- inferQuartoInfo(
     appDir = "quarto-website-r",
     appPrimaryDoc = NULL,
+    appFiles = bundleFiles("quarto-website-r"),
     quarto = quarto,
     metadata = metadata
   )
@@ -490,6 +494,7 @@ test_that("inferQuartoInfo returns NULL when content cannot be rendered by Quart
   quartoInfo <- inferQuartoInfo(
     appDir = "shinyapp-simple",
     appPrimaryDoc = NULL,
+    appFiles = bundleFiles("shinyapp-simple"),
     quarto = quarto,
     metadata = list()
   )
@@ -517,6 +522,40 @@ test_that("writeManifest: Quarto document includes quarto in the manifest", {
   expect_equal(manifest$metadata$appmode, "quarto-static")
   expect_equal(manifest$quarto$engines, "markdown")
   expect_equal(manifest$metadata$primary_rmd, "quarto-doc-none.qmd")
+})
+
+test_that("writeManifest: Specifying quarto arg includes quarto in the manifest, even with no appPrimaryDoc specified (.qmd)", {
+  quarto <- quartoPathOrSkip()
+
+  appDir <- "quarto-doc-none"
+  appPrimaryDoc = NULL
+  manifest <- makeManifest(appDir, appPrimaryDoc, quarto = quarto)
+
+  expect_equal(manifest$metadata$appmode, "quarto-static")
+  expect_equal(manifest$quarto$engines, "markdown")
+  expect_equal(manifest$metadata$primary_rmd, "quarto-doc-none.qmd")
+})
+
+test_that("writeManifest: Specifying quarto arg includes quarto in the manifest, even with no appPrimaryDoc specified (.Rmd)", {
+  quarto <- quartoPathOrSkip()
+
+  appDir <- "shiny-rmds"
+  appPrimaryDoc = NULL
+  manifest <- makeManifest(appDir, appPrimaryDoc, quarto = quarto)
+
+  expect_equal(manifest$metadata$appmode, "quarto-shiny")
+  expect_equal(manifest$quarto$engines, "knitr")
+  expect_equal(manifest$metadata$primary_rmd, "non-shiny-rmd.Rmd")
+})
+
+test_that("writeManifest: specifying quarto arg with non-quarto app does not include quarto in the manifest", {
+  quarto <- quartoPathOrSkip()
+
+  appDir <- "shinyapp-singleR"
+  appPrimaryDoc = "single.R"
+  manifest <- makeManifest(appDir, appPrimaryDoc, quarto = quarto)
+
+  expect_null(manifest$quarto)
 })
 
 test_that("writeManifest: Quarto shiny project includes quarto in the manifest", {


### PR DESCRIPTION
### Intent

Fixes #601 

Important distinctions between terms
- Quarto project: a directory containing a Quarto-usable file (i.e. `.qmd` or `.Rmd`) and a `_quarto.yml` file.
- Quarto document: a document that Quarto can process. Usually refers to a `.qmd` file. I'll also talk about "Quarto-compatible files", which includes `.Rmd` as well as `.qmd` files.

We want to treat the user passing a `quarto` binary to deployment functions as an indication that they want to deploy the content as Quarto. Before this PR, if you tried to publish an R Markdown document as `quarto` by providing a `quarto` binary, but you only specified its `appDir`, not the `appPrimaryDoc`, it would publish with an R Markdown app mode. I'm pretty sure (and will check) that doing the same for a single `.qmd` doc would cause us to emit an error because we couldn't run `quarto inspect` on it.

If a deployment is made up of Quarto-compatible files, and the user has passed in a path to a `quarto` binary, we want to give the deployment a `quarto` app mode, even if they don't specify a primary document.

### Approach

We assign Quarto app modes (`quarto-static` and `quarto-shiny`) when we have one or more Quarto-compatible files and have a non-null `quartoInfo` object, which is the result of running `quarto inspect`.

But running `quarto inspect` happens before we have inferred the app mode, and inferring the primary doc when none has been specified explicitly happens *after* inferring the app mode, because `static`, is treated differently from `rmd-*` and `quarto-*`, which are treated differently from all others.

This PR attempts to work around this by adding a fallback heuristic to `inferQuartoInfo`. In effect, this attempts to infer what the primary document *would* be if this deployment had a `quarto-*` app mode, and uses that for `quarto inspect`.

Internally, `inferQuartoInfo` calls an internal `quartoInspect` function, which takes an `appDir` and an `appPrimaryDoc`, and attempts to `quarto inspect` them in order.

Within `inferQuartoInfo`, before `quartoInspect` is called, we now call `inferAppPrimaryDoc` on the existing `appPrimaryDoc`. This will not modify an existing value; it only modifies `NULL` values. So, when we call `quartoInspect`, we will first check the `appDir`, and then whatever the `appPrimaryDoc` for a quarto deployment for this app would be.

This call to `inferAppPrimaryDoc` has to be wrapped in a `tryCatch` statement. If a user is deploying, say, a `shiny` app, it won't contain any Quarto-compatible documents, and this would be an error if we were actually trying to infer the primary doc for something we _know_ to have a Quarto app mode.

This changed the call signature for `inferQuartoInfo` — it now needs `appFiles` to call `inferAppPrimaryDoc`. All of the locations it is called have been adjusted.

### Automated Tests

This pull request adds three tests:

1. Write a manifest for a single-doc Quarto app, passing in `appPrimaryDoc = NULL` and `quarto = "quarto"`. Ensure that Quarto info is present in manifest.
2. Write a manifest for a directory containing R Markdown files, passing in `appPrimaryDoc = NULL` and `quarto = "quarto"`. Ensure that Quarto info is present in manifest.
3. Specify `quarto` argument while deploying non-Quarto-compatible files (in this case a Shiny app). Ensure that no Quarto info is present in the manifest.

When the new code in `inferQuartoInfo` is commented out, 1. stops with an error because no Quarto info is found, and 2. fails because the app mode is R Markdown.

### QA Notes

You can use the content directories in the `tests/testthat` directory for testing. With this version installed, `rsconnect::deployApp` on the following directories, passing `quarto` but not specifying `appPrimaryDoc`, should successfully publish them with the expected app modes.

`quarto-doc-none` should have `quarto-static` as its app mode.

```r
rsconnect::deployApp(appDir = "tests/testthat/quarto-doc-none", quarto = quarto::quarto_path(), server = "my.great.server")
```

`shiny-rmds` should have `quarto-shiny` as its app mode. Note: I'm not sure this will actually deploy correctly, because the inferred primary doc might be a non-shiny R Markdown file, and I'm not sure how that'll work. If it doesn't work, you can try it in a folder with only one of the R Markdown documents, and it should get a `quarto` app mode.

```r
rsconnect::deployApp(appDir = "tests/testthat/shiny-rmds", quarto = quarto::quarto_path(), server = "my.great.server")
```

`shinyapp-singleR` should deploy with a `shiny` app mode.

```r
rsconnect::deployApp(appDir = "tests/testthat/shinyapp-appR", quarto = quarto::quarto_path(), server = "my.great.server")
```

### Checklist

- [x] I updated `NEWS.md`.