### PR TITLE
More `deployApp()` refactoring

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -302,28 +302,7 @@ deployApp <- function(appDir = getwd(),
                               isCloudServer(accountDetails$server), metadata, image)
 
       if (isCloudServer(accountDetails$server)) {
-
-        # Step 1. Create presigned URL and register pending bundle.
-        bundleSize <- file.info(bundlePath)$size
-
-        # Generate a hex-encoded md5 hash.
-        checksum <- fileMD5.as.string(bundlePath)
-        bundle <- client$createBundle(application$id, "application/x-tar", bundleSize, checksum)
-
-        logger("Starting upload now")
-        # Step 2. Upload Bundle to presigned URL
-        if (!uploadBundle(bundle, bundleSize, bundlePath)) {
-          stop("Could not upload file.")
-        }
-        logger("Upload complete")
-
-        # Step 3. Upload revise bundle status.
-        response <- client$updateBundleStatus(bundle$id, status = "ready")
-
-        # Step 4. Retrieve updated bundle post status change - which is required in subsequent
-        # areas of the code below.
-        bundle <- client$getBundle(bundle$id)
-
+        bundle <- uploadCloudBundle(client, application$id, bundlePath)
       } else {
         bundle <- client$uploadApplication(application$id, bundlePath)
       }
@@ -398,7 +377,6 @@ deployApp <- function(appDir = getwd(),
 
   invisible(deploymentSucceeded)
 }
-
 
 # Does almost exactly the same work as writeManifest(), but called within
 # deployApp() instead of being exposed to the user. Returns the path to the

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -236,13 +236,7 @@ deployApp <- function(appDir = getwd(),
   }
 
   # invoke pre-deploy hook if we have one
-  preDeploy <- getOption("rsconnect.pre.deploy")
-  if (is.function(preDeploy)) {
-    if (verbose) {
-      cat("Invoking pre-deploy hook rsconnect.pre.deploy\n")
-    }
-    preDeploy(appPath)
-  }
+  runDeploymentHook(appPath, "rsconnect.pre.deploy", verbose = verbose)
 
   appFiles <- standardizeAppFiles(appDir, appFiles, appFileManifest)
 
@@ -358,13 +352,7 @@ deployApp <- function(appDir = getwd(),
 
   # invoke post-deploy hook if we have one
   if (deploymentSucceeded) {
-    postDeploy <- getOption("rsconnect.post.deploy")
-    if (is.function(postDeploy)) {
-      if (verbose) {
-        cat("Invoking post-deploy hook rsconnect.post.deploy\n")
-      }
-      postDeploy(appPath)
-    }
+    runDeploymentHook(appPath, "rsconnect.post.deploy", verbose = verbose)
   }
 
   logger("Deployment log finished")
@@ -387,6 +375,21 @@ needsVisibilityChange <- function(server, application, appVisibility = NULL) {
     cur <- "public"
   }
   cur != appVisibility
+}
+
+runDeploymentHook <- function(appPath, option, verbose = FALSE) {
+  hook <- getOption(option)
+  if (!is.function(hook)) {
+    return()
+  }
+
+  name <- gsub("rsconnect.", "", option, fixed = TRUE)
+  name <- gsub(".", "-", name, fixed = TRUE)
+
+  if (verbose) {
+    cat("Invoking ", name, " hook ", option, "\n", sep = "")
+  }
+  hook(appPath)
 }
 
 

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -383,11 +383,8 @@ runDeploymentHook <- function(appPath, option, verbose = FALSE) {
     return()
   }
 
-  name <- gsub("rsconnect.", "", option, fixed = TRUE)
-  name <- gsub(".", "-", name, fixed = TRUE)
-
   if (verbose) {
-    cat("Invoking ", name, " hook ", option, "\n", sep = "")
+    cat("Invoking `", option, "` hook\n", sep = "")
   }
   hook(appPath)
 }

