### PR TITLE
Use dirCreate() instead of dir.create()

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -8,8 +8,7 @@
   logger <- verboseLogger(verbose)
   logger("Creating tempfile for appdir")
   # create a directory to stage the application bundle in
-  bundleDir <- tempfile()
-  dir.create(bundleDir, recursive = TRUE)
+  bundleDir <- dirCreate(tempfile())
   on.exit(unlink(bundleDir), add = TRUE)
 
   logger("Copying files")
@@ -25,8 +24,7 @@
         file == appPrimaryDoc) {
       to <- file.path(bundleDir, "app.R")
     }
-    if (!file.exists(dirname(to)))
-      dir.create(dirname(to), recursive = TRUE)
+    dirCreate(dirname(to))
     file.copy(from, to, copy.date = TRUE)
 
     # ensure .Rprofile doesn't call packrat/init.R or renv/activate.R

--- a/R/certificates.R
+++ b/R/certificates.R
@@ -70,8 +70,7 @@ createCertificateFile <- function(certificate) {
 
   # create a temporary file to house the certificates
   certificateStore <- tempfile(pattern = "cacerts", fileext = ".pem")
-  if (!dirExists(dirname(certificateStore)))
-    dir.create(dirname(certificateStore))
+  dirCreate(dirname(certificateStore))
   file.create(certificateStore)
 
   # open temporary cert store

--- a/R/config.R
+++ b/R/config.R
@@ -24,11 +24,7 @@ rsconnectConfigDir <- function(subDir = NULL) {
     target <- file.path(target, subDir)
   }
 
-  # Create the path if it doesn't exist
-  dir.create(target, recursive = TRUE, showWarnings = FALSE)
-
-  # Return completed path
-  target
+  dirCreate(target)
 }
 
 #' Application Configuration Directory
