### PR TITLE
New strategy to retrieve DESCRIPTION if project uses renv

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # rsconnect (development version)
 
-* `deployApp()` and `writeManifest()` now error if your library and lockfile
-  are out-of-sync. Previously it always used what was defined in the lockfile
+* `deployApp()` and `writeManifest()` now error if your library and `renv.lock`
+  are out-of-sync. Previously it always used what was defined in the `renv.lock`
   but that was (a) slow and (b) could lead to different results than what you
   see when running locally (#930).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # rsconnect (development version)
 
+* `deployApp()` and `writeManifest()` now error if your library and lockfile
+  are out-of-sync. Previously it always used what was defined in the lockfile
+  but that was (a) slow and (b) could lead to different results than what you
+  see when running locally (#930).
+
 # rsconnect 1.0.1
 
 * `deployDoc()` includes `.Rprofile`, `requirements.txt` and `renv.lock` when

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -34,8 +34,10 @@ parseRenvDependencies <- function(bundleDir, snapshot = FALSE) {
     return(data.frame())
   }
 
+  deps$description <- lapply(deps$Package, package_record)
+
   if (!snapshot) {
-    lib_versions <- unlist(lapply(deps$Package, packageDescription, fields = "Version"))
+    lib_versions <- unlist(lapply(deps$description, "[[", "Version"))
 
     if (any(deps$Version != lib_versions)) {
       cli::cli_abort(c(
@@ -46,7 +48,6 @@ parseRenvDependencies <- function(bundleDir, snapshot = FALSE) {
     }
   }
 
-  deps$description <- lapply(deps$Package, package_record)
   deps
 }
 

--- a/tests/testthat/_snaps/bundlePackageRenv.md
+++ b/tests/testthat/_snaps/bundlePackageRenv.md
@@ -1,0 +1,10 @@
+# errors if library and project are inconsistent
+
+    Code
+      parseRenvDependencies(app_dir)
+    Condition
+      Error in `parseRenvDependencies()`:
+      ! Library and lockfile are out of sync
+      i Use renv::restore() or renv::snapshot() to synchronise
+      i Or ignore the lockfile by adding to you .rscignore
+

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -72,6 +72,17 @@ test_that("gets DESCRIPTION from renv & system libraries", {
   expect_type(deps$description[[which(deps$Package == "MASS")]], "list")
 })
 
+
+test_that("errors if library and project are inconsistent", {
+  withr::local_options(renv.verbose = FALSE)
+
+  app_dir <- local_temp_app(list("foo.R" = "library(foreign); library(MASS)"))
+  renv::snapshot(app_dir, prompt = FALSE)
+  renv::record("MASS@0.1.1", project = app_dir)
+
+  expect_snapshot(parseRenvDependencies(app_dir), error = TRUE)
+})
+
 # standardizeRenvPackage -----------------------------------------
 
 test_that("SCM get names translated", {


### PR DESCRIPTION
Previously we'd always restore the packages from the lockfile, which I had expected to be fast since I had expected the packages to be in the cache. However, this doesn't appear to always be the case, so I instead use a simpler approach where I just force the user to resolve the problem. This means that we can always use the `DESCRIPTION` present in the `.libPaths()` making the code much simpler.

Fixes #930

@edavidaja could you please confirm that this fixes your problem?