### PR TITLE
Tweak handling when appId set

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -264,25 +264,26 @@ deployApp <- function(appDir = getwd(),
 
   # determine the deployment target and target account info
   recordPath <- findRecordPath(appDir, recordDir, appPrimaryDoc)
-  if (is.null(appId)) {
-    target <- deploymentTarget(
-      recordPath = recordPath,
-      appName = appName,
-      appTitle = appTitle,
-      account = account,
-      server = server,
-      forceUpdate = forceUpdate
-    )
-  } else {
-    if (!is.null(appName)) {
-      cli::cli_warn("{.arg appName} is ignored when {.arg appId} is set")
-    }
-
+  if (!is.null(appId) && is.null(appName)) {
+    # User has supplied only appId, so retrieve app data from server
+    # IDE supplies both appId and appName so should never hit this branch
     target <- deploymentTargetForApp(
       appId = appId,
       appTitle = appTitle,
       account = account,
       server = server
+    )
+  } else {
+    # Use name/account/server to look up existing deployment;
+    # create new deployment if no match found
+    target <- deploymentTarget(
+      recordPath = recordPath,
+      appId = appId,
+      appName = appName,
+      appTitle = appTitle,
+      account = account,
+      server = server,
+      forceUpdate = forceUpdate
     )
   }
   if (is.null(target$appId)) {

--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -1,6 +1,7 @@
 # calculate the deployment target based on the passed parameters and
 # any saved deployments that we have
 deploymentTarget <- function(recordPath = ".",
+                             appId = NULL,
                              appName = NULL,
                              appTitle = NULL,
                              account = NULL,
@@ -47,6 +48,18 @@ deploymentTarget <- function(recordPath = ".",
       fullAccount$server
     )
   } else if (nrow(appDeployments) == 1) {
+    # If both appName and appId supplied, check that they're consistent.
+    if (!is.null(appId) && appDeployments$appId != appId) {
+      cli::cli_abort(
+        c(
+          "Supplied {.arg appId} ({appId}) does not match deployment record ({appDeployments$appId}).",
+          i = "Omit {.arg appId} to use existing for deployment for app {.str {appName}}, or",
+          i = "Omit {.arg appName} to create new deployment record."
+        ),
+        call = error_call
+      )
+    }
+
     updateDeploymentTarget(appDeployments, appTitle)
   } else {
     apps <- paste0(
@@ -69,6 +82,7 @@ deploymentTarget <- function(recordPath = ".",
     updateDeploymentTarget(appDeployments[idx, ], appTitle)
   }
 }
+
 
 deploymentTargetForApp <- function(appId,
                                    appTitle = NULL,

--- a/tests/testthat/_snaps/deploymentTarget.md
+++ b/tests/testthat/_snaps/deploymentTarget.md
@@ -83,6 +83,16 @@
       2: test (ron@server2.com): <https://server2.com/ron/123>
       Selection: 1
 
+# errors if single deployment and appId doesn't match
+
+    Code
+      deploymentTarget(app_dir, appName = "test", appId = "2")
+    Condition
+      Error:
+      ! Supplied `appId` (2) does not match deployment record (1).
+      i Omit `appId` to use existing for deployment for app "test", or
+      i Omit `appName` to create new deployment record.
+
 # shouldUpdateApp errors when non-interactive
 
     Code

--- a/tests/testthat/test-deploymentTarget.R
+++ b/tests/testthat/test-deploymentTarget.R
@@ -78,9 +78,6 @@ test_that("succeeds if there's a single existing deployment", {
   local_temp_config()
   addTestServer()
   addTestAccount("ron")
-  mockr::local_mock(
-    applications = function(...) data.frame()
-  )
 
   app_dir <- withr::local_tempdir()
   addTestDeployment(app_dir, appName = "test", appId = "1", username = "ron")
@@ -92,6 +89,20 @@ test_that("succeeds if there's a single existing deployment", {
   target <- deploymentTarget(app_dir, appName = "test")
   expect_equal(target$appId, "1")
   expect_equal(target$username, "ron")
+})
+
+test_that("errors if single deployment and appId doesn't match", {
+  local_temp_config()
+  addTestServer()
+  addTestAccount("ron")
+
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(app_dir, appName = "test", appId = "1", username = "ron")
+
+  expect_snapshot(
+    error = TRUE,
+    deploymentTarget(app_dir, appName = "test", appId = "2")
+  )
 })
 
 test_that("new title overrides existing title", {


### PR DESCRIPTION
The IDE supplies both `appName` and `appId` when deploying so we can't assume supply `appId` means "create record from data on server". Now, we only take that path if `appId` is set but `appName` is not, and a check to make sure that if both are specified they consistent.

I tested this interactively by creating a new project containing a single Rmd. I then published that Rmd to colorado.posit.co and connect.rstudioservices.com, and verified I could then republish to either server.

Fixes #775