### PR TITLE
quick rebranding pass (RStudio => Posit)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,13 +3,13 @@ Type: Package
 Title: Deployment Interface for R Markdown Documents and Shiny Applications
 Version: 0.8.29
 Authors@R: c(
-    person("Aron", "Atkins", role = c("aut", "cre"), email = "aron@rstudio.com"),
-    person("Jonathan", "McPherson", role = "aut", email = "jonathan@rstudio.com"),
+    person("Aron", "Atkins", role = c("aut", "cre"), email = "aron@posit.co"),
+    person("Jonathan", "McPherson", role = "aut", email = "jonathan@posit.co"),
     person("JJ", "Allaire", role = "aut"),
-    person("RStudio", role = c("cph", "fnd"))
+    person("Posit Software", role = c("cph", "fnd"))
     )
 Description: Programmatic deployment interface for 'RPubs', 'shinyapps.io', and
-    'RStudio Connect'. Supported content types include R Markdown documents,
+    'Posit Connect'. Supported content types include R Markdown documents,
     Shiny applications, Plumber APIs, plots, and static web content.
 Depends:
     R (>= 3.0.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## 0.8.29 (in development)
 
+* Update company and product name for rebranding to Posit.
 
 ## 0.8.28
 

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -40,7 +40,7 @@
 #' @param upload If `TRUE` (the default) then the application is uploaded from
 #'   the local system prior to deployment. If `FALSE` then it is re-deployed
 #'   using the last version that was uploaded. `FALSE` is only supported on
-#'   shinyapps.io; `TRUE` is required on RStudio Connect.
+#'   shinyapps.io; `TRUE` is required on Posit Connect.
 #' @param recordDir Directory where publish record is written. Can be `NULL`
 #'   in which case record will be written to the location specified with `appDir`.
 #' @param launch.browser If true, the system's default web browser will be
@@ -76,7 +76,7 @@
 #'   visibility of the deployment. When `NULL`, no change to visibility is
 #'   made. Currently has an effect only on deployments to shinyapps.io.
 #' @param image Optional. The name of the image to use when building and
-#'   executing this content. If none is provided, RStudio Connect will
+#'   executing this content. If none is provided, Posit Connect will
 #'   attempt to choose an image based on the content requirements.
 #' @examples
 #' \dontrun{
@@ -341,13 +341,13 @@ deployApp <- function(appDir = getwd(),
     if (isShinyappsServer(accountDetails$server)) {
       if (identical(contentCategory, "api")) {
         stop("Plumber APIs are not currently supported on shinyapps.io; they ",
-             "can only be published to RStudio Connect or rstudio.cloud.")
+             "can only be published to Posit Connect or rstudio.cloud.")
       }
     }
   } else {
     if (identical(upload, FALSE)) {
       # it is not possible to deploy to Connect without uploading
-      stop("RStudio Connect does not support deploying without uploading. ",
+      stop("Posit Connect does not support deploying without uploading. ",
            "Specify upload=TRUE to upload and re-deploy your application.")
     }
   }

--- a/R/rsa.R
+++ b/R/rsa.R
@@ -32,7 +32,7 @@ createUniqueId <- function(bytes) {
   paste0(as.hexmode(sample(256, bytes)-1), collapse="")
 }
 
-# generateToken generates a token for signing requests sent to the RStudio
+# generateToken generates a token for signing requests sent to the Posit
 # Connect service. The token's ID and public key are sent to the server, and
 # the private key is saved locally.
 generateToken <- function() {

--- a/R/rsconnect-package.R
+++ b/R/rsconnect-package.R
@@ -1,7 +1,7 @@
 #' Deployment Interface for R Markdown Documents and Shiny Applications
 #'
 #' The `rsconnect`` package provides a programmatic deployment
-#' interface for RPubs, shinyapps.io, and RStudio Connect. Supported contents
+#' interface for RPubs, shinyapps.io, and Posit Connect. Supported contents
 #' types include R Markdown documents, Shiny applications, plots, and static
 #' web content.
 #'

--- a/R/writeManifest.R
+++ b/R/writeManifest.R
@@ -31,7 +31,7 @@
 #'   to gather information about the content.
 #'
 #' @param image Optional. The name of the image to use when building and
-#'   executing this content. If none is provided, RStudio Connect will
+#'   executing this content. If none is provided, Posit Connect will
 #'   attempt to choose an image based on the content requirements.
 #'
 #' @param verbose If TRUE, prints progress messages to the console

--- a/README.Rmd
+++ b/README.Rmd
@@ -23,7 +23,7 @@ knitr::opts_chunk$set(
 <!-- badges: end -->
 
 An R package used for deploying applications to the [ShinyApps](https://www.shinyapps.io/) hosted service, 
-or to [RStudio Connect](https://www.rstudio.com/products/connect/).
+or to [Posit Connect](https://www.posit.co/products/enterprise/connect/).
 
 ## Installation
 
@@ -44,9 +44,9 @@ devtools::install_github("rstudio/rsconnect")
 
 To get started using ShinyApps check out the [Getting Started Guide](https://shiny.rstudio.com/articles/shinyapps.html).
 
-For more information using RStudio Connect, see the [RStudio Connect User Guide](https://docs.rstudio.com/connect/user/index.html).
+For more information using Posit Connect, see the [Posit Connect User Guide](https://docs.rstudio.com/connect/user/index.html).
 
 
 ## Legal Stuff
 
-TensorFlow, the TensorFlow logo and any related marks are trademarks of Google Inc., and are not affiliated with RStudio, Inc.
+TensorFlow, the TensorFlow logo and any related marks are trademarks of Google Inc., and are not affiliated with Posit Software, PBC

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ status](https://www.r-pkg.org/badges/version/rsconnect)](https://cran.r-project.
 <!-- badges: end -->
 
 An R package used for deploying applications to the
-[ShinyApps](https://www.shinyapps.io/) hosted service, or to [RStudio
-Connect](https://www.rstudio.com/products/connect/).
+[ShinyApps](https://www.shinyapps.io/) hosted service, or to [Posit
+Connect](https://www.posit.co/products/enterprise/connect/).
 
 ## Installation
 
@@ -36,10 +36,10 @@ devtools::install_github("rstudio/rsconnect")
 To get started using ShinyApps check out the [Getting Started
 Guide](https://shiny.rstudio.com/articles/shinyapps.html).
 
-For more information using RStudio Connect, see the [RStudio Connect
-User Guide](https://docs.rstudio.com/connect/user/index.html).
+For more information using Posit Connect, see the [Posit Connect User
+Guide](https://docs.rstudio.com/connect/user/index.html).
 
 ## Legal Stuff
 
 TensorFlow, the TensorFlow logo and any related marks are trademarks of
-Google Inc., and are not affiliated with RStudio, Inc.
+Google Inc., and are not affiliated with Posit Software, PBC

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -79,7 +79,7 @@ multiple servers.}
 \item{upload}{If \code{TRUE} (the default) then the application is uploaded from
 the local system prior to deployment. If \code{FALSE} then it is re-deployed
 using the last version that was uploaded. \code{FALSE} is only supported on
-shinyapps.io; \code{TRUE} is required on RStudio Connect.}
+shinyapps.io; \code{TRUE} is required on Posit Connect.}
 
 \item{recordDir}{Directory where publish record is written. Can be \code{NULL}
 in which case record will be written to the location specified with \code{appDir}.}
@@ -126,7 +126,7 @@ to gather information about the content.}
 made. Currently has an effect only on deployments to shinyapps.io.}
 
 \item{image}{Optional. The name of the image to use when building and
-executing this content. If none is provided, RStudio Connect will
+executing this content. If none is provided, Posit Connect will
 attempt to choose an image based on the content requirements.}
 }
 \description{

--- a/man/options.Rd
+++ b/man/options.Rd
@@ -36,7 +36,7 @@ Supported global options include:
    \item{\code{rsconnect.force.update.apps}}{When \code{TRUE}, bypasses the prompt to confirm whether you wish to update previously-deployed content}
    \item{\code{rsconnect.pre.deploy}}{A function to run prior to deploying content; it receives as an argument the path to the content that's about to be deployed.}
    \item{\code{rsconnect.post.deploy}}{A function to run after successfully deploying content; it receives as an argument the path to the content that was just deployed.}
-   \item{\code{rsconnect.python.enabled}}{When \code{TRUE}, use the python executable specified by the \code{RETICULATE_PYTHON} environment variable and add a \code{python} section to the deployment manifest. By default, python is enabled when deploying to RStudio Connect and disabled when deploying to shinyapps.io.}
+   \item{\code{rsconnect.python.enabled}}{When \code{TRUE}, use the python executable specified by the \code{RETICULATE_PYTHON} environment variable and add a \code{python} section to the deployment manifest. By default, python is enabled when deploying to Posit Connect and disabled when deploying to shinyapps.io.}
 }
 When deploying content from the RStudio IDE, the rsconnect package's deployment methods are executed in a vanilla R session that doesn't execute startup scripts. This can make it challenging to ensure options are set properly prior to push-button deployment, so the rsconnect package has a parallel set of ``startup'' scripts it runs prior to deploying. The follow are run in order, if they exist, prior to deployment:
 \describe{

--- a/man/rsconnect-package.Rd
+++ b/man/rsconnect-package.Rd
@@ -7,7 +7,7 @@
 \title{Deployment Interface for R Markdown Documents and Shiny Applications}
 \description{
 The `rsconnect`` package provides a programmatic deployment
-interface for RPubs, shinyapps.io, and RStudio Connect. Supported contents
+interface for RPubs, shinyapps.io, and Posit Connect. Supported contents
 types include R Markdown documents, Shiny applications, plots, and static
 web content.
 }

--- a/man/servers.Rd
+++ b/man/servers.Rd
@@ -57,8 +57,7 @@ using \code{\link[=connectUser]{connectUser()}}.
 The \code{servers} and \code{serverInfo} functions are provided for viewing
 previously registered servers.
 
-There is always at least one server registered (the \code{shinyapps.io}
-server)
+Servers for \code{shinyapps.io} and \code{rstudio.cloud} are always registered.
 }
 \examples{
 \dontrun{

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -45,7 +45,7 @@ content. The provided Quarto binary will be used to run \verb{quarto inspect}
 to gather information about the content.}
 
 \item{image}{Optional. The name of the image to use when building and
-executing this content. If none is provided, RStudio Connect will
+executing this content. If none is provided, Posit Connect will
 attempt to choose an image based on the content requirements.}
 
 \item{verbose}{If TRUE, prints progress messages to the console}


### PR DESCRIPTION
Replaces #614

At least one minor change was because we had stale docs on `main`.