### PR TITLE
Always record quarto version in manifest

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -108,7 +108,6 @@ createAppManifest <- function(appDir,
                               users = NULL,
                               pythonConfig = NULL,
                               retainPackratDirectory = TRUE,
-                              isCloudServer = FALSE,
                               image = NULL,
                               verbose = FALSE,
                               quiet = FALSE) {
@@ -198,9 +197,8 @@ createAppManifest <- function(appDir,
   }
 
   # indicate whether this is a quarto app/doc
-  if (!is.null(appMetadata$quartoInfo) && !isCloudServer) {
-    manifest$quarto <- appMetadata$quartoInfo
-  }
+  manifest$quarto <- appMetadata$quartoInfo
+
   # if there is python info for reticulate or Quarto, attach it
   if (!is.null(python)) {
     manifest$python <- python

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -321,8 +321,7 @@ deployApp <- function(appDir = getwd(),
 
   # Run checks prior to first saveDeployment() to avoid errors that will always
   # prevent a successful upload from generating a partial deployment
-  isCloudServer <- isCloudServer(target$server)
-  if (!isCloudServer && identical(upload, FALSE)) {
+  if (!isCloudServer(target$server) && identical(upload, FALSE)) {
     # it is not possible to deploy to Connect without uploading
     stop("Posit Connect does not support deploying without uploading. ",
          "Specify upload=TRUE to upload and re-deploy your application.")
@@ -416,7 +415,6 @@ deployApp <- function(appDir = getwd(),
       quiet = quiet,
       verbose = verbose,
       pythonConfig = pythonConfig,
-      isCloudServer = isCloudServer,
       image = image
     )
     size <- format(file_size(bundlePath), big.mark = ",")
@@ -582,7 +580,6 @@ bundleApp <- function(appName,
                       verbose = FALSE,
                       quiet = FALSE,
                       pythonConfig = NULL,
-                      isCloudServer = FALSE,
                       image = NULL) {
   logger <- verboseLogger(verbose)
 
@@ -608,7 +605,6 @@ bundleApp <- function(appName,
     users = users,
     pythonConfig = pythonConfig,
     retainPackratDirectory = TRUE,
-    isCloudServer = isCloudServer,
     image = image,
     verbose = verbose,
     quiet = quiet


### PR DESCRIPTION
Fixes #885

This will now send the `quarto` field to shinyapps.io. Is that ok?