### PR TITLE
skip when biobase is not installed

### DIFF
--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -25,6 +25,7 @@ test_that("recommended packages are snapshotted", {
 })
 
 test_that("works with BioC packages", {
+  skip_if_not_installed("Biobase")
   app <- local_temp_app(list("index.R" = c(
     "library(Biobase)"
   )))


### PR DESCRIPTION
Attempting to address:

```
  ── Error ('test-bundlePackageRenv.R:35:3'): works with BioC packages ───────────
  Error in `renv_snapshot_validate_report(valid, prompt, force)`: aborting snapshot due to pre-flight validation failure
  Backtrace:
       ▆
    1. ├─testthat::expect_no_condition(...) at test-bundlePackageRenv.R:35:2
    2. │ └─testthat:::expect_no_(...)
    3. │   └─testthat:::quasi_capture(enquo(object), NULL, capture)
    4. │     ├─testthat (local) .capture(...)
    5. │     │ └─rlang::try_fetch(...)
    6. │     │   └─base::withCallingHandlers(...)
    7. │     └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
    8. └─rsconnect:::snapshotRenvDependencies(app)
    9.   └─renv::snapshot(bundleDir, prompt = FALSE)
   10.     └─renv:::renv_snapshot_validate_report(valid, prompt, force)
```