### PR TITLE
Deprecate all non-libcurl backends

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # rsconnect 0.8.30 (development version)
 
+* Non-libcurl `rsconnect.http` options have been deprecated. This allows us to 
+  focus our efforts on a single backend, rather than spreading development
+  efforts across five. The old backends will remain available for at least 2
+  years, but if you are using them because libcurl doesn't work for you, please
+  report the problem ASAP so we can fix it.
+
 * Uploading large files to rpubs works once more (#450).
 
 * `deployApp()` includes some new conveniences for large uploads including

--- a/R/http.R
+++ b/R/http.R
@@ -296,6 +296,18 @@ httpTrace <- function(method, path, time) {
 
 httpFunction <- function() {
   httpType <- getOption("rsconnect.http", "libcurl")
+
+  if (is_string(httpType) && httpType != "libcurl") {
+    lifecycle::deprecate_warn(
+      "0.9.0",
+      I("The `rsconnect.http` option"),
+      details = c(
+        "It should no longer be necessary to set this option",
+        "If the default http handler doesn't work for you, please file an issue at <https://github.com/rstudio/rsconnect/issues>"
+      )
+    )
+  }
+
   if (identical("libcurl", httpType)) {
     httpLibCurl
   } else if (identical("rcurl", httpType)) {

--- a/tests/testthat/_snaps/http.md
+++ b/tests/testthat/_snaps/http.md
@@ -68,3 +68,13 @@
       Error in `POST()`:
       ! <http://127.0.0.1:{port}/status/403> failed with HTTP status 403
 
+# non-libCurl methods are deprecated
+
+    Code
+      . <- httpFunction()
+    Condition
+      Warning:
+      The `rsconnect.http` option was deprecated in rsconnect 0.9.0.
+      i It should no longer be necessary to set this option
+      i If the default http handler doesn't work for you, please file an issue at <https://github.com/rstudio/rsconnect/issues>
+

--- a/tests/testthat/test-http-curl.R
+++ b/tests/testthat/test-http-curl.R
@@ -1,6 +1,6 @@
 test_that("basic HTTP methods work", {
   skip_if(Sys.which("curl") == "")
-  withr::local_options(rsconnect.http = "curl")
+  withr::local_options(rsconnect.http = "curl", lifecycle_verbosity = "quiet")
 
   test_http_GET()
   test_http_POST_JSON()

--- a/tests/testthat/test-http-internal.R
+++ b/tests/testthat/test-http-internal.R
@@ -1,5 +1,5 @@
 test_that("basic HTTP methods work", {
-  withr::local_options(rsconnect.http = "internal")
+  withr::local_options(rsconnect.http = "internal", lifecycle_verbosity = "quiet")
 
   test_http_GET()
   test_http_POST_JSON()

--- a/tests/testthat/test-http-rcurl.R
+++ b/tests/testthat/test-http-rcurl.R
@@ -1,6 +1,6 @@
 test_that("basic HTTP methods work", {
   skip_if_not_installed("RCurl")
-  withr::local_options(rsconnect.http = "rcurl")
+  withr::local_options(rsconnect.http = "rcurl", lifecycle_verbosity = "quiet")
 
   test_http_GET()
   test_http_POST_JSON()

--- a/tests/testthat/test-http.R
+++ b/tests/testthat/test-http.R
@@ -105,3 +105,8 @@ test_that("http error includes status in error class", {
     class = "rsconnect_http_403"
   )
 })
+
+test_that("non-libCurl methods are deprecated", {
+  withr::local_options(rsconnect.http = "internal")
+  expect_snapshot(. <- httpFunction())
+})


### PR DESCRIPTION
@aronatkins I think we agree that we want slowly move towards a single backend that is thoroughly tested. The main question is the speed and I'm happy to take your suggestion; treat this as a starting proposal.