### PR TITLE
Fix checking and logging of `envVars` in `deployApp()`

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -259,6 +259,15 @@ deployApp <- function(appDir = getwd(),
     }
   }
 
+  check_character(envVars, allow_null = TRUE)
+  if (!is.null(envVars) && any(nzchar(names2(envVars)))) {
+    cli::cli_abort(c(
+      "{.arg envVars} must be a character vector containing only environment variable {.strong names}.",
+      "i" = "Set environment variables with `Sys.setenv() or an `.Renviron` file.",
+      "i" = "Use `unname()`` to remove the names from the vector passed to {.arg envVars}."
+    ))
+  }
+
   if (!is.null(appSourceDoc)) {
     # Used by IDE so can't deprecate
     recordDir <- appSourceDoc

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -50,9 +50,10 @@
 #'   on second and subsequent deploys, the title will be unchanged.
 #' @param envVars A character vector giving the names of environment variables
 #'   whose values should be synchronised with the server (currently supported by
-#'   Connect only). The values of the environment variables are sent over an
-#'   encrypted connection and are not stored in the bundle, making this a safe
-#'   way to send private data to Connect.
+#'   Connect only). The values of the environment variables should be set in the
+#'   current session with [Sys.setenv()] or via an `.Renviron` file. Values are
+#'   sent over an encrypted connection and are not stored in the bundle, making
+#'   this a safe way to send private data to Connect.
 #'
 #'   The names (not values) are stored in the deployment record so that future
 #'   deployments will automatically update their values. Other environment

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -360,7 +360,7 @@ deployApp <- function(appDir = getwd(),
     stop("Posit Connect does not support deploying without uploading. ",
          "Specify upload=TRUE to upload and re-deploy your application.")
   }
-  if (!isConnectServer(target$server) && length(envVars) > 1) {
+  if (!isConnectServer(target$server) && length(envVars) > 0) {
     cli::cli_abort("{.arg envVars} only supported for Posit Connect servers")
   }
 

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -360,12 +360,14 @@ deployApp <- function(appDir = getwd(),
     stop("Posit Connect does not support deploying without uploading. ",
          "Specify upload=TRUE to upload and re-deploy your application.")
   }
-  if (!isConnectServer(target$server) && length(envVars) > 0) {
-    cli::cli_abort("{.arg envVars} only supported for Posit Connect servers")
-  }
 
   accountDetails <- accountInfo(target$account, target$server)
   client <- clientForAccount(accountDetails)
+
+  if (length(envVars) > 0 && !"setEnvVars" %in% names(client)) {
+    cli::cli_abort("{target$server} does not support setting {.arg envVars}")
+  }
+
   if (verbose) {
     showCookies(serverInfo(accountDetails$server)$url)
   }

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -264,7 +264,7 @@ deployApp <- function(appDir = getwd(),
     cli::cli_abort(c(
       "{.arg envVars} must be a character vector containing only environment variable {.strong names}.",
       "i" = "Set environment variables with `Sys.setenv() or an `.Renviron` file.",
-      "i" = "Use `unname()`` to remove the names from the vector passed to {.arg envVars}."
+      "i" = "Use {.fn unname} to remove the names from the vector passed to {.arg envVars}."
     ))
   }
 

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -50,10 +50,12 @@
 #'   on second and subsequent deploys, the title will be unchanged.
 #' @param envVars A character vector giving the names of environment variables
 #'   whose values should be synchronised with the server (currently supported by
-#'   Connect only). The values of the environment variables should be set in the
-#'   current session with [Sys.setenv()] or via an `.Renviron` file. Values are
-#'   sent over an encrypted connection and are not stored in the bundle, making
-#'   this a safe way to send private data to Connect.
+#'   Connect only). The values of sensitive environment variables should be set
+#'   in the current session via an `.Renviron` file or with the help of a
+#'   credential store like
+#'   [keyring](https://r-lib.github.io/keyring/index.html). Values are sent over
+#'   an encrypted connection and are not stored in the bundle, making this a
+#'   safe way to send private data to Connect.
 #'
 #'   The names (not values) are stored in the deployment record so that future
 #'   deployments will automatically update their values. Other environment

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -432,7 +432,7 @@ deployApp <- function(appDir = getwd(),
     taskComplete(quiet, "Visibility updated")
   }
   if (length(target$envVars) > 0) {
-    taskStart(quiet, "Updating environment variables {envVars}...")
+    taskStart(quiet, "Updating {length(envVars)} environment variable{?s}: {.field {names(envVars)}}...")
     client$setEnvVars(application$guid, target$envVars)
     taskComplete(quiet, "Environment variables updated")
   }

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -434,7 +434,7 @@ deployApp <- function(appDir = getwd(),
     taskComplete(quiet, "Visibility updated")
   }
   if (length(target$envVars) > 0) {
-    taskStart(quiet, "Updating {length(envVars)} environment variable{?s}: {.field {names(envVars)}}...")
+    taskStart(quiet, "Updating environment variables {envVars}...")
     client$setEnvVars(application$guid, target$envVars)
     taskComplete(quiet, "Environment variables updated")
   }

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -260,7 +260,7 @@ deployApp <- function(appDir = getwd(),
   }
 
   check_character(envVars, allow_null = TRUE)
-  if (!is.null(envVars) && any(nzchar(names2(envVars)))) {
+  if (!is.null(envVars) && !is.null(names(envVars))) {
     cli::cli_abort(c(
       "{.arg envVars} must be a character vector containing only environment variable {.strong names}.",
       "i" = "Set environment variables with `Sys.setenv() or an `.Renviron` file.",

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -69,9 +69,10 @@ on second and subsequent deploys, the title will be unchanged.}
 
 \item{envVars}{A character vector giving the names of environment variables
 whose values should be synchronised with the server (currently supported by
-Connect only). The values of the environment variables are sent over an
-encrypted connection and are not stored in the bundle, making this a safe
-way to send private data to Connect.
+Connect only). The values of the environment variables should be set in the
+current session with \code{\link[=Sys.setenv]{Sys.setenv()}} or via an \code{.Renviron} file. Values are
+sent over an encrypted connection and are not stored in the bundle, making
+this a safe way to send private data to Connect.
 
 The names (not values) are stored in the deployment record so that future
 deployments will automatically update their values. Other environment

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -69,10 +69,12 @@ on second and subsequent deploys, the title will be unchanged.}
 
 \item{envVars}{A character vector giving the names of environment variables
 whose values should be synchronised with the server (currently supported by
-Connect only). The values of the environment variables should be set in the
-current session with \code{\link[=Sys.setenv]{Sys.setenv()}} or via an \code{.Renviron} file. Values are
-sent over an encrypted connection and are not stored in the bundle, making
-this a safe way to send private data to Connect.
+Connect only). The values of sensitive environment variables should be set
+in the current session via an \code{.Renviron} file or with the help of a
+credential store like
+\href{https://r-lib.github.io/keyring/index.html}{keyring}. Values are sent over
+an encrypted connection and are not stored in the bundle, making this a
+safe way to send private data to Connect.
 
 The names (not values) are stored in the deployment record so that future
 deployments will automatically update their values. Other environment

--- a/tests/testthat/_snaps/deployApp.md
+++ b/tests/testthat/_snaps/deployApp.md
@@ -79,3 +79,13 @@
       2: Delete existing deployment & create a new app
       Selection: 2
 
+# deployApp() errors if envVars is given a named vector
+
+    Code
+      deployApp(local_temp_app(), envVars = c(FLAG = "true"))
+    Condition
+      Error in `deployApp()`:
+      ! `envVars` must be a character vector containing only environment variable names.
+      i Set environment variables with `Sys.setenv() or an `.Renviron` file.
+      i Use `unname()`` to remove the names from the vector passed to `envVars`.
+

--- a/tests/testthat/_snaps/deployApp.md
+++ b/tests/testthat/_snaps/deployApp.md
@@ -87,5 +87,5 @@
       Error in `deployApp()`:
       ! `envVars` must be a character vector containing only environment variable names.
       i Set environment variables with `Sys.setenv() or an `.Renviron` file.
-      i Use `unname()`` to remove the names from the vector passed to `envVars`.
+      i Use `unname()` to remove the names from the vector passed to `envVars`.
 

--- a/tests/testthat/test-deployApp.R
+++ b/tests/testthat/test-deployApp.R
@@ -100,3 +100,11 @@ test_that("applicationDeleted() errors or prompts as needed", {
   expect_snapshot(. <- applicationDeleted(client, target, app))
   expect_length(dir(app, recursive = TRUE), 0)
 })
+
+# envvars -----------------------------------------------------------------
+
+test_that("deployApp() errors if envVars is given a named vector", {
+  expect_snapshot(error = TRUE, {
+    deployApp(local_temp_app(), envVars = c("FLAG" = "true"))
+  })
+})


### PR DESCRIPTION
Two small fixes for the checking of `envVars` in `deployApp()`:

1. First, the values of the envvars were being printed in to the logs, where we'd only want the names.

2. The check ensuring that `envVars` is only used for Posit Connect servers would not run if the user was only setting a single variable.
