### PR TITLE
`use_tidy_description()` and remove unused packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,16 +1,21 @@
-Package: rsconnect
 Type: Package
-Title: Deployment Interface for R Markdown Documents and Shiny Applications
+Package: rsconnect
+Title: Deployment Interface for R Markdown Documents and Shiny
+    Applications
 Version: 0.8.29-1
 Authors@R: c(
-    person("Aron", "Atkins", role = c("aut", "cre"), email = "aron@posit.co"),
-    person("Jonathan", "McPherson", role = "aut", email = "jonathan@posit.co"),
+    person("Aron", "Atkins", , "aron@posit.co", role = c("aut", "cre")),
+    person("Jonathan", "McPherson", , "jonathan@posit.co", role = "aut"),
     person("JJ", "Allaire", role = "aut"),
     person("Posit Software, PBC", role = c("cph", "fnd"))
-    )
-Description: Programmatic deployment interface for 'RPubs', 'shinyapps.io', and
-    'Posit Connect'. Supported content types include R Markdown documents,
-    Shiny applications, Plumber APIs, plots, and static web content.
+  )
+Description: Programmatic deployment interface for 'RPubs',
+    'shinyapps.io', and 'Posit Connect'. Supported content types include R
+    Markdown documents, Shiny applications, Plumber APIs, plots, and
+    static web content.
+License: GPL-2
+URL: https://github.com/rstudio/rsconnect
+BugReports: https://github.com/rstudio/rsconnect/issues
 Depends:
     R (>= 3.0.0)
 Imports:
@@ -25,24 +30,21 @@ Imports:
     tools,
     yaml (>= 2.1.5)
 Suggests:
-    MASS,
-    RCurl,
     callr,
     httpuv,
     knitr,
+    MASS,
+    mockr,
     plumber (>= 0.3.2),
+    RCurl,
     reticulate,
     rmarkdown (>= 1.1),
     shiny,
     sourcetools,
     testthat (>= 3.0.0),
-    xtable,
     withr,
-    mockr
-License: GPL-2
-Encoding: UTF-8
-RoxygenNote: 7.2.3
-Roxygen: list(markdown = TRUE)
-URL: https://github.com/rstudio/rsconnect
-BugReports: https://github.com/rstudio/rsconnect/issues
+    xtable
 Config/testthat/edition: 3
+Encoding: UTF-8
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rsconnect
-Title: Deployment Interface for R Markdown Documents and Shiny
-    Applications
+Title: Deploy Docs, Apps, and APIs to Posit Connect, shinyapps.io, and
+    RPubs
 Version: 0.8.29-1
 Authors@R: c(
     person("Aron", "Atkins", , "aron@posit.co", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,10 +40,8 @@ Suggests:
     reticulate,
     rmarkdown (>= 1.1),
     shiny,
-    sourcetools,
     testthat (>= 3.0.0),
-    withr,
-    xtable
+    withr
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
xtable and sourcetools don't appear to be used anywhere.