### PR TITLE
use renv::dependencies rather than renv::snapshot to compute dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rsconnect (development version)
 
+* Explicit renv dependencies are preserved. (#916)
+
 # rsconnect 1.0.0
 
 ## New features

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -9,7 +9,10 @@ snapshotRenvDependencies <- function(bundleDir,
   )
   defer(options(old))
 
-  renv::snapshot(bundleDir, prompt = FALSE)
+  # analyze code dependencies ourselves rather than relying on the scan during renv::snapshot, as
+  # that will add renv to renv.lock as a dependency.
+  deps <- renv::dependencies(bundleDir)
+  renv::snapshot(bundleDir, packages = deps$Package, prompt = FALSE)
   defer(removeRenv(bundleDir))
 
   parseRenvDependencies(bundleDir, snapshot = TRUE)
@@ -71,11 +74,6 @@ standardizeRenvPackage <- function(pkg,
                                    biocPackages = NULL,
                                    repos = character(),
                                    bioc) {
-  # Don't include renv itself
-  if (identical(pkg$Package, "renv")) {
-    return(NULL)
-  }
-
   # Convert renv source to manifest source/repository
   # https://github.com/rstudio/renv/blob/0.17.2/R/snapshot.R#L730-L773
 

--- a/tests/testthat/_snaps/bundlePackage.md
+++ b/tests/testthat/_snaps/bundlePackage.md
@@ -20,7 +20,7 @@
       pkgs <- bundlePackages(app_dir)
     Message
       i Capturing R dependencies from renv.lock
-      v Found 1 dependency
+      v Found 2 dependencies
 
 # error if can't find source
 

--- a/tests/testthat/_snaps/servers.md
+++ b/tests/testthat/_snaps/servers.md
@@ -62,14 +62,6 @@
       ! Certificates may only be attached to servers that use the HTTPS protocol.
       i Specify an HTTPS URL for the server, or omit the certificate.
 
-# cloud server errors if not cloud server
-
-    Code
-      cloudServerInfo("foo")
-    Condition
-      Error in `cloudServerInfo()`:
-      ! `name` must be one of "shinyapps.io", "posit.cloud", or "rstudio.cloud", not "foo".
-
 # findServer() errors if no servers
 
     Code

--- a/tests/testthat/test-bundlePackage.R
+++ b/tests/testthat/test-bundlePackage.R
@@ -25,7 +25,7 @@ test_that("can capture deps from renv lockfile", {
   app_dir <- local_temp_app(list(foo.R = "library(foreign)"))
   renv::snapshot(app_dir, prompt = FALSE)
   expect_snapshot(pkgs <- bundlePackages(app_dir))
-  expect_named(pkgs, "foreign")
+  expect_named(pkgs, c("foreign", "renv"))
   expect_named(pkgs$foreign, c("Source", "Repository", "description"))
 
   # No renv lockfile or directory left behind

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -65,7 +65,7 @@ test_that("gets DESCRIPTION from renv library", {
   renv::snapshot(app_dir, prompt = FALSE)
 
   deps <- parseRenvDependencies(app_dir)
-  expect_setequal(deps$Package, c("foreign", "withr"))
+  expect_setequal(deps$Package, c("foreign", "withr", "renv"))
   expect_type(deps$description, "list")
   expect_type(deps$description[[1]], "list")
 })


### PR DESCRIPTION
side-effect: an renv dependency is included when consuming an renv.lock, as there is no way to distinguish between a code-dependency and bootstrapping-dependency.

fixes #916

After installing this branch:

```r
remotes::install_github("rstudio/rsconnect", "aron-renv-dependencies")
```

Using this installation technique is needed to avoid pre-flight errors caused by https://github.com/rstudio/rsconnect/issues/915

``` r
packageVersion("rsconnect")
#> [1] '1.0.0.9000'
packageVersion("renv")
#> [1] '1.0.0'
rsconnect::writeManifest(appFiles = c("app.R"))
#> ℹ Capturing R dependencies with renv
#> ✔ Found 40 dependencies
manifest <- jsonlite::read_json("manifest.json")
manifest$packages$rsconnect$description$Imports
#> [1] "cli, curl, digest, jsonlite, lifecycle, openssl (>= 2.0.0),\npackrat (>= 0.6), renv (>= 1.0.0), rlang (>= 1.0.0), rstudioapi\n(>= 0.5), tools, yaml (>= 2.1.5)"
"renv" %in% names(manifest$packages)
#> [1] TRUE
```

<sup>Created on 2023-07-18 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>