### PR TITLE
Cloud static outputs

### DIFF
--- a/R/applications.R
+++ b/R/applications.R
@@ -137,7 +137,7 @@ getApplication <- function(account, server, appId) {
   client <- clientForAccount(accountDetails)
 
   withCallingHandlers(
-    client$getApplication(appId),
+    client$getApplication(appId, dcfVersion),
     rsconnect_http_404 = function(err) {
       cli::cli_abort("Can't find app with id {.str {appId}}", parent = err)
     }

--- a/R/client-connect.R
+++ b/R/client-connect.R
@@ -48,7 +48,7 @@ connectClient <- function(service, authInfo) {
       listRequest(service, authInfo, path, query, "applications")
     },
 
-    createApplication = function(name, title, template, accountId) {
+    createApplication = function(name, title, template, accountId, appMode) {
       # add name; inject title if specified
       details <- list(name = name)
       if (!is.null(title) && nzchar(title))
@@ -87,7 +87,7 @@ connectClient <- function(service, authInfo) {
         "/applications/", applicationId, "/config", sep = ""))
     },
 
-    getApplication = function(applicationId) {
+    getApplication = function(applicationId, dcfVersion) {
       GET(service, authInfo, paste0("/applications/", applicationId))
     },
 

--- a/R/client-shinyapps.R
+++ b/R/client-shinyapps.R
@@ -64,7 +64,7 @@ shinyAppsClient <- function(service, authInfo) {
       listRequest(service, authInfo, path, query, "applications")
     },
 
-    getApplication = function(applicationId) {
+    getApplication = function(applicationId, dcfVersion) {
       path <- paste("/applications/", applicationId, sep = "")
       GET(service, authInfo, path)
     },
@@ -88,7 +88,7 @@ shinyAppsClient <- function(service, authInfo) {
       GET(service, authInfo, path, query)
     },
 
-    createApplication = function(name, title, template, accountId) {
+    createApplication = function(name, title, template, accountId, appMode) {
       json <- list()
       json$name <- name
       # the title field is only used on connect

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -345,29 +345,33 @@ deployApp <- function(appDir = getwd(),
     showCookies(serverInfo(accountDetails$server)$url)
   }
 
+  isNewApplication <- FALSE
   if (is.null(target$appId)) {
     taskStart(quiet, "Creating application on server...")
     application <- client$createApplication(
       target$appName,
       target$appTitle,
       "shiny",
-      accountDetails$accountId
+      accountDetails$accountId,
+      appMetadata$appMode
     )
     taskComplete(quiet, "Created application with id {.val {application$id}}")
+    isNewApplication <- TRUE
   } else {
     application <- taskStart(quiet, "Looking up application with id {.val {target$appId}}...")
     application <- tryCatch(
-      client$getApplication(target$appId),
+      {
+        application <- client$getApplication(target$appId, target$version)
+        taskComplete(quiet, "Found application {.url {application$url}}")
+        application
+      },
       rsconnect_http_404 = function(err) {
-        applicationDeleted(client, target, recordPath)
+        application <- applicationDeleted(client, target, recordPath, appMetadata)
+        taskComplete(quiet, "Created application with id {.val {application$id}}")
+        isNewApplication <- TRUE
+        application
       }
     )
-    if (application$id == target$appId) {
-      taskComplete(quiet, "Found application {.url {application$url}}")
-    } else {
-      taskComplete(quiet, "Created application with id {.val {application$id}}")
-    }
-
   }
   saveDeployment(
     recordPath,
@@ -413,6 +417,9 @@ deployApp <- function(appDir = getwd(),
     # create, and upload the bundle
     taskStart(quiet, "Uploading bundle...")
     if (isCloudServer(accountDetails$server)) {
+      if (application$type == "static" && !isNewApplication) {
+        application$id <- client$createRevision(application)
+      }
       bundle <- uploadCloudBundle(client, application$id, bundlePath)
     } else {
       bundle <- client$uploadApplication(application$id, bundlePath)
@@ -434,7 +441,7 @@ deployApp <- function(appDir = getwd(),
   if (!quiet) {
     cli::cli_rule("Deploying to server")
   }
-  task <- client$deployApplication(application$id, bundle$id)
+  task <- client$deployApplication(application, bundle$id)
   taskId <- if (is.null(task$task_id)) task$id else task$task_id
   # wait for the deployment to complete (will raise an error if it can't)
   response <- client$waitForTask(taskId, quiet)
@@ -516,7 +523,7 @@ runDeploymentHook <- function(appDir, option, verbose = FALSE) {
   hook(appDir)
 }
 
-applicationDeleted <- function(client, target, recordPath) {
+applicationDeleted <- function(client, target, recordPath, appMetadata) {
   header <- "Failed to find existing application on server; it's probably been deleted."
   not_interactive <- c(
     i = "Use {.fn forgetDeployment} to remove outdated record and try again.",
@@ -544,7 +551,8 @@ applicationDeleted <- function(client, target, recordPath) {
     target$appName,
     target$appTitle,
     "shiny",
-    accountDetails$accountId
+    accountDetails$accountId,
+    appMetadata$appMode
   )
 }
 

--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -47,7 +47,8 @@ deploymentTarget <- function(recordPath = ".",
       envVars,
       fullAccount$name, # first deploy must be to own account
       fullAccount$name,
-      fullAccount$server
+      fullAccount$server,
+      dcfVersion
     )
   } else if (nrow(appDeployments) == 1) {
     # If both appName and appId supplied, check that they're consistent.
@@ -76,13 +77,17 @@ deploymentTargetForApp <- function(appId,
   accountDetails <- findAccount(account, server)
   application <- getApplication(accountDetails$name, accountDetails$server, appId)
 
+  resultAppId <- ifelse(is.null(application$content_id), application$id, application$content_id)
+
   createDeploymentTarget(
     application$name,
     application$title %||% appTitle,
-    application$id,
+    resultAppId,
+    NULL,
     application$owner_username,
     accountDetails$name,
-    accountDetails$server
+    accountDetails$server,
+    dcfVersion
   )
 }
 
@@ -92,7 +97,8 @@ createDeploymentTarget <- function(appName,
                                    envVars,
                                    username,
                                    account,
-                                   server) {
+                                   server,
+                                   version) {
   list(
     appName = appName,
     appTitle = appTitle %||% "",
@@ -100,7 +106,8 @@ createDeploymentTarget <- function(appName,
     appId = appId,
     username = username,
     account = account,
-    server = server
+    server = server,
+    version = version
   )
 }
 
@@ -113,7 +120,8 @@ updateDeploymentTarget <- function(previous, appTitle = NULL, envVars = NULL) {
     # if username not previously recorded, use current account
     previous$username %||% previous$account,
     previous$account,
-    previous$server
+    previous$server,
+    previous$version
   )
 }
 

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -79,7 +79,7 @@ deployments <- function(appPath = ".",
 
 deploymentFields <- c(
   "name", "title", "username", "account", "server", "hostUrl", "appId",
-  "bundleId", "url", "envVars"
+  "bundleId", "url", "envVars", "version"
 )
 
 saveDeployment <- function(recordDir,
@@ -89,7 +89,7 @@ saveDeployment <- function(recordDir,
                            hostUrl = serverInfo(target$server)$url,
                            metadata = list(),
                            addToHistory = TRUE) {
-
+  appId <- ifelse(target$server == "posit.cloud", application$content_id, application$id)
   deployment <- deploymentRecord(
     name = target$appName,
     title = target$appTitle,
@@ -98,7 +98,7 @@ saveDeployment <- function(recordDir,
     server = target$server,
     envVars = target$envVars,
     hostUrl = hostUrl,
-    appId = application$id,
+    appId = appId,
     bundleId = bundleId,
     url = application$url,
     metadata = metadata
@@ -143,7 +143,10 @@ deploymentRecord <- function(name,
   c(standard, metadata)
 }
 
+dcfVersion <- "1"
+
 writeDeploymentRecord <- function(record, filePath) {
+  record$version <- dcfVersion
   # use a long width so URLs don't line-wrap
   write.dcf(record, filePath, width = 4096)
 }

--- a/R/http.R
+++ b/R/http.R
@@ -288,24 +288,43 @@ PUT_JSON <- function(service,
   )
 }
 
-PATCH_JSON <- function(service,
-                       authInfo,
-                       path,
-                       json,
-                       query = NULL,
-                       headers = list()) {
+PATCH <- function(service,
+                  authInfo,
+                  path,
+                  query = NULL,
+                  contentType = NULL,
+                  file = NULL,
+                  content = NULL,
+                  headers = list()) {
   httpRequestWithBody(
     service,
     authInfo,
     "PATCH",
     path,
     query,
-    contentType = "application/json",
+    contentType,
+    file,
+    content,
+    headers
+  )
+}
+
+PATCH_JSON <- function(service,
+                       authInfo,
+                       path,
+                       json,
+                       query = NULL,
+                       headers = list()) {
+  PATCH(
+    service,
+    authInfo,
+    path,
+    query,
+    "application/json",
     content = toJSON(json),
     headers = headers
   )
 }
-
 
 # User options ------------------------------------------------------------
 

--- a/tests/testthat/_snaps/deployments.md
+++ b/tests/testthat/_snaps/deployments.md
@@ -6,13 +6,16 @@
     Output
       x: 1
       appPath: path
+      version: 1
     Code
       addToDeploymentHistory("path", list(x = 2))
       writeLines(readLines(deploymentHistoryPath()))
     Output
       x: 2
       appPath: path
+      version: 1
       
       x: 1
       appPath: path
+      version: 1
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -81,6 +81,7 @@ addTestDeployment <- function(path,
                               envVars = NULL,
                               username = account,
                               server = "example.com",
+                              version = dcfVersion,
                               url = paste0("https://", server, "/", username, "/", appId),
                               hostUrl = NULL,
                               metadata = list()) {
@@ -93,7 +94,8 @@ addTestDeployment <- function(path,
       envVars = envVars,
       account = account,
       username = username,
-      server = server
+      server = server,
+      version = version
     ),
     application = list(id = appId, url = url),
     hostUrl = hostUrl,

--- a/tests/testthat/test-client-cloud.R
+++ b/tests/testthat/test-client-cloud.R
@@ -1,0 +1,662 @@
+mockServerFactory <- function(initialResponses) {
+  # Stock responses for certain endpoints. Can still be overridden by tests.
+  if (is.null(initialResponses$"^GET /v1/users/current")) {
+    initialResponses$"GET /v1/users/current" = list(
+      content = list(
+        id=100
+      )
+    )
+  }
+
+  if (is.null(initialResponses$"^GET /v1/accounts/?")) {
+    initialResponses$"^GET /v1/accounts/?" = list(
+      content = list(
+        count=1,
+        total=1,
+        offset=0,
+        accounts=list(
+          list(
+            id=50,
+            name="testthat-account",
+            account="testthat-account"
+          ),
+          list(
+            id=51,
+            name="testthat-superfluous-account",
+            account="testthat-superfluous-account"
+          )
+        )
+      )
+    )
+  }
+
+  mockServer <- list(
+    responses = initialResponses
+  )
+
+  mockServer$addResponse <- function(methodAndPath, response) {
+    mockServer$responses <- append(mockServer$responses, response)
+  }
+
+  mockServer$impl <- function(protocol,
+                          host,
+                          port,
+                          method,
+                          path,
+                          headers,
+                          contentType = NULL,
+                          contentFile = NULL,
+                          certificate = NULL,
+                          timeout = NULL) {
+
+    methodAndPath = paste(method, path)
+
+    request <- list(
+      protocol = protocol,
+      host = host,
+      port = port,
+      method = method,
+      path = path
+    )
+
+    response = list(
+      req = request,
+      status = 200,
+      location = "",
+      contentType = "application/json"
+    )
+
+    found <- FALSE
+
+    for (pathRegex in names(mockServer$responses)) {
+      match <- regexec(pathRegex, methodAndPath)[[1]]
+      if (match[1] != -1) {
+        found <- TRUE
+        responseSupplement <- mockServer$responses[[pathRegex]]
+
+        for (respProperty in names(responseSupplement)) {
+          if (is.function(responseSupplement[[respProperty]])) {
+            responseSupplement[[respProperty]] <- responseSupplement[[respProperty]](
+              methodAndPath,
+              match,
+              headers=headers,
+              contentType=contentType,
+              contentFile=contentFile)
+          }
+
+          response[[respProperty]] = responseSupplement[[respProperty]]
+        }
+
+        if (is.list(response$content)) {
+          response$content <- jsonlite::toJSON(response$content, auto_unbox=TRUE)
+        }
+
+        break
+      }
+    }
+
+    if (!found) {
+      stop(paste("No mocked response defined for", methodAndPath))
+    }
+
+    response
+  }
+
+  mockServer
+}
+
+configureTestAccount <- function(server = 'posit.cloud', name = NULL) {
+  if (is.null(name)) {
+    name = 'testthat-account'
+  }
+
+  existingAccount <- NULL
+  tryCatch(
+    existingAccount <- accountInfo(name, server),
+    error = function(e) { existingAccount = NULL }
+  )
+
+  if (is.null(existingAccount)) {
+    setAccountInfo(
+      name = name,
+      token = 'foo',
+      secret = 'bar',
+      server = server
+    )
+  }
+
+  name
+}
+
+test_that("Get application", {
+  mockServer = mockServerFactory(list(
+    "^GET /outputs/([0-9]+)" = list(
+      content = function(methodAndPath, match, ...) {
+        end <- attr(match, 'match.length')[2] + match[2]
+        output_id <- strtoi(substr(methodAndPath, match[2], end))
+
+        list(
+          "id"=output_id,
+          "source_id"=1,
+          "url"="http://fake-url.test.me/",
+          "state"="active"
+        )
+      }
+    ),
+    "^GET /applications/([0-9]+)" = list(
+      content = function(methodAndPath, match, ...) {
+        end <- attr(match, 'match.length')[2] + match[2]
+        application_id <- strtoi(substr(methodAndPath, match[2], end))
+
+        list(
+          "id"=application_id,
+          "content_id"=5
+        )
+      }
+    )
+  ))
+
+  restoreOpt <- options(rsconnect.http = mockServer$impl)
+  withr::defer(options(restoreOpt))
+
+  fakeService <- list(
+    protocol="test",
+    host="unit-test",
+    port=42
+  )
+  client <- cloudClient(fakeService, NULL)
+
+  app <- client$getApplication("10", NULL)
+
+  expect_equal(app$id, 10)
+  expect_equal(app$content_id, 5)
+  expect_equal(app$url, "http://fake-url.test.me/")
+
+  app <- client$getApplication("5", dcfVersion)
+
+  expect_equal(app$id, 1)
+  expect_equal(app$content_id, 5)
+  expect_equal(app$url, "http://fake-url.test.me/")
+})
+
+test_that("Get application output trashed", {
+  mockServer = mockServerFactory(list(
+    "^GET /outputs/([0-9]+)" = list(
+      content = function(methodAndPath, match, ...) {
+        end <- attr(match, 'match.length')[2] + match[2]
+        output_id <- strtoi(substr(methodAndPath, match[2], end))
+
+        list(
+          "id"=output_id,
+          "source_id"=1,
+          "url"="http://fake-url.test.me/",
+          "state"="trashed"
+        )
+      }
+    ),
+    "^GET /applications/([0-9]+)" = list(
+      content = function(methodAndPath, match, ...) {
+        end <- attr(match, 'match.length')[2] + match[2]
+        application_id <- strtoi(substr(methodAndPath, match[2], end))
+
+        list(
+          "id"=application_id,
+          "content_id"=5
+        )
+      }
+    ),
+    "^PATCH /outputs/5" = list(
+      content = function(methodAndPath, match, ...) {
+        end <- attr(match, 'match.length')[2] + match[2]
+        output_id <- strtoi(substr(methodAndPath, match[2], end))
+        list()
+      }
+    )
+  ))
+
+  restoreOpt <- options(rsconnect.http = mockServer$impl)
+  withr::defer(options(restoreOpt))
+
+  fakeService <- list(
+    protocol="test",
+    host="unit-test",
+    port=42
+  )
+  client <- cloudClient(fakeService, NULL)
+
+  app <- client$getApplication(10, NULL)
+
+  expect_equal(app$id, 10)
+  expect_equal(app$content_id, 5)
+  expect_equal(app$url, "http://fake-url.test.me/")
+
+  app <- client$getApplication(5, dcfVersion)
+
+  expect_equal(app$id, 1)
+  expect_equal(app$content_id, 5)
+  expect_equal(app$url, "http://fake-url.test.me/")
+})
+
+test_that("Create application", {
+  mockServer = mockServerFactory(list(
+    "^POST /outputs" = list(
+      content = list(
+        "id"=1,
+        "source_id"=2,
+        "url"="http://fake-url.test.me/",
+        "state"="active"
+      )
+    ),
+    "^GET /applications/([0-9]+)" = list(
+      content = function(methodAndPath, match, ...) {
+        end <- attr(match, 'match.length')[2] + match[2]
+        application_id <- strtoi(substr(methodAndPath, match[2], end))
+
+        list(
+          "id"=application_id,
+          "content_id"=1
+        )
+      })
+  ))
+
+  restoreOpt <- options(rsconnect.http = mockServer$impl)
+  withr::defer(options(restoreOpt))
+
+  fakeService <- list(
+    protocol="test",
+    host="unit-test",
+    port=42
+  )
+  client <- cloudClient(fakeService, NULL)
+
+  app <- client$createApplication("test app", "unused?", "unused?", "unused?", "static")
+
+  expect_equal(app$id, 2)
+  expect_equal(app$content_id, 1)
+  expect_equal(app$url, "http://fake-url.test.me/")
+})
+
+test_that("Create application with linked source project", {
+  mockServer = mockServerFactory(list(
+    "^POST /outputs" = list(
+      content = function(methodAndPAth, match, contentFile, ...) {
+        content = jsonlite::fromJSON(readChar(contentFile, file.info(contentFile)$size))
+
+        expect_equal(content$project, 41)
+        expect_equal(content$space, 99)
+
+        list(
+        "id"=1,
+        "source_id"=2,
+        "url"="http://fake-url.test.me/",
+        "state"="active"
+        )
+      }
+    ),
+    "^GET /applications/([0-9]+)" = list(
+      content = function(methodAndPath, match, ...) {
+        end <- attr(match, 'match.length')[2] + match[2]
+        application_id <- strtoi(substr(methodAndPath, match[2], end))
+        list(
+          "id"=application_id,
+          "content_id"=application_id-1
+        )
+      }
+    ),
+    "^GET /content/41" = list(
+      content = list(
+        "id"=41,
+        "space_id"=99
+      )
+    )
+  ))
+
+  restoreOpt <- options(rsconnect.http = mockServer$impl)
+  withr::defer(options(restoreOpt))
+
+  Sys.setenv(LUCID_APPLICATION_ID="42")
+  withr::defer(Sys.unsetenv("LUCID_APPLICATION_ID"))
+
+  fakeService <- list(
+    protocol="test",
+    host="unit-test",
+    port=42
+  )
+  client <- cloudClient(fakeService, NULL)
+
+  app <- client$createApplication("test app", "unused?", "unused?", "unused?", "static")
+
+  expect_equal(app$id, 2)
+  expect_equal(app$content_id, 1)
+  expect_equal(app$url, "http://fake-url.test.me/")
+})
+
+test_that("deploymentTargetForApp() results in correct Cloud API calls", {
+  mockServer = mockServerFactory(list(
+    "^GET /v1/applications/([0-9]+)" = list(
+      content = function(methodAndPath, match, ...) {
+        end <- attr(match, 'match.length')[2] + match[2]
+        application_id <- strtoi(substr(methodAndPath, match[2], end))
+        list(
+          "id"=application_id,
+          "content_id"=application_id-1,
+          "name"=paste("testthat app", application_id)
+        )
+      }
+    ),
+    "^GET /v1/outputs/([0-9]+)" = list(
+      content = function(methodAndPath, match, ...) {
+        end <- attr(match, 'match.length')[2] + match[2]
+        output_id <- strtoi(substr(methodAndPath, match[2], end))
+
+        list(
+          "id"=output_id,
+          "source_id"=output_id + 1,
+          "url"="http://fake-url.test.me/",
+          "state"="active",
+          "name"="my output"
+        )
+      }
+    )
+  ))
+
+  restoreOpt <- options(rsconnect.http = mockServer$impl)
+  withr::defer(options(restoreOpt))
+
+  testAccount <- configureTestAccount()
+  withr::defer(removeAccount(testAccount))
+
+  target <- deploymentTargetForApp(
+    appId = 3,
+    account = testAccount,
+    server = 'posit.cloud',
+  )
+
+  expect_equal(target$appName, "my output")
+  expect_equal(target$account, testAccount)
+  expect_equal(target$server, 'posit.cloud')
+  expect_equal(target$appId, 3)
+})
+
+deployAppMockServerFactory <- function(expectedAppType, outputState) {
+  outputResponse <- list(
+    "id"=1,
+    "source_id"=2,
+    "url"="http://fake-url.test.me/",
+    "state"=outputState
+  )
+
+  actualCalls = list(
+    outputCreated = FALSE,
+    outputStateUpdated = FALSE,
+    revisionCreated = FALSE,
+    bundleCreated = FALSE,
+    bundleUploaded = FALSE,
+    bundleReady = FALSE,
+    deployStarted = FALSE
+  )
+
+  server <- mockServerFactory(list(
+    # An attempt to search for preexisting applications with the same name.
+    # This call should change, see https://github.com/rstudio/rsconnect/issues/808
+    "^GET /v1/applications/[?]filter=account_id:50&filter=type:connect"=list(
+      content=list(
+        count=0,
+        total=0,
+        applications=list()
+      )
+    ),
+    "^POST /v1/outputs$"=list(
+      content=function(methodAndPath, match, contentFile, ...) {
+        e <- environment(); p <- parent.env(e); p$actualCalls$outputCreated <- TRUE
+
+        content = jsonlite::fromJSON(readChar(contentFile, file.info(contentFile)$size))
+
+        expect_equal(content$application_type, expectedAppType)
+        expect_equal(content$name, "Desired name here")
+
+        outputResponse
+      }
+    ),
+    "^GET /v1/applications/([0-9]+)$" = list(
+      content = function(methodAndPath, match, ...) {
+        end <- attr(match, 'match.length')[2] + match[2]
+        application_id <- strtoi(substr(methodAndPath, match[2], end))
+
+        list(
+          id=application_id,
+          content_id=application_id-1,
+          name=paste("testthat app", application_id),
+          type=expectedAppType
+        )
+      }
+    ),
+    "^POST /v1/bundles/123/status$" = list(
+      content = function(methodAndPath, match, contentFile, ...){
+        e <- environment(); p <- parent.env(e); p$actualCalls$bundleReady = TRUE
+
+        content = jsonlite::fromJSON(readChar(contentFile, file.info(contentFile)$size))
+        expect_equal(content$status, "ready")
+
+        list()
+      }
+    ),
+    "^POST /v1/bundles$" = list(
+      content = function(methodAndPath, match, contentFile, ...) {
+        e <- environment(); p <- parent.env(e); p$actualCalls$bundleCreated = TRUE
+
+        content = jsonlite::fromJSON(readChar(contentFile, file.info(contentFile)$size))
+
+        list(
+          id=123,
+          presigned_url="https://write-only-memory.com/fake-presigned-url",
+          presigned_checksum=content$checksum
+        )
+      }
+    ),
+    "^PUT /fake-presigned-url" = list(
+      content = function(...) {
+        e <- environment(); p <- parent.env(e); p$actualCalls$bundleUploaded = TRUE
+      }
+    ),
+    "^GET /v1/bundles/123$" = list(
+      content=list(
+        id=123,
+        status="ready"
+      )
+    ),
+    "^POST /v1/applications/[23]/deploy$" = list(
+      content=function(...) {
+        e <- environment(); p <- parent.env(e); p$actualCalls$deployStarted = TRUE
+        list(
+          task_id="testthat-task-id"
+        )
+      }
+    ),
+    "^GET /v1/tasks/testthat-task-id$" = list(
+      content = list(
+        status="success",
+        finished=TRUE
+      )
+    ),
+    # Fetch existing output when re-deploying from .dcf data
+    "^GET /v1/outputs/1$" = list(
+      content=outputResponse
+    ),
+    "^POST /v1/outputs/1/revisions" = list(
+      content=function(...) {
+        e <- environment(); p <- parent.env(e); p$actualCalls$revisionCreated = TRUE
+
+        list(
+          application_id=3
+        )
+      }
+    ),
+    "^PATCH /v1/outputs" = list(
+      content = function(...) {
+        e <- environment(); p <- parent.env(e); p$actualCalls$outputStateUpdated = TRUE
+      }
+    )
+  ))
+
+  expect_calls <- function(expectedCalls) {
+    expect_equal(actualCalls, expectedCalls)
+  }
+
+  reset_calls <- function() {
+    e <- environment(); p <- parent.env(e); p$actualCalls = list(
+      outputCreated = FALSE,
+      outputStateUpdated = FALSE,
+      revisionCreated = FALSE,
+      bundleCreated = FALSE,
+      bundleUploaded = FALSE,
+      bundleReady = FALSE,
+      deployStarted = FALSE
+    )
+  }
+
+  list(
+    server=server,
+    expect_calls=expect_calls,
+    reset_calls=reset_calls
+  )
+}
+
+test_that("deployApp() for shiny results in correct Cloud API calls", {
+  mock <- deployAppMockServerFactory(expectedAppType="connect", outputState="active")
+  mockServer <- mock$server
+
+  restoreOpt <- options(rsconnect.http = mockServer$impl)
+  withr::defer(options(restoreOpt))
+
+  testAccount <- configureTestAccount()
+  withr::defer(removeAccount(testAccount))
+
+  sourcePath = test_path('shinyapp-simple')
+  # Remove local deployment info at end for reproducibility and tidiness.
+  withr::defer(forgetDeployment(appPath=sourcePath, force=TRUE))
+
+  deployApp(
+    appName = "Desired name here",
+    appDir = sourcePath,
+    server = 'posit.cloud',
+    account = testAccount
+  )
+
+  mock$expect_calls(list(
+    outputCreated = TRUE,
+    outputStateUpdated = FALSE,
+    revisionCreated = FALSE,
+    bundleCreated = TRUE,
+    bundleUploaded = TRUE,
+    bundleReady = TRUE,
+    deployStarted = TRUE
+  ))
+
+  mock$reset_calls()
+
+  # deploy again to test existing deployment path
+  deployApp(
+    appDir = sourcePath
+  )
+
+  mock$expect_calls(list(
+    outputCreated = FALSE,
+    outputStateUpdated = FALSE,
+    revisionCreated = FALSE,
+    bundleCreated = TRUE,
+    bundleUploaded = TRUE,
+    bundleReady = TRUE,
+    deployStarted = TRUE
+  ))
+
+  # Start over, add another posit.cloud account and test again with that environment
+  mock$reset_calls()
+  forgetDeployment(appPath=sourcePath, force=TRUE)
+
+  extraLocalAccount <- configureTestAccount(name="testthat-superfluous-account")
+  withr::defer(removeAccount(extraLocalAccount))
+
+  deployApp(
+    appName = "Desired name here",
+    appDir = sourcePath,
+    server = 'posit.cloud',
+    account = testAccount
+  )
+
+  mock$expect_calls(list(
+    outputCreated = TRUE,
+    outputStateUpdated = FALSE,
+    revisionCreated = FALSE,
+    bundleCreated = TRUE,
+    bundleUploaded = TRUE,
+    bundleReady = TRUE,
+    deployStarted = TRUE
+  ))
+
+  mock$reset_calls()
+
+  # deploy again to test existing deployment path
+  deployApp(
+    appDir = sourcePath
+  )
+
+  mock$expect_calls(list(
+    outputCreated = FALSE,
+    outputStateUpdated = FALSE,
+    revisionCreated = FALSE,
+    bundleCreated = TRUE,
+    bundleUploaded = TRUE,
+    bundleReady = TRUE,
+    deployStarted = TRUE
+  ))
+})
+
+test_that("deployDoc() results in correct Cloud API calls", {
+  mock <- deployAppMockServerFactory(expectedAppType="static", outputState="active")
+  mockServer <- mock$server
+
+  restoreOpt <- options(rsconnect.http = mockServer$impl)
+  withr::defer(options(restoreOpt))
+
+  testAccount <- configureTestAccount()
+  withr::defer(removeAccount(testAccount))
+
+  sourcePath = test_path('static-with-quarto-yaml')
+  # Remove local deployment info at end for reproducibility and tidiness.
+  withr::defer(forgetDeployment(appPath=sourcePath, force=TRUE))
+
+  deployDoc(
+    paste(sourcePath, "slideshow.html", sep="/"),
+    appName = "Desired name here",
+    server = 'posit.cloud',
+    account = testAccount
+  )
+
+  mock$expect_calls(list(
+    outputCreated = TRUE,
+    outputStateUpdated = FALSE,
+    revisionCreated = FALSE,
+    bundleCreated = TRUE,
+    bundleUploaded = TRUE,
+    bundleReady = TRUE,
+    deployStarted = TRUE
+  ))
+
+  mock$reset_calls()
+
+  # deploy again to test existing deployment path
+  deployApp(
+    appDir = sourcePath
+  )
+
+  mock$expect_calls(list(
+    outputCreated = FALSE,
+    outputStateUpdated = FALSE,
+    revisionCreated = TRUE,
+    bundleCreated = TRUE,
+    bundleUploaded = TRUE,
+    bundleReady = TRUE,
+    deployStarted = TRUE
+  ))
+})

--- a/tests/testthat/test-deployApp.R
+++ b/tests/testthat/test-deployApp.R
@@ -89,7 +89,7 @@ test_that("applicationDeleted() errors or prompts as needed", {
   addTestAccount("a", "s")
   app <- local_temp_app()
   addTestDeployment(app, appName = "name", account = "a", server = "s")
-  target <- createDeploymentTarget("name", "title", "id", NULL, "a", "a", "s")
+  target <- createDeploymentTarget("name", "title", "id", NULL, "a", "a", "s", 1)
   client <- list(createApplication = function(...) NULL)
 
   expect_snapshot(applicationDeleted(client, target, app), error = TRUE)

--- a/tests/testthat/test-deployments.R
+++ b/tests/testthat/test-deployments.R
@@ -111,9 +111,10 @@ test_that("saveDeployment appends to global history", {
       envVars = NULL,
       account = "foo",
       username = "foo",
-      server = "bar"
+      server = "bar",
+      version = dcfVersion
     ),
-    application = list(),
+    application = list(id=1),
     hostUrl = NULL
   )
 
@@ -137,9 +138,10 @@ test_that("saveDeployment captures hostUrl", {
       envVars = NULL,
       account = "foo",
       username = "foo",
-      server = "example.com"
+      server = "example.com",
+      version = dcfVersion
     ),
-    application = list()
+    application = list(id=10)
   )
 
   out <- deployments(dir)


### PR DESCRIPTION
- Add support for deploying client-rendered static outputs to Posit Cloud
- Save Cloud deployments with appId as the Cloud content id (instead of application id)
- Introduce versioning to dcf files (needed to support backwards compatibility for old Cloud dcf files saved with appId as the application id

Resolves https://github.com/rstudio/rsconnect/issues/824.
Resolves https://github.com/rstudio/rsconnect/issues/821.
