### PR TITLE
fix shinyapps.io deploys

### DIFF
--- a/R/client-cloud.R
+++ b/R/client-cloud.R
@@ -146,11 +146,11 @@ cloudClient <- function(service, authInfo) {
       output <- POST_JSON(service, authInfo, "/outputs", json)
       path <- paste0("/applications/", output$source_id)
       application <- GET(service, authInfo, path)
-      application$application_id <- application$id
-      application$id <- output$id
-      # this swaps the "application url" for the "content url". So we end up redirecting to the right spot after deployment.
-      application$url <- output$url
-      application
+      list(
+        id = output$id,
+        application_id = application$id,
+        url = output$url
+      )
     },
 
     listApplicationProperties = function(applicationId) {

--- a/R/client-connect.R
+++ b/R/client-connect.R
@@ -56,7 +56,11 @@ connectClient <- function(service, authInfo) {
 
       # RSC doesn't currently use the template or account ID
       # parameters; they exist for compatibility with lucid.
-      POST_JSON(service, authInfo, "/applications", details)
+      application <- POST_JSON(service, authInfo, "/applications", details)
+      list(
+        id = application$id,
+        url = application$url
+      )
     },
 
     terminateApplication = function(applicationId) {

--- a/R/client-shinyapps.R
+++ b/R/client-shinyapps.R
@@ -94,7 +94,9 @@ shinyAppsClient <- function(service, authInfo) {
       # the title field is only used on connect
       json$template <- template
       json$account <- as.numeric(accountId)
-      POST_JSON(service, authInfo, "/applications/", json)
+      application <- POST_JSON(service, authInfo, "/applications/", json)
+      application$application_id <- application$id
+      application
     },
 
     listApplicationProperties = function(applicationId) {

--- a/R/client-shinyapps.R
+++ b/R/client-shinyapps.R
@@ -95,8 +95,11 @@ shinyAppsClient <- function(service, authInfo) {
       json$template <- template
       json$account <- as.numeric(accountId)
       application <- POST_JSON(service, authInfo, "/applications/", json)
-      application$application_id <- application$id
-      application
+      list(
+        id = application$id,
+        application_id = application$id,
+        url = application$url
+      )
     },
 
     listApplicationProperties = function(applicationId) {


### PR DESCRIPTION
We changed our call to `uploadCloudBundle` to pass in `application$application_id` to support including the output id in `application$id`, but `application$application_id` wasn't populated for shinyapps.

Resolves https://github.com/rstudio/rsconnect/issues/852.