### PR TITLE
allow multiple servers with same URL

### DIFF
--- a/R/ide.R
+++ b/R/ide.R
@@ -18,7 +18,7 @@ validateServerUrl <- function(url, certificate = NULL) {
 # registered server is returned.
 findAndRegisterLocalServer <- function(url) {
   # helper to find a server given its URL
-  findServerByUrl <- function(name) {
+  findServerByUrl <- function(url) {
     allServers <- rsconnect::servers(local = TRUE)
     match <- allServers[allServers$url == url, , drop = FALSE]
     if (nrow(match) == 0)
@@ -119,7 +119,8 @@ getUserFromRawToken <- function(serverUrl,
 
   # Look up server name from url
   servers <- servers()
-  server <- servers$name[servers$url == serverUrl]
+  matches <- servers$url == serverUrl
+  server <- servers$name[which(matches)[[1]]]
 
   waitForAuthedUser(server, token = token, private_key = privateKey)
 }

--- a/tests/testthat/test-ide.R
+++ b/tests/testthat/test-ide.R
@@ -39,3 +39,50 @@ test_that("getAppById() fails where expected", {
     getAppById("123", "robert", "unknown", "https://example.com")
   })
 })
+
+current_user_service <- function() {
+  app <- env_cache(
+    cache,
+    "current_user_app",
+    {
+      json_app <- webfakes::new_app()
+      json_app$use(webfakes::mw_json())
+      json_app$get("/users/current", function(req, res) {
+        res$set_status(200L)$send_json(list(username=jsonlite::unbox("susan")))
+      })
+      app <- webfakes::new_app_process(json_app)
+    }
+  )
+  parseHttpUrl(app$url())
+}
+
+test_that("getUserFromRawToken having a single matching server", {
+  local_temp_config()
+
+  service <- current_user_service()
+  url <- buildHttpUrl(service)
+
+  addTestServer("test", url = url)
+
+  token <- generateToken()
+  claimUrl <- url
+
+  user <- getUserFromRawToken(claimUrl, token$token, token$private_key)
+  expect_equal(user$username, "susan")
+})
+
+test_that("getUserFromRawToken having multiple matching servers", {
+  local_temp_config()
+
+  service <- current_user_service()
+  url <- buildHttpUrl(service)
+
+  addTestServer("test", url = url)
+  addTestServer("test2", url = url)
+
+  token <- generateToken()
+  claimUrl <- url
+
+  user <- getUserFromRawToken(claimUrl, token$token, token$private_key)
+  expect_equal(user$username, "susan")
+})

--- a/tests/testthat/test-ide.R
+++ b/tests/testthat/test-ide.R
@@ -48,7 +48,7 @@ current_user_service <- function() {
       json_app <- webfakes::new_app()
       json_app$use(webfakes::mw_json())
       json_app$get("/users/current", function(req, res) {
-        res$set_status(200L)$send_json(list(username=jsonlite::unbox("susan")))
+        res$set_status(200L)$send_json(list(username = jsonlite::unbox("susan")))
       })
       app <- webfakes::new_app_process(json_app)
     }


### PR DESCRIPTION
additionally, use the "ensured" URL when finding a local server.

fixes #878