### PR TITLE
include application_id in client-shinyapps getApplication result

### DIFF
--- a/R/client-shinyapps.R
+++ b/R/client-shinyapps.R
@@ -66,7 +66,9 @@ shinyAppsClient <- function(service, authInfo) {
 
     getApplication = function(applicationId, deploymentRecordVersion) {
       path <- paste("/applications/", applicationId, sep = "")
-      GET(service, authInfo, path)
+      application <- GET(service, authInfo, path)
+      application$application_id <- application$id
+      application
     },
 
     getApplicationMetrics = function(applicationId, series, metrics, from = NULL, until = NULL, interval = NULL) {


### PR DESCRIPTION
We're looking for `application$application_id` when we deploy the bundle. This is currently present on the `createApplication` return value, but not for `getApplication`.

Resolves https://github.com/rstudio/rsconnect/issues/901.