### PR TITLE
More deployment refactoring

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -108,6 +108,13 @@ accountConfigFiles <- function(server = NULL) {
 
 # deployments -------------------------------------------------------------
 
+deploymentHistoryPath <- function(new = FALSE) {
+  file.path(
+    rsconnectConfigDir("deployments"),
+    paste0("history", if (new) ".new", ".dcf")
+  )
+}
+
 # given a path, return the directory under which rsconnect package state is
 # stored
 deploymentConfigDir <- function(recordPath) {

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -1,36 +1,3 @@
-saveDeployment <- function(recordDir,
-                           target,
-                           application,
-                           bundleId = NULL,
-                           hostUrl = serverInfo(target$server)$hostUrl,
-                           metadata = list()) {
-
-  deployment <- deploymentRecord(
-    name = target$appName,
-    title = target$appTitle,
-    username = target$username,
-    account = target$account,
-    server = target$server,
-    hostUrl = hostUrl,
-    appId = application$id,
-    bundleId = bundleId,
-    url = application$url,
-    metadata = metadata
-  )
-  path <- deploymentConfigFile(recordDir, target$appName, target$account, target$server)
-  writeDeploymentRecord(deployment, path)
-
-  # also save to global history
-  addToDeploymentHistory(recordDir, deployment)
-
-  invisible(NULL)
-}
-
-writeDeploymentRecord <- function(record, filePath) {
-  # use a long width so URLs don't line-wrap
-  write.dcf(record, filePath, width = 4096)
-}
-
 #' List Application Deployments
 #'
 #' List deployment records for a given application.
@@ -118,6 +85,34 @@ deploymentFields <- c(
   "bundleId", "url", "when", "lastSyncTime"
 )
 
+saveDeployment <- function(recordDir,
+                           target,
+                           application,
+                           bundleId = NULL,
+                           hostUrl = serverInfo(target$server)$hostUrl,
+                           metadata = list()) {
+
+  deployment <- deploymentRecord(
+    name = target$appName,
+    title = target$appTitle,
+    username = target$username,
+    account = target$account,
+    server = target$server,
+    hostUrl = hostUrl,
+    appId = application$id,
+    bundleId = bundleId,
+    url = application$url,
+    metadata = metadata
+  )
+  path <- deploymentConfigFile(recordDir, target$appName, target$account, target$server)
+  writeDeploymentRecord(deployment, path)
+
+  # also save to global history
+  addToDeploymentHistory(recordDir, deployment)
+
+  invisible(NULL)
+}
+
 deploymentRecord <- function(name,
                              title,
                              username,
@@ -145,6 +140,11 @@ deploymentRecord <- function(name,
     lastSyncTime = lastSyncTime
   )
   c(standard, metadata)
+}
+
+writeDeploymentRecord <- function(record, filePath) {
+  # use a long width so URLs don't line-wrap
+  write.dcf(record, filePath, width = 4096)
 }
 
 # Workbench uses to show a list of recently deployed content on user dashboard

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -165,6 +165,7 @@ addToDeploymentHistory <- function(appPath, deploymentRecord) {
 
   # overwrite with new history
   file.rename(newHistory, history)
+  invisible()
 }
 
 #' Forget Application Deployment

--- a/tests/testthat/_snaps/deployments.md
+++ b/tests/testthat/_snaps/deployments.md
@@ -1,0 +1,18 @@
+# addToDeploymentHistory() adds needed new lines
+
+    Code
+      addToDeploymentHistory("path", list(x = 1))
+      writeLines(readLines(deploymentHistoryPath()))
+    Output
+      x: 1
+      appPath: path
+    Code
+      addToDeploymentHistory("path", list(x = 2))
+      writeLines(readLines(deploymentHistoryPath()))
+    Output
+      x: 2
+      appPath: path
+      
+      x: 1
+      appPath: path
+

--- a/tests/testthat/test-deployments.R
+++ b/tests/testthat/test-deployments.R
@@ -143,3 +143,14 @@ test_that("saveDeployment appends to global history", {
   expect_equal(nrow(history), 1)
   expect_setequal(colnames(history), c(deploymentFields, "appPath"))
 })
+
+test_that("addToDeploymentHistory() adds needed new lines", {
+  local_temp_config()
+
+  expect_snapshot({
+    addToDeploymentHistory("path", list(x = 1))
+    writeLines(readLines(deploymentHistoryPath()))
+    addToDeploymentHistory("path", list(x = 2))
+    writeLines(readLines(deploymentHistoryPath()))
+  })
+})

--- a/tests/testthat/test-deployments.R
+++ b/tests/testthat/test-deployments.R
@@ -2,12 +2,34 @@ test_that("deployments() works empty data frame if no deployments", {
   dir <- local_temp_app()
   out <- deployments(dir)
   expect_s3_class(out, "data.frame")
+  expect_named(out, c(deploymentFields, "deploymentFile"))
   expect_equal(nrow(out), 0)
 })
 
+test_that("combines fields across deployments", {
+  local_temp_config()
+  dir <- local_temp_app()
+
+  writeDeploymentRecord(
+    list(x = 1),
+    deploymentConfigFile(dir, "app1", "account", "server")
+  )
+  writeDeploymentRecord(
+    list(y = 1),
+    deploymentConfigFile(dir, "app2", "account", "server")
+  )
+
+  out <- deployments(dir)
+  expect_s3_class(out, "data.frame")
+  expect_named(out, c(deploymentFields, "x", "y", "deploymentFile"))
+  expect_equal(nrow(out), 2)
+})
+
 test_that("deployments() can filter", {
+  local_temp_config()
   mockr::local_mock(accounts = fakeAccounts(c("foo", "bar"), c("foo", "bar")))
   dir <- local_temp_app()
+
   saveDeployment(
     dir,
     createDeploymentTarget(
@@ -19,7 +41,7 @@ test_that("deployments() can filter", {
       server = "foo"
     ),
     application = list(),
-    hostUrl = NA
+    hostUrl = NULL
   )
   saveDeployment(
     dir,
@@ -32,7 +54,7 @@ test_that("deployments() can filter", {
       server = "bar"
     ),
     application = list(id = "123"),
-    hostUrl = NA
+    hostUrl = NULL
   )
 
   out <- deployments(dir)
@@ -64,7 +86,7 @@ test_that("deployments() can excludes orphans", {
       server = "bar1"
     ),
     application = list(),
-    hostUrl = NA
+    hostUrl = NULL
   )
   out <- deployments(dir)
   expect_equal(nrow(out), 0)
@@ -74,8 +96,10 @@ test_that("deployments() can excludes orphans", {
 })
 
 test_that("can read/write metadata", {
+  local_temp_config()
   mockr::local_mock(accounts = fakeAccounts("foo", "bar"))
   dir <- local_temp_app()
+
   saveDeployment(
     dir,
     createDeploymentTarget(
@@ -87,10 +111,35 @@ test_that("can read/write metadata", {
       server = "bar"
     ),
     application = list(),
-    hostUrl = NA,
+    hostUrl = NULL,
     metadata = list(meta1 = "one", meta2 = "two")
   )
   out <- deployments(dir, excludeOrphaned = FALSE)
   expect_equal(out$meta1, "one")
   expect_equal(out$meta2, "two")
+})
+
+test_that("saveDeployment appends to global history", {
+  local_temp_config()
+
+  mockr::local_mock(accounts = fakeAccounts("foo", "bar"))
+  dir <- local_temp_app()
+
+  saveDeployment(
+    dir,
+    createDeploymentTarget(
+      appName = "my-app",
+      appTitle = "",
+      appId = 10,
+      account = "foo",
+      username = "foo",
+      server = "bar"
+    ),
+    application = list(),
+    hostUrl = NULL
+  )
+
+  history <- read.dcf(deploymentHistoryPath())
+  expect_equal(nrow(history), 1)
+  expect_setequal(colnames(history), c(deploymentFields, "appPath"))
 })


### PR DESCRIPTION
* Remove unused code from `deploymentRecord()`, and return a list instead of data frame
* Perform all record value standardisation in `deploymentRecord()`
* Add more tests

To do:
* [ ] After review, organise functions in more logical order