### PR TITLE
add better way to deal with BioConductor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
     tools,
     yaml (>= 2.1.5)
 Suggests:
+    BiocManager,
     RCurl,
     callr,
     httpuv,


### PR DESCRIPTION
Users that do not manually define BioConductor Repositories in their Rprofiles are not able to use BioConductor packages with RStudio Connect. 

This patch will allow `rsconnect`
* to behave as before when BioConductor repositories are pre-specified 
* auto-detect if BioConductor packages are present (installed via `BiocManager::install()`) and add them to the `manifest.json`
* set the bioconductor version via an `rsconnect` option`rsconnect.biocVersion`. 

This is a successor to https://github.com/rstudio/rsconnect/pull/586 