### PR TITLE
renv.consent = TRUE to bypass consent screen

### DIFF
--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -3,7 +3,10 @@ snapshotRenvDependencies <- function(bundleDir,
                                      verbose = FALSE) {
   recordExtraDependencies(bundleDir, extraPackages)
 
-  old <- options(renv.verbose = FALSE, pkgType = "source")
+  old <- options(
+    renv.verbose = FALSE,
+    renv.consent = TRUE,
+    pkgType = "source")
   defer(options(old))
 
   renv::snapshot(bundleDir, prompt = FALSE)


### PR DESCRIPTION
Without this fix, calls that capture dependencies in a vanilla project would prompt for renv consent.


fixes #874