### PR TITLE
Standardize Posit name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
     person("Aron", "Atkins", role = c("aut", "cre"), email = "aron@posit.co"),
     person("Jonathan", "McPherson", role = "aut", email = "jonathan@posit.co"),
     person("JJ", "Allaire", role = "aut"),
-    person("Posit Software", role = c("cph", "fnd"))
+    person("Posit Software, PBC", role = c("cph", "fnd"))
     )
 Description: Programmatic deployment interface for 'RPubs', 'shinyapps.io', and
     'Posit Connect'. Supported content types include R Markdown documents,


### PR DESCRIPTION
I scraped CRAN to find companies that fund R packages, and noticed that Posit is credited 6 different ways (9 if you include RStudio/RStudio PBC/RStudio, PBC). I'm submitting PRs with the official "Posit Software, PBC" name on the few Posit varieties to nip it in the bud.