### PR TITLE
ragg is no longer an implicit dependency of Shiny content

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,16 @@
 
 ## 0.8.28 (in development)
 
+* Shiny applications and Shiny documents no longer include an implicit
+  dependency on [`ragg`](https://ragg.r-lib.org) when that package is present
+  in the local environment. This reverts a change introduced in 0.8.27.
+  
+  Shiny applications should add an explicit dependency on `ragg` (usually with
+  a `library("ragg")` statement) to see it used by `shiny::renderPlot` (via
+  `shiny::plotPNG`).
+  
+  The documentation for `shiny::plotPNG` explains the use of `ragg`. (#598)
+
 * Fix bug that prevented publishing or writing manifests for non-Quarto content
   when a Quarto path was provided to the `quarto` argument of `writeManifest()`,
   `deployApp()`, and related functions.

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -532,13 +532,13 @@ inferRPackageDependencies <- function(appMode, hasParameters, documentsHavePytho
   }
   if (appMode == "quarto-shiny") {
     # Quarto Shiny documents are executed with rmarkdown::run
-    deps <- c(deps, "rmarkdown", shinyDeps())
+    deps <- c(deps, "rmarkdown", "shiny")
   }
   if (appMode == "rmd-shiny") {
-    deps <- c(deps, "rmarkdown", shinyDeps())
+    deps <- c(deps, "rmarkdown", "shiny")
   }
   if (appMode == "shiny") {
-    deps <- c(deps, shinyDeps())
+    deps <- c(deps, "shiny")
   }
   if (appMode == "api") {
     deps <- c(deps, "plumber")
@@ -547,15 +547,6 @@ inferRPackageDependencies <- function(appMode, hasParameters, documentsHavePytho
     deps <- c(deps, "reticulate")
   }
   unique(deps)
-}
-
-# With shiny v1.7.2 or higher, renderPlot() defaults to ragg for png rendering
-# (if it's installed), so include it if it's installed locally (this way users
-# will get consistent PNG results without needing to add library(ragg) to the
-# app). https://github.com/rstudio/shiny/pull/3654
-shinyDeps <- function() {
-  include_ragg <- isAvailable("ragg") && isAvailable("shiny", "1.7.1.9000")
-  c("shiny", if (include_ragg) "ragg")
 }
 
 isWindows <- function() {


### PR DESCRIPTION
Reverts #598