### PR TITLE
Simplify temporary options setting

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -1195,8 +1195,8 @@ performPackratSnapshot <- function(bundleDir, verbose = FALSE) {
   # explicitly configured. This is a no-op for older versions of packrat.
   renvDiscovery <- getOption("packrat.dependency.discovery.renv")
   if (is.null(renvDiscovery)) {
-    oldDiscovery <- options("packrat.dependency.discovery.renv" = TRUE)
-    on.exit(options(oldDiscovery), add = TRUE)
+    old <- options("packrat.dependency.discovery.renv" = TRUE)
+    on.exit(options(old), add = TRUE)
   }
 
   # attempt to eagerly load the BiocInstaller or BiocManaager package if installed, to work around

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -150,37 +150,23 @@ deployApp <- function(appDir = getwd(),
   # at verbose log level, turn on all tracing options implicitly for the
   # duration of the call
   if (verbose) {
-    options <- c("rsconnect.http.trace",
-                 "rsconnect.http.trace.json",
-                 "rsconnect.error.trace")
-    restorelist <- list()
-    newlist <- list()
-
-    # record options at non-default position
-    for (option in options) {
-      if (!isTRUE(getOption(option))) {
-        restorelist[[option]] <- FALSE
-        newlist[[option]] <- TRUE
-      }
-    }
-
-    # apply new option values
-    options(newlist)
-
-    # restore all old option values on exit
-    on.exit(options(restorelist), add = TRUE)
+    old_verbose <- options(
+      rsconnect.http.trace = TRUE,
+      rsconnect.http.trace.json = TRUE,
+      rsconnect.error.trace = TRUE
+    )
+    on.exit(options(old_verbose), add = TRUE)
   }
 
   # install error handler if requested
   if (isTRUE(getOption("rsconnect.error.trace"))) {
-    errOption <- getOption("error")
-    options(error = function(e) {
+    old_error <- options(error = function(e) {
       cat("----- Deployment error -----\n")
       cat(geterrmessage(), "\n")
       cat("----- Error stack trace -----\n")
       traceback(x = sys.calls(), max.lines = 3)
     })
-    on.exit(options(error = errOption), add = TRUE)
+    on.exit(options(old_error), add = TRUE)
   }
 
   # normalize appDir path and ensure it exists

--- a/R/lint-framework.R
+++ b/R/lint-framework.R
@@ -155,9 +155,8 @@ lint <- function(project, files = NULL, appPrimaryDoc = NULL) {
   projectContent <- lapply(projectFilesToLint, function(file) {
 
     # force native encoding (disable any potential internal conversion)
-    enc <- getOption("encoding")
-    options(encoding = "native.enc")
-    on.exit(options(encoding = enc), add = TRUE)
+    old <- options(encoding = "native.enc")
+    on.exit(options(old), add = TRUE)
 
     # read content with requested encoding
     # TODO: may consider converting from native encoding to UTF-8 if appropriate


### PR DESCRIPTION
`options()` invisibly returns a list of the previous values, which you can use to reset to the previous state.