### PR TITLE
Store only needed HTTP response components

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -54,8 +54,8 @@ filterQuery <- function(param, value, operator = NULL) {
   return(q)
 }
 
-isContentType <- function(response, contentType) {
-  grepl(contentType, response$contentType, fixed = TRUE)
+isContentType <- function(x, contentType) {
+  grepl(contentType, x, fixed = TRUE)
 }
 
 uploadCloudBundle <- function(client,

--- a/R/http.R
+++ b/R/http.R
@@ -129,8 +129,8 @@ redirectService <- function(service, location) {
 }
 
 handleResponse <- function(response, error_call = caller_env()) {
+  url <- buildHttpUrl(response$req)
   reportError <- function(msg) {
-    url <- buildHttpUrl(response$req)
 
     cli::cli_abort(
       c("<{url}> failed with HTTP status {response$status}", msg),
@@ -139,7 +139,7 @@ handleResponse <- function(response, error_call = caller_env()) {
     )
   }
 
-  if (isContentType(response, "application/json")) {
+  if (isContentType(response$contentType, "application/json")) {
     # parse json responses
     if (nzchar(response$content)) {
       json <- jsonlite::fromJSON(response$content, simplifyVector = FALSE)
@@ -154,7 +154,7 @@ handleResponse <- function(response, error_call = caller_env()) {
     } else {
       reportError(paste("Unexpected json response:", response$content))
     }
-  } else if (isContentType(response, "text/html")) {
+  } else if (isContentType(response$contentType, "text/html")) {
     # extract body of html responses
     body <- regexExtract(".*?<body>(.*?)</body>.*", response$content)
     if (response$status >= 200 && response$status < 400) {
@@ -181,7 +181,8 @@ handleResponse <- function(response, error_call = caller_env()) {
     }
   }
 
-  attr(out, "httpResponse") <- response
+  attr(out, "httpContentType") <- response$contentType
+  attr(out, "httpUrl") <- url
   out
 }
 

--- a/R/ide.R
+++ b/R/ide.R
@@ -50,12 +50,12 @@ validateConnectUrl <- function(url, certificate = NULL) {
     return(list(valid = FALSE, message = conditionMessage(cnd)))
   }
 
-  httpResponse <- attr(response, "httpResponse")
-  if (!isContentType(httpResponse, "application/json")) {
+  contentType <- attr(response, "httpContentType")
+  if (!isContentType(contentType, "application/json")) {
     return(list(valid = FALSE, message = "Endpoint did not return JSON"))
   }
 
-  url <- gsub("/server_settings$", "", buildHttpUrl(httpResponse$req))
+  url <- gsub("/server_settings$", "", attr(response, "httpUrl"))
   list(valid = TRUE, url = url, response = response)
 }
 

--- a/tests/testthat/helper-http.R
+++ b/tests/testthat/helper-http.R
@@ -38,8 +38,7 @@ test_http_GET <- function() {
 
   # Perform the request
   resp <- GET(service, authInfo = NULL, path = "get")
-  expect_equal(attr(resp, "httpResponse")$status, 200)
-  expect_equal(attr(resp, "httpResponse")$contentType, "application/json")
+  expect_equal(attr(resp, "httpContentType"), "application/json")
   expect_equal(resp$path, "/get")
 }
 
@@ -48,7 +47,6 @@ test_http_POST_JSON <- function() {
 
   body <- list(a = 1, b = 2, c = 3)
   resp <- POST_JSON(service, authInfo = NULL, path = "post", json = body)
-  expect_equal(attr(resp, "httpResponse")$status, 200)
   expect_equal(resp$json, body)
 }
 
@@ -56,7 +54,6 @@ test_http_POST_empty <- function() {
   service <- httpbin_service()
 
   resp <- POST(service, authInfo = NULL, path = "post")
-  expect_equal(attr(resp, "httpResponse")$status, 200)
   expect_equal(resp$json, set_names(list()))
 }
 
@@ -75,7 +72,6 @@ test_http_POST_file <- function() {
     contentType = "text/plain",
     file = path
   )
-  expect_equal(attr(resp, "httpResponse")$status, 200)
   expect_equal(resp$data, "1\n2\n3\n")
 }
 
@@ -83,10 +79,8 @@ test_http_headers <- function() {
   service <- httpbin_service()
 
   resp <- GET(service, authInfo = list(apiKey = "abc123"), path = "get")
-  expect_equal(attr(resp, "httpResponse")$status, 200)
   expect_equal(resp$headers$Authorization, "Key abc123")
 
   resp <- POST(service, authInfo = list(apiKey = "abc123"), path = "post")
-  expect_equal(attr(resp, "httpResponse")$status, 200)
   expect_equal(resp$headers$Authorization, "Key abc123")
 }


### PR DESCRIPTION
We only use the contentType and the request url, so store only those values. This makes inspecting the return values easier.