### PR TITLE
Build development version of site

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -30,7 +30,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, any::devtools, local::.
+          extra-packages: any::pkgdown, local::.
           needs: website
 
       - name: Build site
@@ -38,8 +38,8 @@ jobs:
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
-        uses: JamesIves/github-pages-deploy-action@v4
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           clean: false
           branch: gh-pages

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: rsconnect
 Title: Deploy Docs, Apps, and APIs to Posit Connect, shinyapps.io, and
     RPubs
-Version: 0.8.29-1
+Version: 0.8.29.9000
 Authors@R: c(
     person("Aron", "Atkins", , "aron@posit.co", role = c("aut", "cre")),
     person("Toph", "Allen", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# rsconnect 0.8.30 (development version)
+# rsconnect (development version)
 
 * New `rsconnect.http.headers` and `rsconnect.http.cookies` allow you to
   set extra arbitrary additional headers/cookies on each request (#405).

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,8 @@
 url: https://rstudio.github.io/rsconnect
 
+development:
+  mode: auto
+
 template:
   bootstrap: 5
 

--- a/tests/testthat/_snaps/bundle.md
+++ b/tests/testthat/_snaps/bundle.md
@@ -4,7 +4,7 @@
       tweakRProfile(path)
       writeLines(readLines(path))
     Output
-      # Modified by rsconnect package 0.8.29.1 on <NOW>
+      # Modified by rsconnect package <VERSION> on <NOW>
       # Line 1
       # renv initialization disabled in published application
       # source("renv/activate.R")

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -252,6 +252,10 @@ test_that("removes renv/packrat activation", {
       tweakRProfile(path)
       writeLines(readLines(path))
     },
-    transform = function(x) gsub("on \\d{4}.+", "on <NOW>", x)
+    transform = function(x) {
+      x <- gsub("on \\d{4}.+", "on <NOW>", x)
+      x <- gsub(packageVersion("rsconnect"), "<VERSION>", x, fixed = TRUE)
+      x
+    }
   )
 })


### PR DESCRIPTION
This changes the current version to 0.8.29.9000 which causes our tooling to formally recognise it as a development verison. Then we can build and deploys on every push, using pkgdown auto mode to put the development versions in a `dev/` subdirectory.