### PR TITLE
renv dependency limit mirrors the rsconnect bundle limit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rsconnect (development version)
 
+* Fixed analysis of directories that were smaller than the
+  `rsconnect.max.bundle.files=10000` limit but larger than the
+  `renv.config.dependencies.limit=1000` limit. (#968)
+
 # rsconnect 1.0.2
 
 * Fixed redeployments to shinyapps.io where `appName` is provided, but no local

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -9,9 +9,18 @@ snapshotRenvDependencies <- function(bundleDir,
   )
   defer(options(old))
 
+  dependenciesLimit <- getOption("renv.config.dependencies.limit")
+  if (is.null(dependenciesLimit)) {
+    maxFiles <- getOption("rsconnect.max.bundle.files", 10000)
+    oldlim <- options(
+      renv.config.dependencies.limit = maxFiles
+    )
+    defer(options(oldlim))
+  }
+
   # analyze code dependencies ourselves rather than relying on the scan during renv::snapshot, as
   # that will add renv to renv.lock as a dependency.
-  deps <- renv::dependencies(bundleDir)
+  deps <- renv::dependencies(bundleDir, root = bundleDir)
   renv::snapshot(bundleDir, packages = deps$Package, prompt = FALSE)
   defer(removeRenv(bundleDir))
 

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -20,7 +20,7 @@ snapshotRenvDependencies <- function(bundleDir,
 
   # analyze code dependencies ourselves rather than relying on the scan during renv::snapshot, as
   # that will add renv to renv.lock as a dependency.
-  deps <- renv::dependencies(bundleDir, root = bundleDir)
+  deps <- renv::dependencies(bundleDir, root = bundleDir, progress = FALSE)
   renv::snapshot(bundleDir, packages = deps$Package, prompt = FALSE)
   defer(removeRenv(bundleDir))
 

--- a/tests/testthat/_snaps/bundlePackageRenv.md
+++ b/tests/testthat/_snaps/bundlePackageRenv.md
@@ -1,3 +1,8 @@
+# large directories are analyzed
+
+    Code
+      deps <- snapshotRenvDependencies(app_dir)
+
 # errors if library and project are inconsistent
 
     Code

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -56,6 +56,20 @@ test_that("works with BioC packages", {
   expect_equal(Biobase$Repository, biocRepos(".")[[1]])
 })
 
+# https://github.com/rstudio/rsconnect/issues/968
+test_that("large directories are analyzed", {
+  app_dir <- local_temp_app(list("foo.R" = "library(foreign)"))
+  data_dir <- file.path(app_dir, "data")
+  dir.create(data_dir)
+  for (each in seq_len(1001)) {
+    writeLines(character(0), file.path(data_dir, paste0(each, ".txt")))
+  }
+  expect_snapshot(
+    deps <- snapshotRenvDependencies(app_dir)
+  )
+  expect_contains(deps$Package, "foreign")
+})
+
 # parseRenvDependencies ---------------------------------------------------
 
 test_that("gets DESCRIPTION from renv & system libraries", {

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -58,6 +58,8 @@ test_that("works with BioC packages", {
 
 # https://github.com/rstudio/rsconnect/issues/968
 test_that("large directories are analyzed", {
+  skip_on_cran()
+  skip_on_ci()
   app_dir <- local_temp_app(list("foo.R" = "library(foreign)"))
   data_dir <- file.path(app_dir, "data")
   dir.create(data_dir)

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -58,8 +58,6 @@ test_that("works with BioC packages", {
 
 # https://github.com/rstudio/rsconnect/issues/968
 test_that("large directories are analyzed", {
-  skip_on_cran()
-  skip_on_ci()
   app_dir <- local_temp_app(list("foo.R" = "library(foreign)"))
   data_dir <- file.path(app_dir, "data")
   dir.create(data_dir)


### PR DESCRIPTION
additionally, do not let renv infer the root.

fixes #968