### PR TITLE
Add "type" query filter when listing apps on cloud or shinyapps

### DIFF
--- a/R/lucid.R
+++ b/R/lucid.R
@@ -74,8 +74,8 @@ shinyAppsClient <- function(service, authInfo) {
    listApplications = function(accountId, filters = list()) {
       path <- "/applications/"
       query <- paste(filterQuery(
-        c("account_id", names(filters)),
-        c(accountId, unname(filters))
+        c("account_id", "type", names(filters)),
+        c(accountId, "shiny", unname(filters))
       ), collapse = "&")
       listRequest(service, authInfo, path, query, "applications")
     },
@@ -339,8 +339,8 @@ cloudClient <- function(service, authInfo) {
     listApplications = function(accountId, filters = list()) {
       path <- "/applications/"
       query <- paste(filterQuery(
-        c("account_id", names(filters)),
-        c(accountId, unname(filters))
+        c("account_id", "type", names(filters)),
+        c(accountId, "connect", unname(filters))
       ), collapse = "&")
       listRequest(service, authInfo, path, query, "applications")
     },


### PR DESCRIPTION
This fixes an issue with cloud support whereby publishing a Shiny App to rstudio.cloud with the same name as an existing app on shinyapps.io results in the app getting published to shinyapps.io again.

This is because the call to `listApplications` on the `cloudClient` does not currently limit the apps to cloud applications (`type=connect`), so it returns the matching shiny application as the first result. 

The change is to include a `type` filter in the `listApplications` function.  The type value used is `connect` or `shiny`, depending on the client.