### PR TITLE
Reduce the usage of appPath

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rsconnect 0.8.30 (development version)
 
+* The `rsconnect.pre.deploy` and `rsconnect.post.deploy` hooks are now always
+  called with the content directory, not sometimes the path to a specific file
+  (#696).
+
 * `showMetrics()` once again returns a correctly named data frame (#528).
 
 * `listBundleFiles()` and hence `deployApp()` now correctly handles `.rscignore` 

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -237,7 +237,7 @@ deployApp <- function(appDir = getwd(),
   }
 
   # invoke pre-deploy hook if we have one
-  runDeploymentHook(appPath, "rsconnect.pre.deploy", verbose = verbose)
+  runDeploymentHook(appDir, "rsconnect.pre.deploy", verbose = verbose)
 
   appFiles <- standardizeAppFiles(appDir, appFiles, appFileManifest)
 
@@ -247,7 +247,7 @@ deployApp <- function(appDir = getwd(),
   }
 
   # determine the deployment target and target account info
-  target <- deploymentTarget(appPath, appName, appTitle, appId, account, server)
+  target <- deploymentTarget(recordDir, appName, appTitle, appId, account, server)
 
   # test for compatibility between account type and publish intent
   if (!isCloudServer(target$server) && identical(upload, FALSE)) {
@@ -353,7 +353,7 @@ deployApp <- function(appDir = getwd(),
 
   # invoke post-deploy hook if we have one
   if (deploymentSucceeded) {
-    runDeploymentHook(appPath, "rsconnect.post.deploy", verbose = verbose)
+    runDeploymentHook(appDir, "rsconnect.post.deploy", verbose = verbose)
   }
 
   logger("Deployment log finished")
@@ -378,7 +378,7 @@ needsVisibilityChange <- function(server, application, appVisibility = NULL) {
   cur != appVisibility
 }
 
-runDeploymentHook <- function(appPath, option, verbose = FALSE) {
+runDeploymentHook <- function(appDir, option, verbose = FALSE) {
   hook <- getOption(option)
   if (!is.function(hook)) {
     return()
@@ -387,7 +387,7 @@ runDeploymentHook <- function(appPath, option, verbose = FALSE) {
   if (verbose) {
     cat("Invoking `", option, "` hook\n", sep = "")
   }
-  hook(appPath)
+  hook(appDir)
 }
 
 

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -56,8 +56,11 @@
 #'   the local system prior to deployment. If `FALSE` then it is re-deployed
 #'   using the last version that was uploaded. `FALSE` is only supported on
 #'   shinyapps.io; `TRUE` is required on Posit Connect.
-#' @param recordDir Directory where publish record is written. Can be `NULL`
-#'   in which case record will be written to the location specified with `appDir`.
+#' @param recordDir Directory where deployment record is written. The default,
+#'   `NULL`, uses `appDir`, since this is usually where you want the deployment
+#'   data to be stored. This argument is typically only needed when deploying
+#'   a directory of static files since you want to store the record with the
+#'   code that generated those files, not the files themselves.
 #' @param launch.browser If true, the system's default web browser will be
 #'   launched automatically after the app is started. Defaults to `TRUE` in
 #'   interactive sessions only. If a function is passed, it will be called

--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -1,6 +1,6 @@
 # calculate the deployment target based on the passed parameters and
 # any saved deployments that we have
-deploymentTarget <- function(appPath = ".",
+deploymentTarget <- function(recordPath = ".",
                              appName = NULL,
                              appTitle = NULL,
                              appId = NULL,
@@ -9,7 +9,7 @@ deploymentTarget <- function(appPath = ".",
                              error_call = caller_env()) {
 
   appDeployments <- deployments(
-    appPath = appPath,
+    appPath = recordPath,
     nameFilter = appName,
     accountFilter = account,
     serverFilter = server
@@ -18,11 +18,10 @@ deploymentTarget <- function(appPath = ".",
   if (nrow(appDeployments) == 0) {
     fullAccount <- findAccount(account, server)
     if (is.null(appName)) {
-      appName <- generateAppName(appTitle, appPath, account, unique = FALSE)
+      appName <- generateAppName(appTitle, recordPath, account, unique = FALSE)
     }
 
     createDeploymentTarget(
-      appPath,
       appName,
       appTitle %||% "",
       appId,
@@ -32,7 +31,6 @@ deploymentTarget <- function(appPath = ".",
     )
   } else if (nrow(appDeployments) == 1) {
     createDeploymentTarget(
-      appPath,
       appDeployments$name,
       appTitle %||% appDeployments$title,
       appDeployments$appId,
@@ -55,8 +53,7 @@ deploymentTarget <- function(appPath = ".",
   }
 }
 
-createDeploymentTarget <- function(appPath,
-                                   appName,
+createDeploymentTarget <- function(appName,
                                    appTitle,
                                    appId,
                                    username,

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -81,8 +81,11 @@ the local system prior to deployment. If \code{FALSE} then it is re-deployed
 using the last version that was uploaded. \code{FALSE} is only supported on
 shinyapps.io; \code{TRUE} is required on Posit Connect.}
 
-\item{recordDir}{Directory where publish record is written. Can be \code{NULL}
-in which case record will be written to the location specified with \code{appDir}.}
+\item{recordDir}{Directory where deployment record is written. The default,
+\code{NULL}, uses \code{appDir}, since this is usually where you want the deployment
+data to be stored. This argument is typically only needed when deploying
+a directory of static files since you want to store the record with the
+code that generated those files, not the files themselves.}
 
 \item{launch.browser}{If true, the system's default web browser will be
 launched automatically after the app is started. Defaults to \code{TRUE} in

--- a/man/options.Rd
+++ b/man/options.Rd
@@ -34,8 +34,8 @@ Supported global options include:
    \item{\code{rsconnect.max.bundle.size}}{The maximum size, in bytes, for deployed content. If not set, defaults to 3 GB.}
    \item{\code{rsconnect.max.bundle.files}}{The maximum number of files to deploy. If not set, defaults to 10,000.}
    \item{\code{rsconnect.force.update.apps}}{When \code{TRUE}, bypasses the prompt to confirm whether you wish to update previously-deployed content}
-   \item{\code{rsconnect.pre.deploy}}{A function to run prior to deploying content; it receives as an argument the path to the content that's about to be deployed.}
-   \item{\code{rsconnect.post.deploy}}{A function to run after successfully deploying content; it receives as an argument the path to the content that was just deployed.}
+   \item{\code{rsconnect.pre.deploy}}{A function to run prior to deploying content; it receives as an argument the directory containing the content  about to be deployed.}
+   \item{\code{rsconnect.post.deploy}}{A function to run after successfully deploying content; it receives as an argument the directory containing the content  about to be deployed.}
    \item{\code{rsconnect.python.enabled}}{When \code{TRUE}, use the python executable specified by the \code{RETICULATE_PYTHON} environment variable and add a \code{python} section to the deployment manifest. By default, python is enabled when deploying to Posit Connect and disabled when deploying to shinyapps.io.}
 }
 When deploying content from the RStudio IDE, the rsconnect package's deployment methods are executed in a vanilla R session that doesn't execute startup scripts. This can make it challenging to ensure options are set properly prior to push-button deployment, so the rsconnect package has a parallel set of ``startup'' scripts it runs prior to deploying. The follow are run in order, if they exist, prior to deployment:


### PR DESCRIPTION
* I think the hooks should always get a directory, not sometimes a path.

* It's clear that `deploymentTarget` should get the path where the deployments are recorded

@aronatkins this is part of a very gradual unpicking of the complicated `appPath`/`recordDir` logic in `deployApp()`.