### PR TITLE
Use cli_rule() instead of cat_rule()

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -259,7 +259,7 @@ deployApp <- function(appDir = getwd(),
   }
 
   if (!quiet) {
-    cli::cat_rule("Preparing for deployment")
+    cli::cli_rule("Preparing for deployment")
   }
 
   # determine the deployment target and target account info
@@ -389,14 +389,14 @@ deployApp <- function(appDir = getwd(),
   }
 
   if (!quiet) {
-    cli::cat_rule("Deploying to server")
+    cli::cli_rule("Deploying to server")
   }
   task <- client$deployApplication(application$id, bundle$id)
   taskId <- if (is.null(task$task_id)) task$id else task$task_id
   # wait for the deployment to complete (will raise an error if it can't)
   response <- client$waitForTask(taskId, quiet)
   if (!quiet) {
-    cli::cat_rule("Deployment complete")
+    cli::cli_rule("Deployment complete")
   }
 
   # wait 1/10th of a second for any queued output get picked by RStudio


### PR DESCRIPTION
This ensures that the rules go to the same stream as the rest of the feedback. Fixes #756.

@aronatkins I'm not sure if you want more here. It would be nice to include the deployed url in the output, but it's currently a logical vector, so if we wanted to avoid breaking existing code, we'd need to add it as an attribute, which doesn't seem super appealing. Another alternative would be to implement something like `lastDeployment()` which would read the most recent deployment from the global deployment history.