### PR TITLE
More cloud support changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Suggests:
     xtable
 License: GPL-2
 Encoding: UTF-8
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Roxygen: list(markdown = TRUE)
 URL: https://github.com/rstudio/rsconnect
 BugReports: https://github.com/rstudio/rsconnect/issues

--- a/R/accounts.R
+++ b/R/accounts.R
@@ -484,8 +484,12 @@ resolveAccount <- function(account, server = NULL) {
   }
 }
 
-isShinyapps <- function(server) {
+isCloudServer <- function(server) {
   identical(server, "shinyapps.io") | identical(server, "rstudio.cloud")
+}
+
+isShinyappsServer <- function(server) {
+  identical(server, "shinyapps.io")
 }
 
 isRPubs <- function(server) {
@@ -494,7 +498,7 @@ isRPubs <- function(server) {
 
 isConnectInfo <- function(accountInfo = NULL, server = NULL) {
   host <- if (is.null(accountInfo)) server else accountInfo$server
-  !isShinyapps(host) && !isRPubs(host)
+  !isCloudServer(host) && !isRPubs(host)
 }
 
 stopWithNoAccount <- function() {

--- a/R/accounts.R
+++ b/R/accounts.R
@@ -485,7 +485,7 @@ resolveAccount <- function(account, server = NULL) {
 }
 
 isCloudServer <- function(server) {
-  identical(server, "shinyapps.io") | identical(server, "rstudio.cloud")
+  identical(server, "shinyapps.io") || identical(server, "rstudio.cloud")
 }
 
 isShinyappsServer <- function(server) {

--- a/R/auth.R
+++ b/R/auth.R
@@ -146,8 +146,8 @@ showUsers <- function(appDir=getwd(), appName=NULL, account = NULL,
   # resolve account
   accountDetails <- accountInfo(resolveAccount(account, server), server)
 
-  if (!isShinyapps(accountDetails$server)) {
-    stop("This method only works for ShinyApps servers.")
+  if (!isCloudServer(accountDetails$server)) {
+    stop("This method only works for ShinyApps or rstudio.cloud servers.")
   }
 
   # resolve application

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -387,7 +387,7 @@ isShinyRmd <- function(filename) {
 
 # infer the mode of the application from its layout
 # unless we're an API, in which case, we're API mode.
-inferAppMode <- function(appDir, appPrimaryDoc, files, quartoInfo) {
+inferAppMode <- function(appDir, appPrimaryDoc, files, quartoInfo, isCloudServer = FALSE) {
   # plumber API
   plumberFiles <- grep("^(plumber|entrypoint).r$", files, ignore.case = TRUE, perl = TRUE)
   if (length(plumberFiles) > 0) {
@@ -456,6 +456,12 @@ inferAppMode <- function(appDir, appPrimaryDoc, files, quartoInfo) {
     if (!is.null(quartoInfo)) {
       return("quarto-static")
     } else {
+      # For Shinyapps and rstudio.cloud, treat "rmd-static" app mode as "rmd-shiny" so that
+      # they can be served from a shiny process in Connect until we have better support of
+      # rmarkdown static content
+      if (isCloudServer) {
+        return("rmd-shiny")
+      }
       return("rmd-static")
     }
   }
@@ -634,7 +640,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
                               forceGenerate, python = NULL, documentsHavePython = FALSE,
                               retainPackratDirectory = TRUE,
                               quartoInfo = NULL,
-                              isShinyApps = FALSE,
+                              isCloud = FALSE,
                               image = NULL,
                               verbose = FALSE) {
 
@@ -803,7 +809,7 @@ createAppManifest <- function(appDir, appMode, contentCategory, hasParameters,
   }
 
   # indicate whether this is a quarto app/doc
-  if (!is.null(quartoInfo) && !isShinyApps) {
+  if (!is.null(quartoInfo) && !isCloud) {
     manifest$quarto <- quartoInfo
   }
   # if there is python info for reticulate or Quarto, attach it

--- a/R/servers.R
+++ b/R/servers.R
@@ -269,7 +269,7 @@ missingServerErrorMessage <- function(name) {
 clientForAccount <- function(account) {
 
   # determine appropriate server information for account
-  if (isShinyapps(account$server)) {
+  if (isCloudServer(account$server)) {
     constructor <- lucidClientForAccount(account)
   } else {
     serverInfo <- serverInfo(account$server)

--- a/R/writeManifest.R
+++ b/R/writeManifest.R
@@ -36,8 +36,6 @@
 #'
 #' @param verbose If TRUE, prints progress messages to the console
 #'
-#' @param isCloudServer Set to TRUE if the target is shinyapps.io or rsrudio.cloud
-#'
 #'
 #' @export
 writeManifest <- function(appDir = getwd(),
@@ -48,8 +46,7 @@ writeManifest <- function(appDir = getwd(),
                           forceGeneratePythonEnvironment = FALSE,
                           quarto = NULL,
                           image = NULL,
-                          verbose = FALSE,
-                          isCloudServer = FALSE) {
+                          verbose = FALSE) {
 
   condaMode <- FALSE
 
@@ -71,8 +68,7 @@ writeManifest <- function(appDir = getwd(),
       appDir = appDir,
       appPrimaryDoc = appPrimaryDoc,
       files = appFiles,
-      quartoInfo = quartoInfo,
-      isCloudServer = isCloudServer)
+      quartoInfo = quartoInfo)
   appPrimaryDoc <- inferAppPrimaryDoc(
       appPrimaryDoc = appPrimaryDoc,
       appFiles = appFiles,

--- a/R/writeManifest.R
+++ b/R/writeManifest.R
@@ -46,7 +46,8 @@ writeManifest <- function(appDir = getwd(),
                           forceGeneratePythonEnvironment = FALSE,
                           quarto = NULL,
                           image = NULL,
-                          verbose = FALSE) {
+                          verbose = FALSE,
+                          isCloudServer = FALSE) {
 
   condaMode <- FALSE
 
@@ -68,7 +69,8 @@ writeManifest <- function(appDir = getwd(),
       appDir = appDir,
       appPrimaryDoc = appPrimaryDoc,
       files = appFiles,
-      quartoInfo = quartoInfo)
+      quartoInfo = quartoInfo,
+      isCloudServer = isCloudServer)
   appPrimaryDoc <- inferAppPrimaryDoc(
       appPrimaryDoc = appPrimaryDoc,
       appFiles = appFiles,
@@ -106,7 +108,7 @@ writeManifest <- function(appDir = getwd(),
       documentsHavePython = documentsHavePython,
       retainPackratDirectory = FALSE,
       quartoInfo = quartoInfo,
-      isShinyApps = FALSE,
+      isCloud = FALSE,
       image = image,
       verbose = verbose)
   manifestJson <- enc2utf8(toJSON(manifest, pretty = TRUE))

--- a/R/writeManifest.R
+++ b/R/writeManifest.R
@@ -36,6 +36,8 @@
 #'
 #' @param verbose If TRUE, prints progress messages to the console
 #'
+#' @param isCloudServer Set to TRUE if the target is shinyapps.io or rsrudio.cloud
+#'
 #'
 #' @export
 writeManifest <- function(appDir = getwd(),

--- a/man/deployTFModel.Rd
+++ b/man/deployTFModel.Rd
@@ -20,12 +20,14 @@ Deploy a single Tensorflow saved model as a bundle. Should be passed a
 directory that contains the \emph{saved_model.pb} or \emph{saved_model.pbtxt} file,
 as well as any variables and assets necessary to load the model.
 
-A saved model directory might look like this:\preformatted{./1/
+A saved model directory might look like this:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{./1/
 ./1/saved_model.pb or ./1/saved_model.pbtxt
 ./1/variables/
 ./1/variables/variables.data-00000-of-00001
 ./1/variables/variables.index
-}
+}\if{html}{\out{</div>}}
 
 For information on creating saved models, see the Keras method
 \code{\link[keras:export_savedmodel.keras.engine.training.Model]{keras::export_savedmodel.keras.engine.training.Model()}} or the TensorFlow

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -50,6 +50,8 @@ executing this content. If none is provided, RStudio Connect will
 attempt to choose an image based on the content requirements.}
 
 \item{verbose}{If TRUE, prints progress messages to the console}
+
+\item{isCloudServer}{Set to TRUE if the target is shinyapps.io or rsrudio.cloud}
 }
 \description{
 Given a directory content targeted for deployment, write a manifest.json into

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -13,8 +13,7 @@ writeManifest(
   forceGeneratePythonEnvironment = FALSE,
   quarto = NULL,
   image = NULL,
-  verbose = FALSE,
-  isCloudServer = FALSE
+  verbose = FALSE
 )
 }
 \arguments{
@@ -50,8 +49,6 @@ executing this content. If none is provided, RStudio Connect will
 attempt to choose an image based on the content requirements.}
 
 \item{verbose}{If TRUE, prints progress messages to the console}
-
-\item{isCloudServer}{Set to TRUE if the target is shinyapps.io or rsrudio.cloud}
 }
 \description{
 Given a directory content targeted for deployment, write a manifest.json into

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -13,7 +13,8 @@ writeManifest(
   forceGeneratePythonEnvironment = FALSE,
   quarto = NULL,
   image = NULL,
-  verbose = FALSE
+  verbose = FALSE,
+  isCloudServer = FALSE
 )
 }
 \arguments{

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -396,6 +396,13 @@ test_that("getPythonForTarget defaults to disabled for shinyapps.io", {
   expect_equal(result, NULL)
 })
 
+test_that("getPythonForTarget defaults to enabled for rstudio.cloud", {
+  skip_on_cran()
+
+  result <- getPythonForTarget("/usr/bin/python", list(server="rstudio.cloud"))
+  expect_equal(result, "/usr/bin/python")
+})
+
 # Quarto Tests
 
 test_that("quartoInspect identifies on Quarto projects", {

--- a/tests/testthat/test-detection.R
+++ b/tests/testthat/test-detection.R
@@ -12,7 +12,7 @@ test_that("Shiny R Markdown files are detected correctly", {
 # Each file is written with its content to a temporary directory.
 # Returns the result of inferAppMode when run against that directory.
 # The temporary directory is removed on exit.
-inferAppModeFromFiles <- function(fileContent) {
+inferAppModeFromFiles <- function(fileContent, isCloudServer = FALSE) {
   targetDir <- tempfile()
   dir.create(targetDir)
   on.exit(unlink(targetDir, recursive = TRUE))
@@ -28,7 +28,7 @@ inferAppModeFromFiles <- function(fileContent) {
   }
 
   files <- list.files(targetDir, recursive = FALSE, all.files = FALSE, include.dirs = FALSE, no.. = TRUE, full.names = FALSE)
-  appMode <- inferAppMode(targetDir, NULL, files, quartoInfo = NULL)
+  appMode <- inferAppMode(targetDir, NULL, files, quartoInfo = NULL, isCloudServer = isCloudServer)
   return(appMode)
 }
 
@@ -75,6 +75,20 @@ test_that("inferAppMode", {
     "alpha.Rmd" = NA,
     "bravo.Rmd" = NA
   )))
+
+  # Static R Markdown treated as rmd-shiny for shinyapps and rstudio.cloud targets
+  expect_identical("rmd-shiny", inferAppModeFromFiles(list(
+    "index.Rmd" = NA
+  ), isCloudServer = TRUE))
+  expect_identical("rmd-shiny", inferAppModeFromFiles(list(
+    "index.Rmd" = NA,
+    "alpha.Rmd" = NA,
+    "bravo.Rmd" = NA
+  ), isCloudServer = TRUE))
+  expect_identical("rmd-shiny", inferAppModeFromFiles(list(
+    "alpha.Rmd" = NA,
+    "bravo.Rmd" = NA
+  ), isCloudServer = TRUE))
 
   rmdRuntimeShiny <- c(
     "---",


### PR DESCRIPTION
This PR contains several small changes to better support publishing to cloud targets (shinyapps.io and rstudio.cloud).  

* Renamed `isShinyapps` to `isCloudServer` to better reflect the meaning of cloud targets
* Changed `inferAppMode` to return `rmd-shiny` instead of `rmd-static` for cloud targets.  This coercion is intended to be in place until we have a better support for static content in cloud.
* Changed `getPythonForTarget` to have `pythonEnabled` be `true` by default, except for the case of shinyapps.io.
* Changed `deployApp` to allow `contentCategory=api` to work for rstudio.cloud, but not shinyapps.io