### PR TITLE
Rebrand rstudio.cloud -> posit.cloud

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## 0.8.29 (in development)
 
-* Update company and product name for rebranding to Posit.
+* Update company and product names for rebranding to Posit.
 
 ## 0.8.28
 

--- a/R/accounts.R
+++ b/R/accounts.R
@@ -246,8 +246,8 @@ setAccountInfo <- function(name, token, secret,
     stop(stringParamErrorMessage("secret"))
 
   # create connect client
-  if (identical(server, cloudServerInfo()$name)) {
-    serverInfo <- cloudServerInfo()
+  if (identical(server, cloudServerInfo(server)$name)) {
+    serverInfo <- cloudServerInfo(server)
   } else {
     serverInfo <- shinyappsServerInfo()
   }

--- a/R/accounts.R
+++ b/R/accounts.R
@@ -486,7 +486,8 @@ resolveAccount <- function(account, server = NULL) {
 }
 
 isCloudServer <- function(server) {
-  identical(server, "shinyapps.io") || identical(server, "rstudio.cloud")
+  identical(server, "shinyapps.io")||
+    identical(server, cloudServerInfo(server)$name)
 }
 
 isShinyappsServer <- function(server) {

--- a/R/auth.R
+++ b/R/auth.R
@@ -147,7 +147,7 @@ showUsers <- function(appDir=getwd(), appName=NULL, account = NULL,
   accountDetails <- accountInfo(resolveAccount(account, server), server)
 
   if (!isCloudServer(accountDetails$server)) {
-    stop("This method only works for ShinyApps or rstudio.cloud servers.")
+    stop("This method only works for ShinyApps or posit.cloud servers.")
   }
 
   # resolve application

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -456,7 +456,7 @@ inferAppMode <- function(appDir, appPrimaryDoc, files, quartoInfo, isCloudServer
     if (!is.null(quartoInfo)) {
       return("quarto-static")
     } else {
-      # For Shinyapps and rstudio.cloud, treat "rmd-static" app mode as "rmd-shiny" so that
+      # For Shinyapps and posit.cloud, treat "rmd-static" app mode as "rmd-shiny" so that
       # they can be served from a shiny process in Connect until we have better support of
       # rmarkdown static content
       if (isCloudServer) {

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -341,7 +341,7 @@ deployApp <- function(appDir = getwd(),
     if (isShinyappsServer(accountDetails$server)) {
       if (identical(contentCategory, "api")) {
         stop("Plumber APIs are not currently supported on shinyapps.io; they ",
-             "can only be published to Posit Connect or rstudio.cloud.")
+             "can only be published to Posit Connect or Posit Cloud.")
       }
     }
   } else {
@@ -596,7 +596,7 @@ bundleApp <- function(appName, appDir, appFiles, appPrimaryDoc, assetTypeName,
 
 
 getPythonForTarget <- function(path, accountDetails) {
-  # python is enabled on Connect and rstudio.cloud, but not on Shinyapps
+  # python is enabled on Connect and posit.cloud, but not on Shinyapps
   targetIsShinyapps <- isShinyappsServer(accountDetails$server)
   pythonEnabled = getOption("rsconnect.python.enabled", default=!targetIsShinyapps)
   if (pythonEnabled) {

--- a/R/lucid.R
+++ b/R/lucid.R
@@ -286,7 +286,7 @@ shinyAppsClient <- function(service, authInfo) {
   )
 }
 
-# return a list of functions that can be used to interact with rstudio.cloud
+# return a list of functions that can be used to interact with posit.cloud
 cloudClient <- function(service, authInfo) {
   list(
 

--- a/R/lucid.R
+++ b/R/lucid.R
@@ -2,8 +2,8 @@ lucidClientForAccount <- function(account) {
   authInfo <- account
 
   # determine appropriate server information for account
-  if (account$server == cloudServerInfo()$name) {
-    serverInfo <- cloudServerInfo()
+  if (account$server == cloudServerInfo(account$server)$name) {
+    serverInfo <- cloudServerInfo(account$server)
     constructor = cloudClient
   } else {
     serverInfo <- shinyappsServerInfo()
@@ -23,6 +23,10 @@ shinyAppsClient <- function(service, authInfo) {
 
     status = function() {
       handleResponse(GET(service, authInfo,  "/internal/status"))
+    },
+
+    service = function() {
+      "shinyapps.io"
     },
 
     currentUser = function() {
@@ -288,6 +292,10 @@ cloudClient <- function(service, authInfo) {
 
     status = function() {
       handleResponse(GET(service, authInfo,  "/internal/status"))
+    },
+
+    service = function() {
+      "posit.cloud"
     },
 
     currentUser = function() {

--- a/R/servers.R
+++ b/R/servers.R
@@ -62,10 +62,20 @@ servers <- function(local = FALSE) {
   if (local) {
     locals
   } else {
-    rbind(
+    serversList <- rbind(
       locals,
       as.data.frame(shinyappsServerInfo(), stringsAsFactors = FALSE),
       as.data.frame(cloudServerInfo(), stringsAsFactors = FALSE))
+
+    # RStudio IDE requires a server whose name matches the server name on
+    # previously configured accounts. Prevent breakage for pre-rebrand users.
+    if (!is.null(rsconnect::accounts(server = "rstudio.cloud"))) {
+      serversList <- rbind(
+        serversList,
+        as.data.frame(cloudServerInfo("rstudio.cloud"), stringsAsFactors = FALSE)
+      )
+    }
+    serversList
   }
 }
 

--- a/R/servers.R
+++ b/R/servers.R
@@ -86,8 +86,13 @@ shinyappsServerInfo <- function() {
                                "https://api.shinyapps.io/v1"))
 }
 
-cloudServerInfo <- function() {
-  info <- list(name = "rstudio.cloud",
+cloudServerInfo <- function(name = "posit.cloud") {
+  # We encode the current and prior product names here and call this function to
+  # see if a configured server identifier references the cloud product.
+  if (!is.element(name, c("posit.cloud", "rstudio.cloud"))) {
+    name = "posit.cloud"
+  }
+  info <- list(name = name,
                certificate = inferCertificateContents(
                  system.file("cert/shinyapps.io.pem", package = "rsconnect")),
                url = getOption("rsconnect.shinyapps_url",
@@ -223,14 +228,13 @@ serverInfo <- function(name) {
   if (!isStringParam(name))
     stop(stringParamErrorMessage("name"))
 
-  # there's no config file for shinyapps.io
+  # there's no config file for Posit's hosted offerings
   if (identical(name, "shinyapps.io")) {
     return(shinyappsServerInfo())
   }
 
-  # there's no config file for rstudio.cloud
-  if (identical(name, "rstudio.cloud")) {
-    return(cloudServerInfo())
+  if (identical(name, cloudServerInfo(name)$name)) {
+    return(cloudServerInfo(name))
   }
 
   configFile <- serverConfigFile(name)

--- a/R/servers.R
+++ b/R/servers.R
@@ -11,7 +11,7 @@
 #' The `servers` and `serverInfo` functions are provided for viewing
 #' previously registered servers.
 #'
-#' Servers for `shinyapps.io` and `rstudio.cloud` are always registered.
+#' Servers for `shinyapps.io` and `posit.cloud` are always registered.
 #'
 #' @param name Optional nickname for the server. If none is given, the nickname
 #'   is inferred from the server's hostname.

--- a/man/servers.Rd
+++ b/man/servers.Rd
@@ -57,7 +57,7 @@ using \code{\link[=connectUser]{connectUser()}}.
 The \code{servers} and \code{serverInfo} functions are provided for viewing
 previously registered servers.
 
-Servers for \code{shinyapps.io} and \code{rstudio.cloud} are always registered.
+Servers for \code{shinyapps.io} and \code{posit.cloud} are always registered.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-accounts.R
+++ b/tests/testthat/test-accounts.R
@@ -52,3 +52,10 @@ test_that("account file containing pattern characters found without server name"
     })
   )
 })
+
+test_that("All hosted product names are identified as cloud", {
+  expect_true(isCloudServer("shinyapps.io"))
+  expect_true(isCloudServer("rstudio.cloud"))
+  expect_true(isCloudServer("posit.cloud"))
+  expect_false(isCloudServer("connect.internal"))
+})

--- a/tests/testthat/test-lucid.R
+++ b/tests/testthat/test-lucid.R
@@ -1,0 +1,26 @@
+context("lucid")
+
+test_that("cloud accounts create cloud clients", {
+  account <- list(
+    server = "rstudio.cloud"
+  )
+
+  client <- lucidClientForAccount(account)
+  expect_equal(client$service(), "posit.cloud")
+
+  account <- list(
+    server = "posit.cloud"
+  )
+
+  client <- lucidClientForAccount(account)
+  expect_equal(client$service(), "posit.cloud")
+})
+
+test_that("shinyapps accounts create shinyapps clients", {
+  account <- list(
+    server = "shinyapps.io"
+  )
+
+  client <- lucidClientForAccount(account)
+  expect_equal(client$service(), "shinyapps.io")
+})

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -1,0 +1,30 @@
+context("server")
+
+test_that("servers list", {
+  allServers <- servers()$name
+  predefinedServers <- c()
+  for (server in allServers) {
+    if (identical(server, shinyappsServerInfo()$name)) {
+      predefinedServers <- append(predefinedServers, server)
+    }
+    if (identical(server, cloudServerInfo()$name)) {
+      predefinedServers <- append(predefinedServers, server)
+    }
+  }
+  expect_length(predefinedServers, 2)
+  expect_true(is.element("posit.cloud", predefinedServers))
+  expect_true(is.element("shinyapps.io", predefinedServers))
+})
+
+test_that("cloud server info matches name given if valid", {
+  rstudioServer <- serverInfo("rstudio.cloud")
+  expect_equal(rstudioServer$name, "rstudio.cloud")
+
+  rstudioServer <- serverInfo("posit.cloud")
+  expect_equal(rstudioServer$name, "posit.cloud")
+})
+
+test_that("cloud server info is modern if invalid", {
+  server <- cloudServerInfo("someones.connect.server")
+  expect_equal(server$name, "posit.cloud")
+})


### PR DESCRIPTION
Fixes #636 

This is a bit more than find/replace in order to support accounts and applications that were already published under the `rstudio.cloud` name; lots of logic wants the server name on the account or publication history to match this. We also need to simultaneously support `setAccountInfo()` using both product names for a while to give this release time to be adopted. At a future point we'll update the cloud UI's code snippet to use `server = posit.cloud`.