### PR TITLE
handle unknown and Local package source

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 * Do not use `getOption("available_packages_filters")` option when calling
   `available.packages()`. (#1002)
 
+* Packages installed from source within an renv project are not associated
+  with repositories. (#1004)
+
 # rsconnect 1.1.0
 
 * Fixed analysis of directories that were smaller than the

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -112,10 +112,11 @@ standardizeRenvPackage <- function(pkg,
       # Try packages defined from default bioC repos
       pkg$Repository <- findRepoUrl(pkg$Package, biocPackages)
     }
-  } else if (pkg$Source == "unknown") {
-    pkg$Source <- NA_character_
   } else if (pkg$Source %in% c("Bitbucket", "GitHub", "GitLab")) {
     pkg$Source <- tolower(pkg$Source)
+  } else if (pkg$Source %in% c("Local", "unknown")) {
+    pkg$Source <- NA_character_
+    pkg$Repository <- NA_character_
   }
 
   # Remove Remote fields that pak adds for "standard" installs from CRAN

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -173,10 +173,18 @@ test_that("packages installed from other repos get correctly named", {
   )
 })
 
-test_that("source packages get NA source", {
-  source <- list(Package = "pkg", Source = "unknown")
+test_that("source packages get NA source + repository", {
+  source <- list(Package = "pkg", Source = "unknown", Repository = "useless")
   expect_equal(
     standardizeRenvPackage(source),
-    list(Package = "pkg", Source = NA_character_)
+    list(Package = "pkg", Source = NA_character_, Repository = NA_character_)
+  )
+})
+
+test_that("Local packages get NA source + repository", {
+  source <- list(Package = "pkg", Source = "Local", Repository = "useless")
+  expect_equal(
+    standardizeRenvPackage(source),
+    list(Package = "pkg", Source = NA_character_, Repository = NA_character_)
   )
 })


### PR DESCRIPTION
This shifts from using a local "Source" with whatever "Repository" comes from renv to using NA for both. An error now occurs because the package did not come from a well-known repository.

fixes #1004

```r
# Create a new project and launch a separate RStudio session.
usethis::create_project("~/Desktop/mixed-content")

# In that new project ...
unlink("R", recursive = TRUE)
writeLines(c(
    "library(shiny)",
    "shinyApp('single file Shiny deploy', function(input, output) {})"
), "app.R")

renv::init()
renv::install(c("rsconnect"), prompt = FALSE)
renv::install("~/Downloads/shiny_1.7.5.tar.gz", repos = NULL, type = "source", prompt = FALSE)
renv::snapshot(prompt = FALSE)

rsconnect::writeManifest()
jsonlite::fromJSON("manifest.json")$packages$shiny[c("Source","Repository")]
#> $Source
#> [1] "Local"
#>
#> $Repository
#> [1] "CRAN"

renv::install("rstudio/rsconnect@aron-issue-1004", prompt = FALSE)

# restart R session ...

rsconnect::writeManifest()
#> ℹ Capturing R dependencies from renv.lock
#> ✔ Found 32 dependencies
#> Error in `createAppManifest()` at rstudio-rsconnect-8856765/R/writeManifest.R:61:2:
#> ! All packages must be installed from a reproducible location.
#> ✖ Can't re-install packages installed from source: shiny.
#> ℹ See `rsconnect::appDependencies()` for more details.
#> Run `rlang::last_trace()` to see where the error occurred.
```
