### PR TITLE
Use `defer()` instead of `on.exit()`

### DIFF
--- a/R/appDependencies.R
+++ b/R/appDependencies.R
@@ -123,7 +123,7 @@ appDependencies <- function(appDir = getwd(), appFiles = NULL) {
   }
 
   bundleDir <- bundleAppDir(appDir, appFiles)
-  on.exit(unlink(bundleDir, recursive = TRUE), add = TRUE)
+  defer(unlink(bundleDir, recursive = TRUE))
 
   extraPackages <- inferRPackageDependencies(appMetadata)
   deps <- computePackageDependencies(bundleDir, extraPackages, quiet = TRUE)

--- a/R/auth.R
+++ b/R/auth.R
@@ -303,7 +303,7 @@ writePasswordFile <- function(path, passwords) {
 
   # open and file
   f <- file(path, open = "w")
-  on.exit(close(f), add = TRUE)
+  defer(close(f))
 
   # write passwords
   apply(passwords, 1, function(r) {

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -10,7 +10,7 @@
   # create a directory to stage the application bundle in
   bundleDir <- tempfile()
   dir.create(bundleDir, recursive = TRUE)
-  on.exit(unlink(bundleDir), add = TRUE)
+  defer(unlink(bundleDir))
 
   logger("Copying files")
   # copy the files into the bundle dir
@@ -74,7 +74,7 @@ writeBundle <- function(bundleDir, bundlePath, verbose = FALSE) {
   logger <- verboseLogger(verbose)
 
   prevDir <- setwd(bundleDir)
-  on.exit(setwd(prevDir), add = TRUE)
+  defer(setwd(prevDir))
 
   tarImplementation <- getTarImplementation()
   logger("Using tar: ", tarImplementation)

--- a/R/bundlePackagePackrat.R
+++ b/R/bundlePackagePackrat.R
@@ -157,17 +157,14 @@ performPackratSnapshot <- function(bundleDir, verbose = FALSE) {
   # ensure we snapshot recommended packages
   srp <- packrat::opts$snapshot.recommended.packages()
   packrat::opts$snapshot.recommended.packages(TRUE, persist = FALSE)
-  on.exit(
-    packrat::opts$snapshot.recommended.packages(srp, persist = FALSE),
-    add = TRUE
-  )
+  defer(packrat::opts$snapshot.recommended.packages(srp, persist = FALSE))
 
   # Force renv dependency scanning within packrat unless the option has been
   # explicitly configured. This is a no-op for older versions of packrat.
   renvDiscovery <- getOption("packrat.dependency.discovery.renv")
   if (is.null(renvDiscovery)) {
     old <- options("packrat.dependency.discovery.renv" = TRUE)
-    on.exit(options(old), add = TRUE)
+    defer(options(old))
   }
 
   # attempt to eagerly load the BiocInstaller or BiocManaager package if

--- a/R/certificates.R
+++ b/R/certificates.R
@@ -76,7 +76,7 @@ createCertificateFile <- function(certificate) {
 
   # open temporary cert store
   con <- file(certificateStore, open = "at")
-  on.exit(close(con), add = TRUE)
+  defer(close(con))
 
   # copy the contents of the certificate file into the store, if we found one
   # (we don't do a straight file copy since we don't want to inherit or

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -247,7 +247,7 @@ deployApp <- function(appDir = getwd(),
       rsconnect.http.trace.json = TRUE,
       rsconnect.error.trace = TRUE
     )
-    on.exit(options(old_verbose), add = TRUE)
+    defer(options(old_verbose))
   }
 
   # install error handler if requested
@@ -258,7 +258,7 @@ deployApp <- function(appDir = getwd(),
       cat("----- Error stack trace -----\n")
       traceback(x = sys.calls(), max.lines = 3)
     })
-    on.exit(options(old_error), add = TRUE)
+    defer(options(old_error))
   }
 
   # at verbose log level, generate header
@@ -586,7 +586,7 @@ bundleApp <- function(appName,
       appDir = appDir,
       appFiles = appFiles,
       appPrimaryDoc = appMetadata$appPrimaryDoc)
-  on.exit(unlink(bundleDir, recursive = TRUE), add = TRUE)
+  defer(unlink(bundleDir, recursive = TRUE))
 
   # generate the manifest and write it into the bundle dir
   logger("Generate manifest.json")

--- a/R/deploySite.R
+++ b/R/deploySite.R
@@ -145,7 +145,7 @@ rmarkdownSite <- function(siteDir, quiet = FALSE, error_call = caller_env()) {
 
 outputDir <- function(wd, path) {
   old <- setwd(wd)
-  on.exit(setwd(old))
+  defer(setwd(old))
 
   if (!file.exists(path)) {
     dir.create(path, recursive = TRUE, showWarnings = FALSE)

--- a/R/http-curl.R
+++ b/R/http-curl.R
@@ -90,7 +90,7 @@ httpCurl <- function(protocol,
 
   if (result == 0) {
     fileConn <- file(outputFile, "rb")
-    on.exit(close(fileConn))
+    defer(close(fileConn))
     readHttpResponse(list(
         protocol = protocol,
         host     = host,

--- a/R/http-internal.R
+++ b/R/http-internal.R
@@ -66,7 +66,7 @@ httpInternal <- function(protocol,
                              open = "w+b",
                              blocking = TRUE,
                              timeout = timeout)
-    on.exit(close(conn))
+    defer(close(conn))
 
     # write the request header and file payload
     writeBin(charToRaw(paste(request, collapse = "")), conn, size = 1)

--- a/R/http-libcurl.R
+++ b/R/http-libcurl.R
@@ -34,7 +34,7 @@ httpLibCurl <- function(protocol,
 
     # open a connection to read the file, and ensure it's closed when we're done
     contentCon <- file(contentFile, "rb")
-    on.exit(if (!is.null(contentCon)) close(contentCon), add = TRUE)
+    defer(if (!is.null(contentCon)) close(contentCon))
 
     progress <- is_interactive() && fileLength >= 10 * 1024^2
 

--- a/R/http.R
+++ b/R/http.R
@@ -500,7 +500,7 @@ signatureHeaders <- function(authInfo, method, path, file = NULL) {
 rfc2616Date <- function(time = Sys.time()) {
   # set locale to POSIX/C to ensure ASCII date
   old <- Sys.setlocale("LC_TIME", "C")
-  on.exit(Sys.setlocale("LC_TIME", old))
+  defer(Sys.setlocale("LC_TIME", old))
 
   strftime(Sys.time(), "%a, %d %b %Y %H:%M:%S GMT", tz = "GMT")
 }

--- a/R/lint.R
+++ b/R/lint.R
@@ -15,7 +15,7 @@ lint <- function(project, files = NULL, appPrimaryDoc = NULL) {
 
   # Perform actions within the project directory (so relative paths are easily used)
   owd <- getwd()
-  on.exit(setwd(owd))
+  defer(setwd(owd))
   setwd(project)
 
   linters <- mget(objects(.__LINTERS__.), envir = .__LINTERS__.)
@@ -31,7 +31,7 @@ lint <- function(project, files = NULL, appPrimaryDoc = NULL) {
 
     # force native encoding (disable any potential internal conversion)
     old <- options(encoding = "native.enc")
-    on.exit(options(old), add = TRUE)
+    defer(options(old))
 
     # read content with requested encoding
     # TODO: may consider converting from native encoding to UTF-8 if appropriate

--- a/R/writeManifest.R
+++ b/R/writeManifest.R
@@ -47,7 +47,7 @@ writeManifest <- function(appDir = getwd(),
     appFiles = appFiles,
     appPrimaryDoc = appMetadata$appPrimaryDoc
   )
-  on.exit(unlink(bundleDir, recursive = TRUE), add = TRUE)
+  defer(unlink(bundleDir, recursive = TRUE))
 
   python <- getPython(python)
   pythonConfig <- pythonConfigurator(python, forceGeneratePythonEnvironment)

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -57,6 +57,28 @@ local_temp_app <- function(files = list(), env = caller_env()) {
   dir
 }
 
+
+local_shiny_bundle <- function(appName, appDir, appPrimaryDoc, python = NULL) {
+  appFiles <- bundleFiles(appDir)
+  appMetadata <- appMetadata(appDir, appFiles, appPrimaryDoc = appPrimaryDoc)
+
+  tarfile <- bundleApp(
+    appName,
+    appDir,
+    appFiles = appFiles,
+    appMetadata = appMetadata,
+    pythonConfig = pythonConfigurator(python),
+    quiet = TRUE
+  )
+  bundleTempDir <- tempfile()
+  utils::untar(tarfile, exdir = bundleTempDir)
+  unlink(tarfile)
+
+  defer(unlink(bundleTempDir, recursive = TRUE), env = caller_env())
+  bundleTempDir
+}
+
+
 # Servers and accounts ----------------------------------------------------
 
 addTestAccount <- function(account = "ron", server = "example.com", userId = account) {

--- a/tests/testthat/test-writeManifest.R
+++ b/tests/testthat/test-writeManifest.R
@@ -16,7 +16,7 @@ test_that("Rmd with reticulate as a dependency includes python in the manifest",
   manifest <- makeManifest(appDir, python = python)
   requirements_file <- file.path(appDir, manifest$python$package_manager$package_file)
   expect_equal(requirements_file, "test-reticulate-rmds/requirements.txt")
-  on.exit(unlink(requirements_file))
+  defer(unlink(requirements_file))
 
   expect_equal(manifest$metadata$appmode, "rmd-static")
   expect_equal(manifest$metadata$primary_rmd, "index.Rmd")
@@ -32,7 +32,7 @@ test_that("Rmd with reticulate as an inferred dependency includes reticulate and
   manifest <- makeManifest(appDir, "implicit.Rmd", python = python)
   requirements_file <- file.path(appDir, manifest$python$package_manager$package_file)
   expect_equal(requirements_file, "test-reticulate-rmds/requirements.txt")
-  on.exit(unlink(requirements_file))
+  defer(unlink(requirements_file))
 
   expect_equal(manifest$metadata$appmode, "rmd-static")
   expect_equal(manifest$metadata$primary_rmd, "implicit.Rmd")


### PR DESCRIPTION
Since we have it in utils now, and it's both safer than `on.exit()` and can be used in more places.