### PR TITLE
Handle HTTP redirects

### DIFF
--- a/R/ide.R
+++ b/R/ide.R
@@ -17,84 +17,45 @@ validateServerUrl <- function(url, certificate = NULL) {
 # The URL may be specified with or without the protocol and port; this function
 # will try both http and https and follow any redirects given by the server.
 validateConnectUrl <- function(url, certificate = NULL) {
-  tryAllProtocols <- TRUE
-
-  if (!grepl("://", url, fixed = TRUE))
-  {
+  # Add protocol if missing, assuming https except for local installs
+  if (!grepl("://", url, fixed = TRUE)) {
     if (grepl(":3939", url, fixed = TRUE)) {
-      # assume http for default (local) connect installations
       url <- paste0("http://", url)
     } else {
-      # assume https elsewhere
       url <- paste0("https://", url)
     }
   }
-
-  # if the URL ends with a port number, don't try http/https on the same port
-  if (grepl(":\\d+/?$", url)) {
-    tryAllProtocols <- FALSE
-  }
-
-  settingsEndpoint <- "/server_settings"
   url <- ensureConnectServerUrl(url)
+  is_http <- grepl("^http://", url)
 
-  # populate certificate if supplied
-  certificate <- inferCertificateContents(certificate)
+  GET_server_settings <- function(url) {
+    auth_info <- list(certificate = inferCertificateContents(certificate))
+    GET(
+      parseHttpUrl(url),
+      auth_info,
+      "/server_settings",
+      timeout = getOption("rsconnect.http.timeout", 10)
+    )
+  }
 
-  # begin trying URLs to discover the correct one
   response <- NULL
-  errMessage <- ""
-  retry <- TRUE
-  while (retry) {
-    tryCatch({
-      response <- GET(parseHttpUrl(url),
-                          list(certificate = certificate),
-                          settingsEndpoint,
-                          timeout = getOption("rsconnect.http.timeout", 10))
-
-      httpResponse <- attr(response, "httpResponse")
-      # check for redirect
-      if (httpResponse$status == 307 &&
-          !is.null(httpResponse$location)) {
-
-        # we were served a redirect; try again with the new URL
-        url <- httpResponse$location
-        if (substring(url, (nchar(url) - nchar(settingsEndpoint)) + 1)   ==
-            settingsEndpoint) {
-          # chop /server_settings from the redirect path to get the raw API path
-          url <- substring(url, 1, nchar(url) - nchar(settingsEndpoint))
-        }
-        next
-      }
-      if (!isContentType(httpResponse, "application/json")) {
-        response <- NULL
-        errMessage <- "Endpoint did not return JSON"
-      }
-
-      # got a real response; stop trying now
-      retry <- FALSE
-    }, error = function(e) {
-      if (inherits(e, "OPERATION_TIMEDOUT") && tryAllProtocols) {
-        # if the operation timed out on one protocol, try the other one (note
-        # that we don't do this if a port is specified)
-        if (substring(url, 1, 7) == "http://") {
-          url <<- paste0("https://", substring(url, 8))
-        } else if (substring(url, 1, 8) == "https://") {
-          url <<- paste0("http://", substring(url, 9))
-        }
-        tryAllProtocols <<- FALSE
-        return()
-      }
-      errMessage <<- e$message
-      retry <<- FALSE
-    })
+  cnd <- catch_cnd(response <- GET_server_settings(url), "error")
+  if (is_http && cnd_inherits(cnd, "OPERATION_TIMEDOUT")) {
+    url <- gsub("^http://", "https://", url)
+    cnd <- catch_cnd(response <- GET_server_settings(url), "error")
   }
 
-  if (is.null(response)) {
-    list(valid = FALSE, message = errMessage)
-  } else {
-    list(valid = TRUE, url = url, response = response)
+  if (!is.null(cnd)) {
+    return(list(valid = FALSE, message = conditionMessage(cnd)))
   }
+
+  httpResponse <- attr(response, "httpResponse")
+  if (!isContentType(httpResponse, "application/json")) {
+    return(list(valid = FALSE, message = "Endpoint did not return JSON"))
+  }
+
+  url <- gsub("/server_settings$", "", buildHttpUrl(httpResponse$req))
+  list(valid = TRUE, url = url, response = response)
 }
 
 # given a server URL, returns that server's short name. if the server is not

--- a/tests/testthat/test-ide.R
+++ b/tests/testthat/test-ide.R
@@ -1,7 +1,7 @@
 test_that("validateConnectUrl() returns expected return for some known endpoints", {
 
-  expect_false(validateConnectUrl("http://posit.cloud")$valid)
-  expect_false(validateConnectUrl("http://shinyapps.io")$valid)
+  expect_false(validateConnectUrl("https://posit.cloud")$valid)
+  expect_false(validateConnectUrl("https://shinyapps.io")$valid)
   expect_true(validateConnectUrl("https://connect.rstudioservices.com/")$valid)
   expect_true(validateConnectUrl("https://colorado.posit.co/rsc")$valid)
 })
@@ -11,4 +11,9 @@ test_that("validateConnectUrl() normalises urls", {
   expect_equal(validateConnectUrl("connect.rstudioservices.com")$url, api_url)
   expect_equal(validateConnectUrl("connect.rstudioservices.com")$url, api_url)
   expect_equal(validateConnectUrl("https://connect.rstudioservices.com/")$url, api_url)
+})
+
+test_that("validateConnectUrl() follows redirects", {
+  api_url <- "https://connect.rstudioservices.com:443/__api__"
+  expect_equal(validateConnectUrl("http://connect.rstudioservices.com")$url, api_url)
 })


### PR DESCRIPTION
Fixes #674

Uploading to shinyapps.io works without redirects because the result of `client$updateBundleStatus()`, which needs the redirect, was not used.

@aronatkins any ideas for testing? I verified that this works with an interactive deployment to shinyapps, and the `httpRequest()` path is tested via `validateConnectUrl()`. But currently no automated tests hit the `httpRequestWithBody()`  path.  Would you mind also verifying that connect/shinyapps doesn't emit any 307 or 308 redirects that I should be respecting?