### PR TITLE
skip quarto-using tests when no quarto (CRAN winbuilder)

### DIFF
--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -16,6 +16,7 @@ test_that("quarto affects mode inference", {
 })
 
 test_that("quarto path is deprecated", {
+  skip_if_no_quarto()
   dir <- local_temp_app(list("foo.Rmd" = ""))
   expect_snapshot(. <- appMetadata(dir, quarto = "abc"))
 })

--- a/tests/testthat/test-deploySite.R
+++ b/tests/testthat/test-deploySite.R
@@ -1,4 +1,5 @@
 test_that("can extract quarto metadata", {
+  skip_if_no_quarto()
   app <- local_temp_app(list(`_quarto.yaml` = c(
     "project:",
     "  type: website",


### PR DESCRIPTION
Addressing:

```
  ── Error ('test-appMetadata.R:20:3'): quarto path is deprecated ────────────────
  `. <- appMetadata(dir, quarto = "abc")` threw an unexpected error.
  Message: `quarto` not found.
  i Check that it is installed and available on your `PATH`.
  Class:   rlang_error/error/condition
  Backtrace:
      ▆
   1. └─rsconnect:::appMetadata(dir, quarto = "abc")
   2.   └─rsconnect:::inferQuartoInfo(...)
   3.     └─rsconnect:::quartoInspect(appDir = appDir, appPrimaryDoc = appPrimaryDoc)
   4.       └─cli::cli_abort(c("`quarto` not found.", i = "Check that it is installed and available on your {.envvar PATH}."))
   5.         └─rlang::abort(...)
  ── Error ('test-deploySite.R:10:3'): can extract quarto metadata ───────────────
  Error in `find_quarto()`: Unable to find quarto command line tools.
  Backtrace:
      ▆
   1. └─rsconnect:::quartoSite(app) at test-deploySite.R:10:2
   2.   └─quarto::quarto_inspect(path)
   3.     └─quarto:::find_quarto()
```
