### PR TITLE
avoid zero-length files

### DIFF
--- a/tests/testthat/quarto-website-r-py/requirements.txt
+++ b/tests/testthat/quarto-website-r-py/requirements.txt
@@ -1,0 +1,2 @@
+# stub requirements.txt
+# Its presence indicates the need for Python dependencies.

--- a/tests/testthat/shiny-app-in-subdir/my-app/server.R
+++ b/tests/testthat/shiny-app-in-subdir/my-app/server.R
@@ -1,0 +1,4 @@
+# Stub server.R
+#
+# Its presence (along with ui.R) indicates that this directory contains a
+# Shiny application.

--- a/tests/testthat/shiny-app-in-subdir/my-app/ui.r
+++ b/tests/testthat/shiny-app-in-subdir/my-app/ui.r
@@ -1,0 +1,4 @@
+# Stub ui.R
+#
+# Its presence (along with server.R) indicates that this directory contains a
+# Shiny application.

--- a/tests/testthat/shinyapp-with-absolute-paths/data/College.txt
+++ b/tests/testthat/shinyapp-with-absolute-paths/data/College.txt
@@ -1,0 +1,1 @@
+fake,42,data


### PR DESCRIPTION
Debian discards zero-length files. We may add additional zero-length files within our test hierarchy in the future, but avoid them for now.

See #954

@tillea - this will help avoid your immediate problem, but the test hierarchy really should have its file and directory structure preserved.