--- a/R/lucid.R
+++ b/R/lucid.R
@@ -620,6 +620,34 @@ isContentType <- function(response, contentType) {
   grepl(contentType, response$contentType, fixed = TRUE)
 }
 
+uploadCloudBundle <- function(client,
+                              application_id,
+                              bundlePath,
+                              verbose = FALSE) {
+  # Step 1. Create presigned URL and register pending bundle.
+  bundleSize <- file.info(bundlePath)$size
+  bundle <- client$createBundle(
+    application_id,
+    content_type = "application/x-tar",
+    content_length = bundleSize,
+    checksum = fileMD5.as.string(bundlePath)
+  )
+
+  # Step 2. Upload Bundle to presigned URL
+  logger <- verboseLogger(verbose)
+  logger("Starting upload now")
+  if (!uploadBundle(bundle, bundleSize, bundlePath)) {
+    stop("Could not upload file.")
+  }
+  logger("Upload complete")
+
+  # Step 3. Upload revise bundle status.
+  response <- client$updateBundleStatus(bundle$id, status = "ready")
+
+  # Step 4. Retrieve updated bundle post status change
+  client$getBundle(bundle$id)
+}
+
 uploadBundle <- function(bundle, bundleSize, bundlePath) {
 
   presigned_service <- parseHttpUrl(bundle$presigned_url)

--- a/tests/testthat/_snaps/deployApp.md
+++ b/tests/testthat/_snaps/deployApp.md
@@ -3,5 +3,5 @@
     Code
       . <- runDeploymentHook("PATH", "rsconnect.pre.deploy", verbose = TRUE)
     Output
-      Invoking pre-deploy hook rsconnect.pre.deploy
+      Invoking `rsconnect.pre.deploy` hook
 

--- a/tests/testthat/_snaps/deployApp.md
+++ b/tests/testthat/_snaps/deployApp.md
@@ -1,0 +1,7 @@
+# deployHook executes function if set
+
+    Code
+      . <- runDeploymentHook("PATH", "rsconnect.pre.deploy", verbose = TRUE)
+    Output
+      Invoking pre-deploy hook rsconnect.pre.deploy
+

--- a/tests/testthat/test-deployApp.R
+++ b/tests/testthat/test-deployApp.R
@@ -16,3 +16,19 @@ test_that("needsVisibilityChange() returns FALSE when no change needed", {
   expect_true(needsVisibilityChange("shinyapps.io", dummyApp(NULL), "private"))
   expect_true(needsVisibilityChange("shinyapps.io", dummyApp("public"), "private"))
 })
+
+test_that("deployHook executes function if set", {
+  expect_equal(
+    runDeploymentHook("PATH", "rsconnect.pre.deploy"),
+    NULL
+  )
+
+  withr::local_options(rsconnect.pre.deploy = function(path) path)
+  expect_equal(
+    runDeploymentHook("PATH", "rsconnect.pre.deploy"),
+    "PATH"
+  )
+  expect_snapshot(
+    . <- runDeploymentHook("PATH", "rsconnect.pre.deploy", verbose = TRUE)
+  )
+})

--- a/tests/testthat/test-deployApp.R
+++ b/tests/testthat/test-deployApp.R
@@ -1,0 +1,18 @@
+test_that("needsVisibilityChange() returns FALSE when no change needed", {
+
+  dummyApp <- function(visibility) {
+    list(
+      deployment = list(
+        properties = list(
+          application.visibility = visibility
+        )
+      )
+    )
+  }
+
+  expect_false(needsVisibilityChange("connect.com"))
+  expect_false(needsVisibilityChange("shinyapps.io", dummyApp("public"), NULL))
+  expect_false(needsVisibilityChange("shinyapps.io", dummyApp("public"), "public"))
+  expect_true(needsVisibilityChange("shinyapps.io", dummyApp(NULL), "private"))
+  expect_true(needsVisibilityChange("shinyapps.io", dummyApp("public"), "private"))
+})


### PR DESCRIPTION
Nothing major here, just pulling out a few helper functions to make the flow of `deployApp()` a bit clearer.