### PR TITLE
Make bundlePackages() more robust

### DIFF
--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -46,7 +46,12 @@ parseRenvDependencies <- function(bundleDir, snapshot = FALSE) {
     renv::restore(bundleDir, library = lib_dir, prompt = FALSE)
     defer(unlink(lib_dir, recursive = TRUE))
 
-    deps$description <- lapply(deps$Package, package_record, lib_dir = lib_dir)
+    deps$description <- lapply(
+      deps$Package,
+      package_record,
+      # Ensure we fall back to system libraries
+      lib_dir = c(lib_dir, .libPaths())
+    )
   }
 
   deps

--- a/tests/testthat/_snaps/bundlePackage.md
+++ b/tests/testthat/_snaps/bundlePackage.md
@@ -20,7 +20,7 @@
       pkgs <- bundlePackages(app_dir)
     Message
       i Capturing R dependencies from renv.lock
-      v Found 2 dependencies
+      v Found 3 dependencies
 
 # error if can't find source
 

--- a/tests/testthat/test-bundlePackage.R
+++ b/tests/testthat/test-bundlePackage.R
@@ -22,11 +22,12 @@ test_that("can snapshot deps with packrat", {
 test_that("can capture deps from renv lockfile", {
   withr::local_options(renv.verbose = FALSE)
 
-  app_dir <- local_temp_app(list(foo.R = "library(foreign)"))
+  app_dir <- local_temp_app(list(foo.R = "library(foreign); library(MASS)"))
   renv::snapshot(app_dir, prompt = FALSE)
   expect_snapshot(pkgs <- bundlePackages(app_dir))
-  expect_named(pkgs, c("foreign", "renv"))
+  expect_named(pkgs, c("foreign", "MASS", "renv"), ignore.order = TRUE)
   expect_named(pkgs$foreign, c("Source", "Repository", "description"))
+  expect_named(pkgs$MASS, c("Source", "Repository", "description"))
 
   # No renv lockfile or directory left behind
   expect_equal(list.files(app_dir), "foo.R")

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -58,16 +58,18 @@ test_that("works with BioC packages", {
 
 # parseRenvDependencies ---------------------------------------------------
 
-test_that("gets DESCRIPTION from renv library", {
+test_that("gets DESCRIPTION from renv & system libraries", {
   withr::local_options(renv.verbose = FALSE)
 
-  app_dir <- local_temp_app(list("foo.R" = "library(withr); library(foreign)"))
+  app_dir <- local_temp_app(list("foo.R" = "library(foreign); library(MASS)"))
   renv::snapshot(app_dir, prompt = FALSE)
 
   deps <- parseRenvDependencies(app_dir)
-  expect_setequal(deps$Package, c("foreign", "withr", "renv"))
+  expect_setequal(deps$Package, c("foreign", "MASS", "renv"))
+
   expect_type(deps$description, "list")
-  expect_type(deps$description[[1]], "list")
+  expect_type(deps$description[[which(deps$Package == "foreign")]], "list")
+  expect_type(deps$description[[which(deps$Package == "MASS")]], "list")
 })
 
 # standardizeRenvPackage -----------------------------------------


### PR DESCRIPTION
This ensures that we work better with both dev renv and with recommended packages that are bundled with R itself.