### PR TITLE
Bundle .Rprofile with documents

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # rsconnect 0.8.30 (development version)
 
-* `deployDoc()` includes a `.Rprofile` in the bundle, if one found in the 
+* `deployDoc()` includes a `.Rprofile` in the bundle, if one is found in the 
   same directory as the document.
 
 * Removed Rmd generation code (`writeRmdIndex()`) which had not worked, or

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rsconnect 0.8.30 (development version)
 
+* `deployDoc()` includes a `.Rprofile` in the bundle, if one found in the 
+  same directory as the document.
+
 * Removed Rmd generation code (`writeRmdIndex()`) which had not worked, or
   been necessary, for quite some time (#106, #109).
 

--- a/R/deployDoc.R
+++ b/R/deployDoc.R
@@ -5,10 +5,10 @@
 #' `.pdf`).
 #'
 #' When deploying an `.Rmd`, `.Qmd`, or `.html`, `deployDoc()` will attempt to
-#' automatically discover dependencies using [rmarkdown::find_external_resources()].
-#' If you find that the document is missing dependencies, either specify the
-#' dependencies explicitly in the document (see
-#' [rmarkdown::find_external_resources()] for details), or call
+#' automatically discover dependencies using [rmarkdown::find_external_resources()],
+#' and include an `.Rprofile` if present. If you find that the document is
+#' missing dependencies, either specify the dependencies explicitly in the
+#' document (see [rmarkdown::find_external_resources()] for details), or call
 #' [deployApp()] directly and specify your own file list in `appFiles`.
 #'
 #' @param doc Path to the document to deploy.
@@ -53,6 +53,11 @@ standardizeSingleDocDeployment <- function(path,
     taskComplete(quiet, "Document dependencies discovered")
 
     appFiles <- c(basename(path), resources$path)
+
+    if (file.exists(file.path(dirname(path), ".Rprofile"))) {
+      appFiles <- c(appFiles, ".Rprofile")
+    }
+    appFiles
   } else {
     # deploy just the file
     appFiles <- basename(path)

--- a/man/deployDoc.Rd
+++ b/man/deployDoc.Rd
@@ -18,10 +18,10 @@ Deploys a single R Markdown, Quarto document, or other file (e.g. \code{.html} o
 \code{.pdf}).
 
 When deploying an \code{.Rmd}, \code{.Qmd}, or \code{.html}, \code{deployDoc()} will attempt to
-automatically discover dependencies using \code{\link[rmarkdown:find_external_resources]{rmarkdown::find_external_resources()}}.
-If you find that the document is missing dependencies, either specify the
-dependencies explicitly in the document (see
-\code{\link[rmarkdown:find_external_resources]{rmarkdown::find_external_resources()}} for details), or call
+automatically discover dependencies using \code{\link[rmarkdown:find_external_resources]{rmarkdown::find_external_resources()}},
+and include an \code{.Rprofile} if present. If you find that the document is
+missing dependencies, either specify the dependencies explicitly in the
+document (see \code{\link[rmarkdown:find_external_resources]{rmarkdown::find_external_resources()}} for details), or call
 \code{\link[=deployApp]{deployApp()}} directly and specify your own file list in \code{appFiles}.
 }
 \examples{

--- a/tests/testthat/test-deployDoc.R
+++ b/tests/testthat/test-deployDoc.R
@@ -36,6 +36,17 @@ test_that("regular rmd deploys file and dependencies", {
   expect_equal(doc$appFiles, c("foo.Rmd", "foo.csv"))
 })
 
+test_that("regular rmd deploys .Rprofile, if present", {
+  dir <- local_temp_app(list(
+    "foo.Rmd" ="",
+    ".Rprofile" = ""
+  ))
+
+  doc <- standardizeSingleDocDeployment(file.path(dir, "foo.Rmd"), quiet = TRUE)
+  expect_equal(doc$appFiles, c("foo.Rmd", ".Rprofile"))
+})
+
+
 test_that("other types deploy that one file", {
   dir <- local_temp_app(list("foo.R" = ""))
   doc <- standardizeSingleDocDeployment(file.path(dir, "foo.R"))

--- a/tests/testthat/test-deployDoc.R
+++ b/tests/testthat/test-deployDoc.R
@@ -38,7 +38,7 @@ test_that("regular rmd deploys file and dependencies", {
 
 test_that("regular rmd deploys .Rprofile, if present", {
   dir <- local_temp_app(list(
-    "foo.Rmd" ="",
+    "foo.Rmd" = "",
     ".Rprofile" = ""
   ))
 


### PR DESCRIPTION
This is important because .Rprofile is the only way to control various knitr settings, and is used when you run `rmarkdown::render()` locally.