### PR TITLE
Stop httpbin.org failures from affecting build

### DIFF
--- a/tests/testthat/helper-http.R
+++ b/tests/testthat/helper-http.R
@@ -22,6 +22,15 @@ local_cookie_store <- function(env = caller_env()) {
   withr::defer(env_bind(.cookieStore, !!!old), envir = env)
 }
 
+skip_on_http_failure <- function(code) {
+  tryCatch(
+    code,
+    rsconnect_http = function(cnd) {
+      testthat::skip("http request failed")
+    }
+  )
+}
+
 # Generic tests of various http methods -----------------------------------
 
 test_http_GET <- function() {

--- a/tests/testthat/test-http-libcurl.R
+++ b/tests/testthat/test-http-libcurl.R
@@ -31,18 +31,18 @@ test_that("can get and set cookies", {
   service <- parseHttpUrl("http://httpbin.org/")
 
   # Setting
-  GET(service, list(), "cookies/set", query = "a=1")
+  skip_on_http_failure(GET(service, list(), "cookies/set", query = "a=1"))
   cookies <- getCookies(service$host)
   expect_equal(cookies$name, "a")
   expect_equal(cookies$value, "1")
 
   # Overwriting
-  GET(service, list(), "cookies/set", query = "a=2&b=1")
+  skip_on_http_failure(GET(service, list(), "cookies/set", query = "a=2&b=1"))
   cookies <- getCookies(service$host)
   expect_equal(cookies$name, c("b", "a"))
   expect_equal(cookies$value, c("1", "2"))
 
   # Preserved across calls
-  out <- GET(service, list(), "cookies")
+  skip_on_http_failure(out <- GET(service, list(), "cookies"))
   expect_equal(out$cookies, list(a = "2", b = "1"))
 })

--- a/tests/testthat/test-http.R
+++ b/tests/testthat/test-http.R
@@ -46,12 +46,12 @@ test_that("can add user specific cookies", {
   withr::local_options(rsconnect.http.cookies = c("a=1", "b=2"))
   service <- parseHttpUrl("http://httpbin.org/")
 
-  json <- GET(service, list(), "cookies")
+  skip_on_http_failure(json <- GET(service, list(), "cookies"))
   expect_equal(json$cookies, list(a = "1", b = "2"))
 
   withr::local_options(rsconnect.http.cookies = c("c=3", "d=4"))
-  POST(service, list(), "post")
-  json <- GET(service, list(), "cookies")
+  skip_on_http_failure(POST(service, list(), "post"))
+  skip_on_http_failure(json <- GET(service, list(), "cookies"))
   expect_equal(json$cookies, list(a = "1", b = "2", c = "3", d = "4"))
 })
 


### PR DESCRIPTION
Quick fix to prevent build failures until we figure out how to do this with a local server.