### PR TITLE
Change strategy for generating appName

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # rsconnect 0.8.30 (development version)
 
+* `deployApp()` now derives `appName` from `appDir` and `appPrimaryDoc`, 
+  never using the title. It also tells you what name has used (#538).
+  It now only simplifies the path if you are publishing to shinyapps.io,
+  since its restrictions on application names are much tighter than those
+  of Posit Connect.
+  
+* `generateAppName()` has been deprecated as using the `appTitle` to generate
+  the `appName` leads to confusion if you later try to change the title.
+
 * `deployApp()` is more aggressive about saving deployment data, which should
   make it less likely that you need to repeat yourself after a failed 
   deployment. In particular, it now saves both before and after uploading the

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -33,10 +33,13 @@
 #'   being deployed.
 #' @param appSourceDoc `r lifecycle::badge("deprecated")` Please use
 #'   `recordDir` instead.
-#' @param appName Name of application (names must be unique within an account).
-#'   If not supplied on the first deploy, it will be generated from the base
-#'   name of `appDir` and `appTitle`, if supplied. On subsequent deploys,
-#'   it will use the previously stored value.
+#' @param appName Application name, a string consisting of letters, numbers,
+#'   `_` and `-`. The application name is used to identify applications on a
+#'   server, so much be unique.
+#'
+#'   If not specified, the first deployment will be automatically it from the
+#'   `appDir` for directory and website, and from the `appPrimaryDoc` for
+#'   document. On subsequent deploys, it will use the previously stored value.
 #' @param appTitle Free-form descriptive title of application. Optional; if
 #'   supplied, will often be displayed in favor of the name. If ommitted,
 #'   on second and subsequent deploys, the title will be unchanged.
@@ -247,7 +250,15 @@ deployApp <- function(appDir = getwd(),
 
   # determine the deployment target and target account info
   recordPath <- findRecordPath(appDir, recordDir, appPrimaryDoc)
-  target <- deploymentTarget(recordPath, appName, appTitle, appId, account, server)
+  target <- deploymentTarget(
+    recordPath = recordPath,
+    appName = appName,
+    appTitle = appTitle,
+    appId = appId,
+    account = account,
+    server = server,
+    quiet = quiet
+  )
 
   # test for compatibility between account type and publish intent
   if (!isCloudServer(target$server) && identical(upload, FALSE)) {
@@ -269,7 +280,7 @@ deployApp <- function(appDir = getwd(),
       recordPath,
       target = target,
       application = application,
-      metadata = metadata
+      metadata = metadata,
     )
   })
 

--- a/R/title.R
+++ b/R/title.R
@@ -1,5 +1,13 @@
 #' Generate Application Name
 #'
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
+#' This function has been deprecated since we no longer believe that using the
+#' title to generate the name is a sound approach, and if the app name is
+#' already present, it's better for you to come up with your own unique name
+#' than relying on an automated algorithm.
+#'
 #' Generate a short name (identifier) for an application given an application
 #' title.
 #'
@@ -22,6 +30,7 @@
 #' (note that it is not guaranteed to be unique on the server). This behavior
 #' can be disabled by setting `unique = FALSE`.
 #'
+#' @keywords internal
 #' @examples
 #' \dontrun{
 #' # Generate a short name for a sample application
@@ -30,6 +39,8 @@
 #' @export
 
 generateAppName <- function(appTitle, appPath = NULL, account = NULL, unique = TRUE) {
+  lifecycle::deprecate_warn("0.9.0", "generateAppName()")
+
   munge <- function(title) {
     # safe default if no title specified
     if (is.null(title)) {

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -52,10 +52,13 @@ being deployed.}
 \item{appSourceDoc}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Please use
 \code{recordDir} instead.}
 
-\item{appName}{Name of application (names must be unique within an account).
-If not supplied on the first deploy, it will be generated from the base
-name of \code{appDir} and \code{appTitle}, if supplied. On subsequent deploys,
-it will use the previously stored value.}
+\item{appName}{Application name, a string consisting of letters, numbers,
+\verb{_} and \code{-}. The application name is used to identify applications on a
+server, so much be unique.
+
+If not specified, the first deployment will be automatically it from the
+\code{appDir} for directory and website, and from the \code{appPrimaryDoc} for
+document. On subsequent deploys, it will use the previously stored value.}
 
 \item{appTitle}{Free-form descriptive title of application. Optional; if
 supplied, will often be displayed in favor of the name. If ommitted,

--- a/man/generateAppName.Rd
+++ b/man/generateAppName.Rd
@@ -20,6 +20,13 @@ or an individual document. Optional.}
 Returns a valid short name for the application.
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
+This function has been deprecated since we no longer believe that using the
+title to generate the name is a sound approach, and if the app name is
+already present, it's better for you to come up with your own unique name
+than relying on an automated algorithm.
+
 Generate a short name (identifier) for an application given an application
 title.
 }
@@ -40,3 +47,4 @@ can be disabled by setting \code{unique = FALSE}.
 generateAppName("My Father's Country", "~/fathers-country", "myacct")
 }
 }
