### PR TITLE
Fix issues when appId set

### DIFF
--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -80,7 +80,8 @@ deploymentTargetForApp <- function(appId,
     appName = application$name,
     appTitle = application$title %||% appTitle,
     appId = application$id,
-    username = application$owner_username,
+    envVars = NULL,
+    username = application$owner_username %||% accountDetails$name,
     account = accountDetails$name,
     server = accountDetails$server
   )

--- a/tests/testthat/test-deploymentTarget.R
+++ b/tests/testthat/test-deploymentTarget.R
@@ -249,6 +249,17 @@ test_that("defaultAppName reifies appNames for shinyApps", {
   expect_equal(defaultAppName(paste(long_name, "..."), "shinyapps.io"), long_name)
 })
 
+test_that("deploymentTargetForApp works with cloud", {
+  local_temp_config()
+  addTestServer()
+  addTestAccount("ron")
+  local_mocked_bindings(
+    getApplication = function(...) list(name = "name", id = "id")
+  )
+
+  target <- deploymentTargetForApp("123")
+  expect_equal(target$username, "ron")
+})
 
 # helpers -----------------------------------------------------------------
 


### PR DESCRIPTION
Need to set `envVars` argument and cloud doesn't supply `owner_username`. This value is only used for display, and AFAIK is not important, so I just defaulted to the account user name.

Fixes #819