### PR TITLE
Add Quarto to CI so that Quarto tests are not skipped.

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,6 +41,8 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
+      
+      - uses: quarto-dev/quarto-actions/setup@v2
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## 0.8.28 (in development)
 
+* Fix bug that prevented publishing or writing manifests for non-Quarto content
+  when a Quarto path was provided to the `quarto` argument of `writeManifest()`,
+  `deployApp()`, and related functions.
+
 
 ## 0.8.27
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -925,17 +925,23 @@ explodeFiles <- function(dir, files) {
 quartoInspect <- function(appDir = NULL, appPrimaryDoc = NULL, quarto = NULL) {
   if (!is.null(quarto)) {
     inspect <- NULL
+    print("Running quarto inspect")
+    print(paste("appDir:", appDir))
+    print(paste("appPrimaryDoc:", appPrimaryDoc))
     # If "quarto inspect appDir" fails, we will try "quarto inspect
     # appPrimaryDoc", so that we can support single files as well as projects.
     primaryDocPath <- file.path(appDir, appPrimaryDoc) # prior art: appHasParameters()
     for (path in c(appDir, primaryDocPath)) {
       args <- c("inspect", path.expand(path))
       inspect <- suppressWarnings(system2(quarto, args, stdout = TRUE, stderr = FALSE))
+      cat(inspect)
       if (is.null(attr(inspect, "status"))) {
+        print("Returning inspect")
         return(jsonlite::fromJSON(inspect))
       }
     }
   }
+  print("Returning NULL")
   return(NULL)
 }
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -936,11 +936,12 @@ quartoInspect <- function(appDir = NULL, appPrimaryDoc = NULL, quarto = NULL) {
       {
         inspectOutput <- suppressWarnings(system2(quarto, args, stdout = TRUE, stderr = TRUE))
         inspect <- jsonlite::fromJSON(inspectOutput)
-        return(inspect)
       },
       error = function(e) e
     )
+    if (!is.null(inspect)) break
   }
+  return(inspect)
 }
 
 # Attempt to gather Quarto version and engines, first from quarto inspect if a


### PR DESCRIPTION
### Intent

Quarto tests are skipped if no Quarto installation is detected. This PR adds a Quarto installation to our CI workflows so that Quarto tests run in CI.

This surfaced a bug with `quartoInspect()` on Windows with non-Quarto content, so this PR solves that too. The bug prevents the successful deployment of non-Quarto content when a Quarto path is passed to the `quarto` argument of `writeManifest()`, `deployApp()`, etc. In those situations, we want deployment to continue with a non-Quarto app mode, but it would cause deployment to stop.

### Approach

To install Quarto, I used the [`quarto-setup`](https://github.com/quarto-dev/quarto-actions/tree/main/setup) action from [quarto-dev/quarto-actions](https://github.com/quarto-dev/quarto-actions).

The Quarto-related bug on windows stems from seemingly different behavior of `system2()` on Windows. I'm not 100% sure about this, but I'm trying to narrow it down. Here's my current understanding:

Running `quartoInspect()` when the `appDir` and `appPrimaryDoc` passed are not Quarto-compatible should return `NULL`; on Windows it failed.

This worked by calling `quarto inspect` like so:

```r
args <- c("inspect", path.expand(path))
inspect <- suppressWarnings(system2(quarto, args, stdout = TRUE, stderr = FALSE))
```

When `quarto inspect` is called on a non-Quarto path, it outputs on `stderr`, and in this case, `system2()` returns `NULL` because `stderr` is FALSE. We would only attempt to parse non-`NULL` results with `jsonlite::fromJSON(inspect)`, with the expectation that all non-`NULL` results are successful results. (l

However, on Windows, it returns `character(0)`, which causes an error `jsonlite::fromJSON(inspect)` to err. Screenshots demonstrating this behavior in a Windows VM are attached at the bottom of this note.

I solved this by wrapping the `inspect` and `jsonlite::fromJSON()` calls in `tryCatch()`. Strictly, only the latter of those needs to be treated like this. At the time I wrote that, I wasn't 100% confident in localizing the error to `jsonlite::fromJSON`, and it *does*, I think, makes sense to capture any errors that `system2` would produce and ignore them.

### Automated Tests

This PR enables more automated tests to run in CI on various operating systems, surfacing errors like this that I wouldn't have seen developing on macOS.

### QA Notes

My laptop is on low battery so these might be a bit skimpy. This PR does touch Quarto-related deployment code, so we should make sure the following work:

- [x] Deploy Quarto-compatible content to a Connect instance:

```r
rsconnect::deployApp("tests/testthat/quarto-proj-r-shiny", quarto = quarto::quarto_path())
rsconnect::deployApp("tests/testthat/quarto-doc-none", quarto = quarto::quarto_path())

```

- [ ] Deploy Quarto non-content to a Connect instance:

```r
rsconnect::deployApp("tests/testthat/shinyapp-simple", quarto = quarto::quarto_path())
```

### Other

- I updated NEWS with this bugfix.

### Screenshots of the issue on Windows

Running `quarto inspect` on Quarto content

![Screen Shot 2022-07-13 at 04 39 32 PM@2x](https://user-images.githubusercontent.com/3117884/178832029-f84d63e2-df08-46e1-b54f-b56b3d15d843.png)

The same, but parsing the output:

![Screen Shot 2022-07-13 at 04 41 48 PM@2x](https://user-images.githubusercontent.com/3117884/178832180-7fa68bbb-7f14-4785-90c7-f9d687e5d622.png)

Running `quarto inspect` on non-Quarto content. Note it returns `character(0)` instead of `NULL` as it does on Unix-alikes.

![Screen Shot 2022-07-13 at 04 40 27 PM@2x](https://user-images.githubusercontent.com/3117884/178832105-ae1a1d8f-43ea-41a7-a5a5-f5b6298e36f6.png)

The same, but parsing the output. This is the bug we were seeing. This would be skipped on Unix in the previous build because `system2` returns `NULL`, which we checked for.

![Screen Shot 2022-07-13 at 04 42 21 PM@2x](https://user-images.githubusercontent.com/3117884/178832266-6eb5ae8d-fade-4697-8728-74e289909a16.png)
 