### PR TITLE
initial implementation for static outputs in cloud

### DIFF
--- a/R/applications.R
+++ b/R/applications.R
@@ -132,12 +132,12 @@ resolveApplication <- function(accountDetails, appName) {
   stopWithApplicationNotFound(appName)
 }
 
-getApplication <- function(account, server, appId) {
+getApplication <- function(account, server, appId, contentId) {
   accountDetails <- accountInfo(account, server)
   client <- clientForAccount(accountDetails)
 
   withCallingHandlers(
-    client$getApplication(appId),
+    client$getApplication(appId, contentId),
     rsconnect_http_404 = function(err) {
       cli::cli_abort("Can't find app with id {.str {appId}}", parent = err)
     }
@@ -279,7 +279,7 @@ syncAppMetadata <- function(appPath = ".") {
     client <- clientForAccount(account)
 
     application <- tryCatch(
-      client$getApplication(curDeploy$appId),
+      client$getApplication(curDeploy$appId, curDeploy$contentId),
       rsconnect_http_404 = function(c) {
         # if the app has been deleted, delete the deployment record
         file.remove(curDeploy$deploymentFile)

--- a/R/client-connect.R
+++ b/R/client-connect.R
@@ -46,7 +46,7 @@ connectClient <- function(service, authInfo) {
       listRequest(service, authInfo, path, query, "applications")
     },
 
-    createApplication = function(name, title, template, accountId) {
+    createApplication = function(name, title, template, accountId, appMode) {
       # add name; inject title if specified
       details <- list(name = name)
       if (!is.null(title) && nzchar(title))
@@ -85,7 +85,7 @@ connectClient <- function(service, authInfo) {
         "/applications/", applicationId, "/config", sep = ""))
     },
 
-    getApplication = function(applicationId) {
+    getApplication = function(applicationId, contentId) {
       GET(service, authInfo, paste0("/applications/", applicationId))
     },
 

--- a/R/client-shinyapps.R
+++ b/R/client-shinyapps.R
@@ -64,7 +64,7 @@ shinyAppsClient <- function(service, authInfo) {
       listRequest(service, authInfo, path, query, "applications")
     },
 
-    getApplication = function(applicationId) {
+    getApplication = function(applicationId, contentId) {
       path <- paste("/applications/", applicationId, sep = "")
       GET(service, authInfo, path)
     },
@@ -88,7 +88,7 @@ shinyAppsClient <- function(service, authInfo) {
       GET(service, authInfo, path, query)
     },
 
-    createApplication = function(name, title, template, accountId) {
+    createApplication = function(name, title, template, accountId, appMode) {
       json <- list()
       json$name <- name
       # the title field is only used on connect

--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -84,12 +84,13 @@ deploymentTarget <- function(recordPath = ".",
 }
 
 
-deploymentTargetForApp <- function(appId,
+deploymentTargetForApp <- function(appId = NULL,
+                                   contentId = NULL,
                                    appTitle = NULL,
                                    account = NULL,
                                    server = NULL) {
   accountDetails <- findAccount(account, server)
-  application <- getApplication(accountDetails$account, accountDetails$server, appId)
+  application <- getApplication(accountDetails$account, accountDetails$server, appId, contentId)
 
   createDeploymentTarget(
     application$name,

--- a/R/ide.R
+++ b/R/ide.R
@@ -114,7 +114,7 @@ showRstudioSourceMarkers <- function(basePath, lint) {
 
 # https://github.com/rstudio/rstudio/blob/ee56d49b0fca5f3d7c3f5214a4010355d1bb0212/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java#L699
 
-getAppById <- function(id, account, server, hostUrl) {
+getAppById <- function(id, account, server, hostUrl, contentId = NULL) {
   check_string(account)
   check_string(server)
   check_string(hostUrl)
@@ -135,7 +135,7 @@ getAppById <- function(id, account, server, hostUrl) {
     }
   }
 
-  getApplication(account, server, id)
+  getApplication(account, server, id, contentId)
 }
 
 


### PR DESCRIPTION
Adding content id makes things a bit weird, but I think it should work.

Keeping this as a draft until I can verify this works end-to-end on staging.

We shouldn't need to fork rsconnect – devtools supports branch package installs from github. This PR is directed at a feature branch that will merge to main once we get closer to go-live.