### PR TITLE
lint failure confirmation prompt default is "no"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rsconnect 0.8.30 (development version)
 
+* The confirmation prompt presented upon lint failures indicates "no" as its
+  default. (#652)
+
 # rsconnect 0.8.29
 
 * Introduced support for publishing to Posit Cloud. This feature is currently

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -297,7 +297,7 @@ deployApp <- function(appDir = getwd(),
         }
         message("The following potential problems were identified in the project files:\n")
         printLinterResults(lintResults)
-        response <- readline("Do you want to proceed with deployment? [Y/n]: ")
+        response <- readline("Do you want to proceed with deployment? [y/N]: ")
         if (tolower(substring(response, 1, 1)) != "y") {
           message("Cancelling deployment.")
           return(invisible(lintResults))


### PR DESCRIPTION
fixes #652