### PR TITLE
Remove unneeded call to cli::format_inline()

### DIFF
--- a/R/utils-cli.R
+++ b/R/utils-cli.R
@@ -14,7 +14,6 @@ cli_menu <- function(header,
       call = error_call
     )
   }
-  choices <- sapply(choices, cli::format_inline, .envir = .envir, USE.NAMES = FALSE)
 
   choices <- paste0(cli::style_bold(seq_along(choices)), ": ", choices)
   cli::cli_inform(


### PR DESCRIPTION
This is no longer needed, and will cause a bug if `choices` contains a literal `{`.