@@ -125,8 +121,7 @@ deploymentConfigDir <- function(recordPath) {
 
 deploymentConfigFile <- function(recordPath, name, account, server) {
   accountDir <- file.path(deploymentConfigDir(recordPath), server, account)
-  if (!file.exists(accountDir))
-    dir.create(accountDir, recursive = TRUE)
+  dirCreate(accountDir)
   file.path(accountDir, paste0(name, ".dcf"))
 }
 

--- a/R/configMigrate.R
+++ b/R/configMigrate.R
@@ -13,7 +13,7 @@ migrateConfig <- function(configDir) {
   if (dirExists(oldConfigDir)) {
 
     # Create the parent folder if necessary
-    dir.create(dirname(configDir), recursive = TRUE, showWarnings = FALSE)
+    dirCreate(dirname(configDir))
 
     # Migrate the old directory to the new one
     file.rename(oldConfigDir, configDir)
@@ -90,7 +90,7 @@ migrateDeploymentsConfig <- function(appPath) {
 
     # write the new record
     rsconnectDCF <- file.path(migrateDir, "shinyapps.io", shinyappsFile)
-    dir.create(dirname(rsconnectDCF), showWarnings = FALSE, recursive = TRUE)
+    dirCreate(dirname(rsconnectDCF))
     write.dcf(deployment, rsconnectDCF)
 
     # remove old DCF

--- a/R/deploySite.R
+++ b/R/deploySite.R
@@ -147,10 +147,5 @@ outputDir <- function(wd, path) {
   old <- setwd(wd)
   on.exit(setwd(old))
 
-  if (!file.exists(path)) {
-    dir.create(path, recursive = TRUE, showWarnings = FALSE)
-  }
-
-
-  normalizePath(path, mustWork = FALSE)
+  normalizePath(dirCreate(path), mustWork = FALSE)
 }

--- a/R/rpubs.R
+++ b/R/rpubs.R
@@ -68,8 +68,7 @@ rpubsUpload <- function(title,
 
     # create a tempdir to build the package in and copy the files to it
     fileSep <- .Platform$file.sep
-    packageDir <- tempfile()
-    dir.create(packageDir)
+    packageDir <- dirCreate(tempfile())
     packageFile <- function(fileName) {
       paste(packageDir, fileName, sep = fileSep)
     }

--- a/tests/testthat/test-bundleFiles.R
+++ b/tests/testthat/test-bundleFiles.R
@@ -74,7 +74,7 @@ test_that("bundle directories are recursively enumerated", {
     "models/abcd/a_b_pt1/a/b/c1/4.RDS",
     "models/abcd/a_b_pt1/a/b/c1/5.RDS"
   )
-  dir.create(file.path(dir, "models/abcd/a_b_pt1/a/b/c1/"), recursive = TRUE)
+  dirCreate(file.path(dir, "models/abcd/a_b_pt1/a/b/c1/"))
   file.create(file.path(dir, files))
 
   size <- sum(file.info(file.path(dir, files))$size)
@@ -96,8 +96,7 @@ test_that("ignores RStudio files", {
 
 test_that("ignores knitr cache directories", {
   dir <- withr::local_tempdir()
-  dir.create(file.path(dir, "foo_cache"))
-  dir.create(file.path(dir, "bar_cache"))
+  dirCreate(file.path(dir, c("foo_cache", "bar_cache")))
   file.create(file.path(dir, c("foo_cache", "bar_cache"), "contents"))
   file.create(file.path(dir, c("foo.Rmd")))
 
@@ -106,15 +105,15 @@ test_that("ignores knitr cache directories", {
 
 test_that("ignores files anywhere in path", {
   dir <- withr::local_tempdir()
-  dir.create(file.path(dir, "a/b/c"), recursive = TRUE)
+  dirCreate(file.path(dir, "a/b/c"))
   file.create(file.path(dir, c("x", "a/b/.gitignore", "a/b/c/.DS_Store")))
 
   expect_equal(bundleFiles(dir), "x")
 })
 
 test_that("ignores files listed in .rscignore", {
-  dir <- withr::local_tempdir()
-  dir.create(file.path(dir, "a"), recursive = TRUE)
+  dir <- local_temp_app()
+  dirCreate(file.path(dir, "a"))
   file.create(file.path(dir, c("x", "a/y")))
   expect_setequal(bundleFiles(dir), c("x", "a/y"))
 
@@ -135,9 +134,9 @@ test_that("ignores temporary files", {
 
 test_that("ignores python virtual envs", {
   dir <- withr::local_tempdir()
-  dir.create(file.path(dir, "test", "bin"), recursive = TRUE)
+  dirCreate(file.path(dir, "test", "bin"))
   file.create(file.path(dir, "test", "bin", "python"))
-  dir.create(file.path(dir, "venv"))
+  dirCreate(file.path(dir, "venv"))
   file.create(file.path(dir, "venv", "somefile"))
 
   expect_equal(bundleFiles(dir), character())
@@ -147,7 +146,7 @@ test_that("ignores python virtual envs", {
 
 test_that("returns relative paths", {
   dir <- withr::local_tempdir()
-  dir.create(file.path(dir, "x"))
+  dirCreate(file.path(dir, "x"))
   file.create(file.path(dir, "x", c("a", "b", "c")))
 
   expect_equal(explodeFiles(dir, "x"), c("x/a", "x/b", "x/c"))
@@ -163,7 +162,7 @@ test_that("drops drops non-existent files with warning", {
 
 test_that("expands files and directory", {
   dir <- withr::local_tempdir()
-  dir.create(file.path(dir, "x"))
+  dirCreate(file.path(dir, "x"))
   file.create(file.path(dir, "x", c("a", "b")))
   file.create(file.path(dir, "c"))
 
@@ -172,7 +171,7 @@ test_that("expands files and directory", {
 
 test_that("can include nested files/directories", {
   dir <- withr::local_tempdir()
-  dir.create(file.path(dir, "x", "y"), recursive = TRUE)
+  dirCreate(file.path(dir, "x", "y"))
   file.create(file.path(dir, "x", c("a", "b", "c")))
   file.create(file.path(dir, "x", "y", c("d", "e")))
 
@@ -183,7 +182,7 @@ test_that("can include nested files/directories", {
 
 test_that("doesn't ignore user supplied files", {
   dir <- withr::local_tempdir()
-  dir.create(file.path(dir, "x", "y"), recursive = TRUE)
+  dirCreate(file.path(dir, "x", "y"))
   file.create(file.path(dir, "x", "packrat"))
   file.create(file.path(dir, "x", "y", "packrat"))
 
@@ -194,9 +193,8 @@ test_that("doesn't ignore user supplied files", {
 
 test_that("explodeFiles() and bundleFiles() both eagerly enforce limits", {
   dir <- withr::local_tempdir()
-  dir.create(file.path(dir, "a"))
+  dirCreate(file.path(dir, c("a", "b")))
   file.create(file.path(dir, "a", letters))
-  dir.create(file.path(dir, "b"))
   file.create(file.path(dir, "b", letters))
 
   withr::local_options(rsconnect.max.bundle.files = 1)

--- a/tests/testthat/test-deploymentTarget.R
+++ b/tests/testthat/test-deploymentTarget.R
@@ -170,9 +170,7 @@ test_that("succeeds if there are no deployments and a single account", {
     applications = function(...) data.frame()
   )
 
-  dir <- withr::local_tempdir()
-  app_dir <- file.path(dir, "my_app")
-  dir.create(app_dir)
+  app_dir <- dirCreate(file.path(withr::local_tempdir(), "my_app"))
 
   target <- deploymentTarget(app_dir, envVars = c("TEST1", "TEST2"))
   expect_equal(target$appName, "my_app")

--- a/tests/testthat/test-linters.R
+++ b/tests/testthat/test-linters.R
@@ -1,5 +1,5 @@
 test_that("linter warns about absolute paths and relative paths", {
-  dir.create("~/.rsconnect-tests", showWarnings = FALSE)
+  dirCreate("~/.rsconnect-tests")
   file.create("~/.rsconnect-tests/local-file.txt")
   withr::defer(unlink("~/.rsconnect-tests", recursive = TRUE))
 


### PR DESCRIPTION
`dirCreate()` was added previously, now just using it everywhere since it's a bit more user friendly:

```R
dirCreate <- function(paths) {
  for (path in paths) {
    dir.create(path, showWarnings = FALSE, recursive = TRUE)
  }
  paths
}
```