### PR TITLE
Handle publishing from temp copy cloud sources

### DIFF
--- a/R/lucid.R
+++ b/R/lucid.R
@@ -387,10 +387,14 @@ cloudClient <- function(service, authInfo) {
         current_application = handleResponse(GET(service, authInfo, path))
         project_id = current_application$content_id
 
-        path <- paste("/content/", project_id, sep="")
-        current_project = handleResponse(GET(service, authInfo, path))
-        json$project = current_project$id
-        json$space = current_project$space_id
+        # in case the source cloud project is a temporary copy, there is no
+        # content id. The output will be published without a space id.
+        if (!is.null(project_id)) {
+          path <- paste("/content/", project_id, sep="")
+          current_project = handleResponse(GET(service, authInfo, path))
+          json$project = current_project$id
+          json$space = current_project$space_id
+        }
       }
       output <- handleResponse(POST_JSON(service, authInfo, "/outputs", json))
       path <- paste("/applications/", output$source_id, sep="")


### PR DESCRIPTION
This fixes a bug that prevented creating published outputs from temporary copies of projects in Posit Cloud. Ordinarily, when creating an output from a project in cloud, the source and its output will be linked in Posit Cloud, and the output will appear in the same space as its source. In the case of temporary copy sources, we will allow creating outputs, but do not link them to the temporary source project and always publish the output to the author's personal workspace.

Fixes #635 