### PR TITLE
Improve output from deployApp()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # rsconnect 0.8.30 (development version)
 
+* `deployApp()` output has been thorougly reviewed and tweaked. As well as 
+  general polish it now gives you more information about what it has discovered
+  about the deployment, like the app name, account & server, and which files
+  are included in the bundle (#669).
+
 * `deployApp()` will now warn if `appFiles` or `appManifestFiles` contain
   files that don't exist, rather than silently ignoring them (#706).
 

--- a/R/accounts.R
+++ b/R/accounts.R
@@ -505,3 +505,7 @@ print.rsconnect_secret <- function(x, ...) {
 str.rsconnect_secret <- function(object, ...) {
   cat(" ", format(object), "\n", sep = "")
 }
+
+accountId <- function(account, server) {
+  paste0(account, "@", server)
+}

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -227,5 +227,6 @@ createAppManifest <- function(appDir,
   } else {
     manifest$users <- NA
   }
+
   manifest
 }

--- a/R/connect.R
+++ b/R/connect.R
@@ -163,15 +163,17 @@ connectClient <- function(service, authInfo) {
       while (TRUE) {
         path <- paste0(file.path("/tasks", taskId), "?first_status=", start)
         response <- handleResponse(GET(service, authInfo, path))
+        messages <- unlist(response$status)
 
-        labeledMessage <- function(msg) {
-          message(paste("[Connect]", msg))
-        }
+        # Strip timestamps, if found
+        timestamp_re <- "\\d{4}/\\d{2}/\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3,} "
+        messages <- gsub(timestamp_re, "", messages)
 
-        if (length(response$status) > 0) {
-          lapply(response$status, labeledMessage)
-          start <- response$last_status
-        }
+        # Made headers more prominent.
+        heading <- grepl("^# ", messages)
+        messages[heading] <- cli::style_bold(messages[heading])
+        cat(paste0(messages, "\n", collapse = ""))
+
         if (length(response$finished) > 0 && response$finished) {
           return(response)
         }

--- a/R/connect.R
+++ b/R/connect.R
@@ -163,16 +163,21 @@ connectClient <- function(service, authInfo) {
       while (TRUE) {
         path <- paste0(file.path("/tasks", taskId), "?first_status=", start)
         response <- handleResponse(GET(service, authInfo, path))
-        messages <- unlist(response$status)
 
-        # Strip timestamps, if found
-        timestamp_re <- "\\d{4}/\\d{2}/\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3,} "
-        messages <- gsub(timestamp_re, "", messages)
+        if (length(response$status) > 0) {
+          messages <- unlist(response$status)
 
-        # Made headers more prominent.
-        heading <- grepl("^# ", messages)
-        messages[heading] <- cli::style_bold(messages[heading])
-        cat(paste0(messages, "\n", collapse = ""))
+          # Strip timestamps, if found
+          timestamp_re <- "\\d{4}/\\d{2}/\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3,} "
+          messages <- gsub(timestamp_re, "", messages)
+
+          # Made headers more prominent.
+          heading <- grepl("^# ", messages)
+          messages[heading] <- cli::style_bold(messages[heading])
+          cat(paste0(messages, "\n", collapse = ""))
+
+          start <- response$last_status
+        }
 
         if (length(response$finished) > 0 && response$finished) {
           return(response)

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -352,7 +352,7 @@ deployApp <- function(appDir = getwd(),
   if (deploymentSucceeded) {
     cli::cli_alert_success("Successfully deployed to {.url {application$url}}")
   } else {
-    cli::cli_alert_danger("Deployment failed with error: {repsonse$error}")
+    cli::cli_alert_danger("Deployment failed with error: {response$error}")
   }
 
   if (!quiet)

--- a/R/deployDoc.R
+++ b/R/deployDoc.R
@@ -44,16 +44,14 @@ standardizeSingleDocDeployment <- function(path,
   check_file(path, error_call = error_call, error_arg = error_arg)
   path <- normalizePath(path)
 
-  withStatus <- withStatus(quiet)
-
   if (isShinyRmd(path)) {
     # deploy entire directory
     appFiles <- NULL
   } else if (isStaticFile(path)) {
-    # deploy file + dependenciy
-    withStatus("Discovering document dependencies", {
-      resources <- rmarkdown::find_external_resources(path)
-    })
+    taskStart(quiet, "Discovering document dependencies...")
+    resources <- rmarkdown::find_external_resources(path)
+    taskComplete(quiet, "Document dependencies discovered")
+
     appFiles <- c(basename(path), resources$path)
   } else {
     # deploy just the file

--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -6,6 +6,7 @@ deploymentTarget <- function(recordPath = ".",
                              appId = NULL,
                              account = NULL,
                              server = NULL,
+                             quiet = FALSE,
                              error_call = caller_env()) {
 
   appDeployments <- deployments(
@@ -20,6 +21,10 @@ deploymentTarget <- function(recordPath = ".",
     if (is.null(appName)) {
       appName <- generateAppName(appTitle, recordPath, account, unique = FALSE)
     }
+    if (!quiet) {
+      dest <- accountId(fullAccount$name, fullAccount$server)
+      cli::cli_alert_info("Deploying {.val {appName}} to {.val {dest}}")
+    }
 
     createDeploymentTarget(
       appName,
@@ -30,6 +35,12 @@ deploymentTarget <- function(recordPath = ".",
       fullAccount$server
     )
   } else if (nrow(appDeployments) == 1) {
+    if (!quiet) {
+      name <- appDeployments$name
+      dest <- accountId(appDeployments$username, appDeployments$server)
+      cli::cli_alert_info("Re-deploying {.val {name}} to {.val {dest}}")
+    }
+
     createDeploymentTarget(
       appDeployments$name,
       appTitle %||% appDeployments$title,

--- a/R/utils.R
+++ b/R/utils.R
@@ -30,17 +30,6 @@ displayStatus <- function(quiet) {
   }
 }
 
-withStatus <- function(quiet) {
-  quiet <- quiet || httpDiagnosticsEnabled()
-  function(status, code) {
-    if (!quiet)
-      cat(status, "...", sep = "")
-    force(code)
-    if (!quiet)
-      cat("DONE\n")
-  }
-}
-
 httpDiagnosticsEnabled <- function() {
   return(getOption("rsconnect.http.trace", FALSE) ||
          getOption("rsconnect.http.verbose", FALSE))


### PR DESCRIPTION
* Add some bigger structure with `cli::cat_rule()`
* Inform about appName and destination
* Don't display bundle/application ID so many times
* List uploaded files
* Strip timestamps from connect logs, highlight headings, and display on stdout, not stderr

Fixes #669