+\keyword{internal}

--- a/man/showMetrics.Rd
+++ b/man/showMetrics.Rd
@@ -28,10 +28,13 @@ for available metrics.}
 \item{appDir}{A directory containing an application (e.g. a Shiny app
 or plumber API). Defaults to the current directory.}
 
-\item{appName}{Name of application (names must be unique within an account).
-If not supplied on the first deploy, it will be generated from the base
-name of \code{appDir} and \code{appTitle}, if supplied. On subsequent deploys,
-it will use the previously stored value.}
+\item{appName}{Application name, a string consisting of letters, numbers,
+\verb{_} and \code{-}. The application name is used to identify applications on a
+server, so much be unique.
+
+If not specified, the first deployment will be automatically it from the
+\code{appDir} for directory and website, and from the \code{appPrimaryDoc} for
+document. On subsequent deploys, it will use the previously stored value.}
 
 \item{account, server}{Uniquely identify a remote server with either your
 user \code{account}, the \code{server} name, or both. Use \code{\link[=accounts]{accounts()}} to see the

--- a/tests/testthat/_snaps/deploymentTarget.md
+++ b/tests/testthat/_snaps/deploymentTarget.md
@@ -72,3 +72,10 @@
       i Known servers: "foo1" and "foo2".
       i Known account names: "ron".
 
+# succeeds if there are no deployments and a single account
+
+    Code
+      target <- deploymentTarget(app_dir)
+    Message
+      Using `appName` "my_app"
+

--- a/tests/testthat/_snaps/title.md
+++ b/tests/testthat/_snaps/title.md
@@ -1,0 +1,8 @@
+# generateAppName has been deprecated
+
+    Code
+      . <- generateAppName("my title")
+    Condition
+      Warning:
+      `generateAppName()` was deprecated in rsconnect 0.9.0.
+

--- a/tests/testthat/test-title.R
+++ b/tests/testthat/test-title.R
@@ -1,15 +1,24 @@
+test_that("generateAppName has been deprecated", {
+  expect_snapshot({
+    . <- generateAppName("my title")
+  })
+})
+
 test_that("generated application names do not exceed maximum length", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   title <- "Good heavens, this title is simply enormous! I can't imagine why anyone would use such a cumbersome moniker."
   name <- generateAppName(title)
   expect_lt(nchar(name), 65)
 })
 
 test_that("empty titles are rejected", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   title <- ""
   expect_error(generateAppName(title))
 })
 
 test_that("path is used to generate valid title if title isn't specified", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   title <- NULL
   path <- "shiny-app-in-subdir"
   name <- generateAppName(title, path)
@@ -17,12 +26,14 @@ test_that("path is used to generate valid title if title isn't specified", {
 })
 
 test_that("invalid characters are removed from titles", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   title <- "Free!* (* = With $5 Donation)"
   name <- generateAppName(title)
   expect_false(grepl("[!*=$]", name))
 })
 
 test_that("valid characters are not removed from titles", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   title <- "inexpensive_kittens-5"
   name <- generateAppName(title)
   expect_identical(title, name)


### PR DESCRIPTION
* No longer use `appTitle`
* Make the reasoning behind use of `recordPath` more clear
* Only munge for shinyApps
* Deprecates `generateAppName()`

Fixes #538