### PR TITLE
More `appMetadata()` refactoring

### DIFF
--- a/R/appMetadata.R
+++ b/R/appMetadata.R
@@ -8,14 +8,6 @@ appMetadata <- function(appDir,
 
   appFiles <- standardizeAppFiles(appDir, appFiles)
 
-  if (!is.null(contentCategory)) {
-    assetTypeName <- contentCategory
-  } else if (!is.null(appPrimaryDoc)) {
-    assetTypeName <- "document"
-  } else {
-    assetTypeName <- "application"
-  }
-
   # User has supplied quarto path or quarto package has supplied metdata
   # https://github.com/quarto-dev/quarto-r/blob/08caf0f42504e7/R/publish.R#L117-L121
   hasQuarto <- !is.null(quarto) || !is.null(metadata$quarto_version)
@@ -49,6 +41,13 @@ appMetadata <- function(appDir,
     metadata = metadata
   )
 
+  if (!is.null(contentCategory)) {
+    assetTypeName <- contentCategory
+  } else if (!is.null(appPrimaryDoc)) {
+    assetTypeName <- "document"
+  } else {
+    assetTypeName <- "application"
+  }
 
   list(
     assetTypeName = assetTypeName,

--- a/R/appMetadata.R
+++ b/R/appMetadata.R
@@ -112,13 +112,10 @@ inferAppMode <- function(appDir,
 
   # We gate the deployment of content that appears to be Quarto behind the
   # presence of Quarto metadata. Rmd files can still be deployed as Quarto
-  # content.
-  # TODO(HW): I think this logic should be moved into appMetdata() because this
-  # should also error if the user specified appMode = "quarto-shiny"
   if (requiresQuarto && !hasQuarto) {
-    stop(paste(
-      "Attempting to deploy Quarto content without Quarto metadata.",
-      "Please provide the path to a quarto binary to the 'quarto' argument."
+    cli::cli_abort(c(
+      "Can't deploy Quarto content when {.arg quarto} is {.code NULL}.",
+      i = "Please supply a path to a quarto binary in {.arg quarto}."
     ))
   }
 

--- a/R/appMetadata.R
+++ b/R/appMetadata.R
@@ -8,9 +8,9 @@ appMetadata <- function(appDir,
 
   appFiles <- standardizeAppFiles(appDir, appFiles)
 
-  # User has supplied quarto path or quarto package has supplied metdata
+  # User has supplied quarto path or quarto package has supplied metadata
   # https://github.com/quarto-dev/quarto-r/blob/08caf0f42504e7/R/publish.R#L117-L121
-  hasQuarto <- !is.null(quarto) || !is.null(metadata$quarto_version)
+  hasQuarto <- !is.null(quarto) || hasQuartoMetadata(metadata)
 
   appMode <- inferAppMode(
     appDir = appDir,
@@ -278,7 +278,7 @@ documentHasPythonChunk <- function(filename) {
 }
 
 inferQuartoInfo <- function(appDir, appPrimaryDoc, quarto, metadata) {
-  if (!is.null(metadata$quarto_version)) {
+  if (hasQuartoMetadata(metadata)) {
     return(list(
       version = metadata[["quarto_version"]],
       engines = metadata[["quarto_engines"]]
@@ -303,6 +303,10 @@ inferQuartoInfo <- function(appDir, appPrimaryDoc, quarto, metadata) {
     version = inspect[["quarto"]][["version"]],
     engines = I(inspect[["engines"]])
   )
+}
+
+hasQuartoMetadata <- function(x) {
+  !is.null(x$quarto_version)
 }
 
 # Run "quarto inspect" on the target and returns its output as a parsed object.

--- a/R/appMetadata.R
+++ b/R/appMetadata.R
@@ -6,9 +6,7 @@ appMetadata <- function(appDir,
                         isCloudServer = FALSE,
                         metadata = list()) {
 
-  if (is.null(appFiles)) {
-    appFiles <- bundleFiles(appDir)
-  }
+  appFiles <- standardizeAppFiles(appDir, appFiles)
 
   if (!is.null(contentCategory)) {
     assetTypeName <- contentCategory
@@ -159,15 +157,9 @@ inferAppMode <- function(appDir,
     return("tensorflow-saved-model")
   }
 
-  # no renderable content here; if there's at least one file, we can just serve
-  # it as static content
-  if (length(appFiles) > 0) {
-    return("static")
-  }
-
-  cli::cli_abort(
-    "No content to deploy; {.arg appFiles} is empty"
-  )
+  # no renderable content here and we know that there's at least one
+  # file or bundFiles() would have errored
+  "static"
 }
 
 isShinyRmd <- function(filename) {

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -850,6 +850,13 @@ standardizeAppFiles <- function(appDir, appFiles = NULL, appFileManifest = NULL)
     # file list provided directly
     appFiles <- explodeFiles(appDir, appFiles)
   }
+
+  if (length(appFiles) == 0) {
+    cli::cli_abort(
+      "No content to deploy; {.arg appFiles} is empty"
+    )
+  }
+  appFiles
 }
 
 appUsesPython <- function(quartoInfo) {

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -192,6 +192,9 @@ deployApp <- function(appDir = getwd(),
   appDir <- normalizePath(appDir)
 
   # create the full path that we'll deploy (append document if requested)
+  # TODO(HW): we use appPrimaryDoc here, but we have not inferred it yet
+  # so the appPath will different deneding on whether it's explicitly
+  # supplied or inferred from the files in the directory.
   appPath <- appDir
   if (!is.null(appSourceDoc) && nchar(appSourceDoc) > 0) {
     appPath <- appSourceDoc

--- a/tests/testthat/_snaps/appMetadata.md
+++ b/tests/testthat/_snaps/appMetadata.md
@@ -3,7 +3,7 @@
     Code
       appMetadata(dir)
     Condition
-      Error in `inferAppMode()`:
+      Error in `standardizeAppFiles()`:
       ! No content to deploy; `appFiles` is empty
 
 # quarto docs require quarto

--- a/tests/testthat/_snaps/appMetadata.md
+++ b/tests/testthat/_snaps/appMetadata.md
@@ -12,12 +12,14 @@
       inferAppMode(single_qmd)
     Condition
       Error in `inferAppMode()`:
-      ! Attempting to deploy Quarto content without Quarto metadata. Please provide the path to a quarto binary to the 'quarto' argument.
+      ! Can't deploy Quarto content when `quarto` is `NULL`.
+      i Please supply a path to a quarto binary in `quarto`.
     Code
       inferAppMode(rmd_and_quarto_yml)
     Condition
       Error in `inferAppMode()`:
-      ! Attempting to deploy Quarto content without Quarto metadata. Please provide the path to a quarto binary to the 'quarto' argument.
+      ! Can't deploy Quarto content when `quarto` is `NULL`.
+      i Please supply a path to a quarto binary in `quarto`.
 
 # errors if no files with needed extension
 

--- a/tests/testthat/_snaps/bundle.md
+++ b/tests/testthat/_snaps/bundle.md
@@ -1,0 +1,18 @@
+# writeManifest: Deploying a Quarto project without Quarto info in an error
+
+    Code
+      makeManifest(appDir, appPrimaryDoc = NULL, quarto = NULL)
+    Condition
+      Error in `inferAppMode()`:
+      ! Can't deploy Quarto content when `quarto` is `NULL`.
+      i Please supply a path to a quarto binary in `quarto`.
+
+# writeManifest: Deploying a Quarto doc without Quarto info in an error
+
+    Code
+      makeManifest(appDir, appPrimaryDoc = appPrimaryDoc, quarto = NULL)
+    Condition
+      Error in `inferAppMode()`:
+      ! Can't deploy Quarto content when `quarto` is `NULL`.
+      i Please supply a path to a quarto binary in `quarto`.
+

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -183,13 +183,18 @@ fakeQuartoMetadata <- function(version, engines) {
   return(metadata)
 }
 
+
+test_that("inferQuartoInfo returns null when no quarto is provided", {
+  expect_null(inferQuartoInfo(quarto = NULL, metadata = list()))
+})
+
+
 test_that("inferQuartoInfo correctly detects info when quarto is provided alone", {
   quarto <- quartoPathOrSkip()
 
   quartoInfo <- inferQuartoInfo(
     appDir = test_path("quarto-doc-none"),
     appPrimaryDoc = "quarto-doc-none.qmd",
-    appFiles = bundleFiles("quarto-doc-none"),
     quarto = quarto,
     metadata = list()
   )
@@ -199,7 +204,6 @@ test_that("inferQuartoInfo correctly detects info when quarto is provided alone"
   quartoInfo <- inferQuartoInfo(
     appDir = test_path("quarto-website-r"),
     appPrimaryDoc = NULL,
-    appFiles = bundleFiles("quarto-website-r"),
     quarto = quarto,
     metadata = list()
   )
@@ -207,21 +211,22 @@ test_that("inferQuartoInfo correctly detects info when quarto is provided alone"
   expect_equal(quartoInfo$engines, I(c("knitr")))
 })
 
-test_that("inferQuartoInfo extracts info from metadata when it is provided alone", {
+test_that("inferQuartoInfo extracts info from metadata", {
   metadata <- fakeQuartoMetadata(version = "99.9.9", engines = c("internal-combustion"))
 
   quartoInfo <- inferQuartoInfo(
     appDir = test_path("quarto-website-r"),
     appPrimaryDoc = NULL,
-    appFiles = bundleFiles("quarto-website-r"),
     quarto = NULL,
     metadata = metadata
   )
-  expect_named(quartoInfo, c("version", "engines"))
-  expect_equal(quartoInfo$engines, I(c("internal-combustion")))
+  expect_equal(quartoInfo, list(
+    version = "99.9.9",
+    engines = I("internal-combustion")
+  ))
 })
 
-test_that("inferQuartoInfo prefers using metadata over running quarto inspect itself when both are provided", {
+test_that("inferQuartoInfo prefers using metadata over quarto inspect", {
   quarto <- quartoPathOrSkip()
 
   metadata <- fakeQuartoMetadata(version = "99.9.9", engines = c("internal-combustion"))
@@ -229,20 +234,18 @@ test_that("inferQuartoInfo prefers using metadata over running quarto inspect it
   quartoInfo <- inferQuartoInfo(
     appDir = test_path("quarto-website-r"),
     appPrimaryDoc = NULL,
-    appFiles = bundleFiles("quarto-website-r"),
     quarto = quarto,
     metadata = metadata
   )
   expect_equal(quartoInfo$engines, I(c("internal-combustion")))
 })
 
-test_that("inferQuartoInfo returns NULL when content cannot be rendered by Quarto", {
+test_that("inferQuartoInfo returns NULL for non-quarto content", {
   quarto <- quartoPathOrSkip()
 
   quartoInfo <- inferQuartoInfo(
     appDir = test_path("shinyapp-simple"),
     appPrimaryDoc = NULL,
-    appFiles = bundleFiles("shinyapp-simple"),
     quarto = quarto,
     metadata = list()
   )
@@ -252,16 +255,10 @@ test_that("inferQuartoInfo returns NULL when content cannot be rendered by Quart
 test_that("quartoInspect identifies on Quarto projects", {
   quarto <- quartoPathOrSkip()
 
-  inspect <- quartoInspect(
-    appDir = test_path("quarto-website-r"),
-    quarto = quarto
-  )
+  inspect <- quartoInspect(quarto, test_path("quarto-website-r"))
   expect_true(all(c("quarto", "engines") %in% names(inspect)))
 
-  inspect <- quartoInspect(
-    appDir = test_path("quarto-proj-r-shiny"),
-    quarto = quarto
-  )
+  inspect <- quartoInspect(quarto, test_path("quarto-proj-r-shiny"))
   expect_true(all(c("quarto", "engines") %in% names(inspect)))
 })
 
@@ -269,9 +266,9 @@ test_that("quartoInspect identifies Quarto documents", {
   quarto <- quartoPathOrSkip()
 
   inspect <- quartoInspect(
+    quarto,
     appDir = test_path("quarto-doc-none"),
-    appPrimaryDoc = "quarto-doc-none.qmd",
-    quarto = quarto
+    appPrimaryDoc = "quarto-doc-none.qmd"
   )
   expect_true(all(c("quarto", "engines") %in% names(inspect)))
 })
@@ -279,13 +276,6 @@ test_that("quartoInspect identifies Quarto documents", {
 test_that("quartoInspect returns NULL on non-quarto Quarto content", {
   quarto <- quartoPathOrSkip()
 
-  inspect <- quartoInspect(
-    appDir = test_path("shinyapp-simple"),
-    quarto = quarto
-  )
+  inspect <- quartoInspect(quarto, test_path("shinyapp-simple"))
   expect_null(inspect)
-})
-
-test_that("quartoInspect returns null when no quarto is provided", {
-  expect_null(quartoInspect(appDir = "quarto-website-r", quarto = NULL))
 })

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -5,6 +5,32 @@ test_that("clear error if no files", {
   expect_snapshot(appMetadata(dir), error = TRUE)
 })
 
+test_that("quarto affects mode inference", {
+  dir <- local_temp_app(list("foo.Rmd" = ""))
+
+  metadata <- appMetadata(dir)
+  expect_equal(metadata$appMode, "rmd-static")
+
+  metadata <- appMetadata(dir, quarto = "quarto")
+  expect_equal(metadata$appMode, "quarto-static")
+})
+
+test_that("asserTypeName derived from contentCategory if supplied", {
+  dir <- local_temp_app(list("foo.Rmd" = ""))
+  metadata <- appMetadata(dir, contentCategory = "site")
+  expect_equal(metadata$assetTypeName, "site")
+})
+
+test_that("compute assetTypeName after infering other info", {
+  dir <- local_temp_app(list("foo.Rmd" = ""))
+  metadata <- appMetadata(dir)
+  expect_equal(metadata$assetTypeName, "document")
+
+  dir <- local_temp_app(list("app.R" = ""))
+  metadata <- appMetadata(dir)
+  expect_equal(metadata$assetTypeName, "application")
+})
+
 # inferAppMode ------------------------------------------------------------
 
 test_that("can infer mode for APIs", {

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -31,6 +31,12 @@ test_that("compute assetTypeName after infering other info", {
   expect_equal(metadata$assetTypeName, "application")
 })
 
+test_that("handles special case of appPrimaryDoc as R file", {
+  dir <- local_temp_app(list("foo.R" = ""))
+  metadata <- appMetadata(dir, appPrimaryDoc = "foo.R")
+  expect_equal(metadata$appMode, "shiny")
+})
+
 # inferAppMode ------------------------------------------------------------
 
 test_that("can infer mode for APIs", {
@@ -47,9 +53,6 @@ test_that("can infer mode for shiny apps", {
 
   dir <- local_temp_app(list("server.R" = ""))
   expect_equal(inferAppMode(dir), "shiny")
-
-  dir <- local_temp_app(list("foo.R" = ""))
-  expect_equal(inferAppMode(dir, "foo.R"), "shiny")
 })
 
 test_that("can infer mode for static quarto and rmd docs", {

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -40,32 +40,31 @@ test_that("handles special case of appPrimaryDoc as R file", {
 # inferAppMode ------------------------------------------------------------
 
 test_that("can infer mode for APIs", {
-  dir <- local_temp_app(list("plumber.R" = ""))
-  expect_equal(inferAppMode(dir), "api")
-
-  dir <- local_temp_app(list("entrypoint.R" = ""))
-  expect_equal(inferAppMode(dir), "api")
+  expect_equal(inferAppMode("plumber.R"), "api")
+  expect_equal(inferAppMode("entrypoint.R"), "api")
 })
 
 test_that("can infer mode for shiny apps", {
-  dir <- local_temp_app(list("app.R" = ""))
-  expect_equal(inferAppMode(dir), "shiny")
-
-  dir <- local_temp_app(list("server.R" = ""))
-  expect_equal(inferAppMode(dir), "shiny")
+  expect_equal(inferAppMode("app.R"), "shiny")
+  expect_equal(inferAppMode("server.R"), "shiny")
 })
 
 test_that("can infer mode for static quarto and rmd docs", {
   dir <- local_temp_app(list("foo.Rmd" = ""))
-  expect_equal(inferAppMode(dir), "rmd-static")
-  expect_equal(inferAppMode(dir, hasQuarto = TRUE), "quarto-static")
+  paths <- list.files(dir, full.names = TRUE)
+
+  expect_equal(inferAppMode(paths), "rmd-static")
+  expect_equal(inferAppMode(paths, hasQuarto = TRUE), "quarto-static")
   # Static R Markdown treated as rmd-shiny for shinyapps and rstudio.cloud targets
-  expect_equal(inferAppMode(dir, isCloudServer = TRUE), "rmd-shiny")
+  expect_equal(inferAppMode(paths, isCloudServer = TRUE), "rmd-shiny")
 })
 
 test_that("quarto docs require quarto", {
-  single_qmd <- local_temp_app(list("foo.qmd" = ""))
-  rmd_and_quarto_yml <- local_temp_app(list("foo.Rmd" = "", "_quarto.yaml" = ""))
+  dir <- local_temp_app(list("foo.qmd" = ""))
+  single_qmd <- list.files(dir, full.names = TRUE)
+
+  dir <- local_temp_app(list("foo.Rmd" = "", "_quarto.yaml" = ""))
+  rmd_and_quarto_yml <- list.files(dir, full.names = TRUE)
 
   expect_snapshot(error = TRUE, {
     inferAppMode(single_qmd)
@@ -79,25 +78,31 @@ test_that("can infer mode for shiny quarto and rmd docs", {
   }
 
   dir <- local_temp_app(list("index.Rmd" = yaml_runtime("shiny")))
-  expect_equal(inferAppMode(dir), "rmd-shiny")
+  paths <- list.files(dir, full.names = TRUE)
+  expect_equal(inferAppMode(paths), "rmd-shiny")
 
   dir <- local_temp_app(list("index.Rmd" = yaml_runtime("shinyrmd")))
-  expect_equal(inferAppMode(dir), "rmd-shiny")
+  paths <- list.files(dir, full.names = TRUE)
+  expect_equal(inferAppMode(paths), "rmd-shiny")
 
   dir <- local_temp_app(list("index.Rmd" = yaml_runtime("shiny_prerendered")))
-  expect_equal(inferAppMode(dir), "rmd-shiny")
+  paths <- list.files(dir, full.names = TRUE)
+  expect_equal(inferAppMode(paths), "rmd-shiny")
 
   # And for quarto
   dir <- local_temp_app(list("index.Qmd" = yaml_runtime("shiny")))
-  expect_equal(inferAppMode(dir, hasQuarto = TRUE), "quarto-shiny")
+  paths <- list.files(dir, full.names = TRUE)
+  expect_equal(inferAppMode(paths, hasQuarto = TRUE), "quarto-shiny")
 
   # can pair server.R with shiny runtime
   dir <- local_temp_app(list("index.Rmd" = yaml_runtime("shiny"), "server.R" = ""))
-  expect_equal(inferAppMode(dir), "rmd-shiny")
+  paths <- list.files(dir, full.names = TRUE)
+  expect_equal(inferAppMode(paths), "rmd-shiny")
 
   # Beats static rmarkdowns
   dir <- local_temp_app(list("index.Rmd" = yaml_runtime("shiny"), "foo.Rmd" = ""))
-  expect_equal(inferAppMode(dir), "rmd-shiny")
+  paths <- list.files(dir, full.names = TRUE)
+  expect_equal(inferAppMode(paths), "rmd-shiny")
 })
 
 test_that("Shiny R Markdown files are detected correctly", {
@@ -115,13 +120,11 @@ test_that("shiny metadata process correctly", {
 })
 
 test_that("can infer tensorflow models", {
-  dir <- local_temp_app(list("saved_model.pb" = ""))
-  expect_equal(inferAppMode(dir), "tensorflow-saved-model")
+  expect_equal(inferAppMode("saved_model.pb"), "tensorflow-saved-model")
 })
 
 test_that("otherwise, fallsback to static deploy", {
-  dir <- local_temp_app(list("a.html" = "", "b.html" = ""))
-  expect_equal(inferAppMode(dir), "static")
+  expect_equal(inferAppMode(c("a.html", "b.html")), "static")
 })
 
 # inferAppPrimaryDoc ------------------------------------------------------

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -29,7 +29,7 @@ test_that("can infer mode for shiny apps", {
 test_that("can infer mode for static quarto and rmd docs", {
   dir <- local_temp_app(list("foo.Rmd" = ""))
   expect_equal(inferAppMode(dir), "rmd-static")
-  expect_equal(inferAppMode(dir, quartoInfo = list()), "quarto-static")
+  expect_equal(inferAppMode(dir, hasQuarto = TRUE), "quarto-static")
   # Static R Markdown treated as rmd-shiny for shinyapps and rstudio.cloud targets
   expect_equal(inferAppMode(dir, isCloudServer = TRUE), "rmd-shiny")
 })
@@ -60,7 +60,7 @@ test_that("can infer mode for shiny quarto and rmd docs", {
 
   # And for quarto
   dir <- local_temp_app(list("index.Qmd" = yaml_runtime("shiny")))
-  expect_equal(inferAppMode(dir, quartoInfo = list()), "quarto-shiny")
+  expect_equal(inferAppMode(dir, hasQuarto = TRUE), "quarto-shiny")
 
   # can pair server.R with shiny runtime
   dir <- local_temp_app(list("index.Rmd" = yaml_runtime("shiny"), "server.R" = ""))

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -517,29 +517,19 @@ test_that("writeManifest: Quarto Python-only website gets correct manifest data"
 })
 
 test_that("writeManifest: Deploying a Quarto project without Quarto info in an error", {
-  missingQuartoInfoErrorText <- paste(
-    "Attempting to deploy Quarto content without Quarto metadata.",
-    "Please provide the path to a quarto binary to the 'quarto' argument."
-  )
-
   appDir <- test_path("quarto-website-r")
-  expect_error(
+  expect_snapshot(
     makeManifest(appDir, appPrimaryDoc = NULL, quarto = NULL),
-    missingQuartoInfoErrorText
+    error = TRUE
   )
 })
 
 test_that("writeManifest: Deploying a Quarto doc without Quarto info in an error", {
-  missingQuartoInfoErrorText <- paste(
-    "Attempting to deploy Quarto content without Quarto metadata.",
-    "Please provide the path to a quarto binary to the 'quarto' argument."
-  )
-
   appDir <- test_path("quarto-doc-none")
   appPrimaryDoc <- "quarto-doc-none.qmd"
-  expect_error(
+  expect_snapshot(
     makeManifest(appDir, appPrimaryDoc = appPrimaryDoc, quarto = NULL),
-    missingQuartoInfoErrorText
+    error = TRUE
   )
 })
 


### PR DESCRIPTION
I've made a bunch of small and steady changes to hopefully make `appMetadata()` easier to understand. Highlights:

* New `hasQuartoMetadata()` function makes allows us to figure out if quarto is needed earlier, allowing `inferQuartoInfo()` to be simpler and to come later in the process.
* I've pulled out the one special case of `inferAppMode()` that used the `appPrimaryDoc`, making it more clear that we can figure out the mode, and then figure out the primary doc.
* `inferAppMode()` now just gets a vector paths in the root directory of the app.

I'm reasonably confident that this hasn't change any behaviour and that the overall flow should now be easier to understand.