### PR TITLE
skip tests that call rmarkdown on CRAN, which requires newer pandoc

### DIFF
--- a/tests/testthat/test-deployApp.R
+++ b/tests/testthat/test-deployApp.R
@@ -6,12 +6,14 @@ test_that("appDir must be an existing directory", {
 })
 
 test_that("single document appDir is deprecated", {
+  skip_on_cran()
   expect_snapshot(error = TRUE, {
     deployApp("foo.Rmd")
   })
 })
 
 test_that("appPrimaryDoc must exist, if supplied", {
+  skip_on_cran()
   dir <- local_temp_app()
 
   expect_snapshot(error = TRUE, {

--- a/tests/testthat/test-deployDoc.R
+++ b/tests/testthat/test-deployDoc.R
@@ -1,10 +1,12 @@
 test_that("deployDoc correctly reports bad path", {
+  skip_on_cran()
   expect_snapshot(deployDoc("doesntexist.Rmd"), error = TRUE)
 })
 
 # standardizeSingleDocDeployment ------------------------------------------
 
 test_that("turns appDir into appDir + appPrimarySourceDoc", {
+  skip_on_cran()
   dir <- local_temp_app(list("foo.R" = ""))
 
   doc <- standardizeSingleDocDeployment(file.path(dir, "foo.R"))
@@ -13,6 +15,7 @@ test_that("turns appDir into appDir + appPrimarySourceDoc", {
 })
 
 test_that("shiny rmd deploys whole directory", {
+  skip_on_cran()
   dir <- local_temp_app(list("foo.Rmd" = c(
     "---",
     "runtime: shiny",
@@ -23,6 +26,7 @@ test_that("shiny rmd deploys whole directory", {
 })
 
 test_that("regular rmd deploys file and dependencies", {
+  skip_on_cran()
   dir <- local_temp_app(list(
     "foo.Rmd" = c(
       "---",
@@ -37,6 +41,7 @@ test_that("regular rmd deploys file and dependencies", {
 })
 
 test_that("regular rmd deploys .Rprofile, if present", {
+  skip_on_cran()
   dir <- local_temp_app(list(
     "foo.Rmd" = "",
     ".Rprofile" = ""
@@ -47,6 +52,7 @@ test_that("regular rmd deploys .Rprofile, if present", {
 })
 
 test_that("regular rmd deploys requirements.txt, if present", {
+  skip_on_cran()
   dir <- local_temp_app(list(
     "foo.Rmd" = "",
     "requirements.txt" = ""
@@ -57,6 +63,7 @@ test_that("regular rmd deploys requirements.txt, if present", {
 })
 
 test_that("regular rmd deploys renv.lock, if present", {
+  skip_on_cran()
   dir <- local_temp_app(list(
     "foo.Rmd" = "",
     "renv.lock" = ""
@@ -67,6 +74,7 @@ test_that("regular rmd deploys renv.lock, if present", {
 })
 
 test_that("regular html does not deploy .Rprofile", {
+  skip_on_cran()
   dir <- local_temp_app(list(
     "foo.html" = "",
     ".Rprofile" = ""
@@ -77,6 +85,7 @@ test_that("regular html does not deploy .Rprofile", {
 })
 
 test_that("regular html does not deploy requirements.txt", {
+  skip_on_cran()
   dir <- local_temp_app(list(
     "foo.html" = "",
     "requirements.txt" = ""
@@ -87,6 +96,7 @@ test_that("regular html does not deploy requirements.txt", {
 })
 
 test_that("regular html does not deploy renv.lock", {
+  skip_on_cran()
   dir <- local_temp_app(list(
     "foo.html" = "",
     "renv.lock" = ""
@@ -97,6 +107,7 @@ test_that("regular html does not deploy renv.lock", {
 })
 
 test_that("other types deploy that one file", {
+  skip_on_cran()
   dir <- local_temp_app(list("foo.R" = ""))
   doc <- standardizeSingleDocDeployment(file.path(dir, "foo.R"))
   expect_equal(doc$appFiles, "foo.R")


### PR DESCRIPTION
The R macOS checks started failing because the available pandoc was older than 1.12.3, which prevented the publication of rsconnect 1.0.2.

```
checking tests ... [46s/50s] ERROR
  Running ‘testthat.R’ [46s/49s]
Running the tests in ‘tests/testthat.R’ failed.
Last 13 lines of output:
   6. └─rmarkdown:::stop2(paste(msg, collapse = " "))
  ── Error ('test-deployDoc.R:65:3'): regular rmd deploys renv.lock, if present ──
  Error: pandoc version 1.12.3 or higher is required and was not found (see the help page ?rmarkdown::pandoc_available).
  Backtrace:
      ▆
   1. └─rsconnect:::standardizeSingleDocDeployment(...) at test-deployDoc.R:65:2
   2. └─rmarkdown::find_external_resources(path)
   3. └─rmarkdown:::discover_rmd_resources(input_file, discover_single_resource)
   4. └─rmarkdown::render(...)
   5. └─rmarkdown::pandoc_available(required_pandoc, error = TRUE)
   6. └─rmarkdown:::stop2(paste(msg, collapse = " "))
  
  [ FAIL 4 | WARN 0 | SKIP 118 | PASS 608 ]
  Error: Test failures
  Execution halted
```

related: rmarkdown test skipping: https://github.com/rstudio/rmarkdown/blob/main/tests/testthat.R