### PR TITLE
tests against "real" projects are skipped on CRAN

### DIFF
--- a/tests/testthat/test-appDependencies.R
+++ b/tests/testthat/test-appDependencies.R
@@ -1,4 +1,6 @@
 test_that("appDependencies includes implicit deps", {
+  skip_on_cran()
+
   withr::local_options(renv.verbose = TRUE)
 
   path <- local_temp_app(list("test.Rmd" = ""))
@@ -8,6 +10,8 @@ test_that("appDependencies includes implicit deps", {
 })
 
 test_that("appDependencies includes implicit deps when appMode forced", {
+  skip_on_cran()
+
   withr::local_options(renv.verbose = TRUE)
 
   dir <- local_temp_app(list(
@@ -53,6 +57,8 @@ test_that("appDependencies includes implicit deps when appMode forced", {
 })
 
 test_that("static project doesn't have deps", {
+  skip_on_cran()
+
   path <- local_temp_app(list("index.html" = ""))
   deps <- appDependencies(path)
 
@@ -66,6 +72,8 @@ test_that("static project doesn't have deps", {
 })
 
 test_that("infers correct packages for each source", {
+  skip_on_cran()
+
   simulateMetadata <- function(appMode,
                                hasParameters = FALSE,
                                documentsHavePython = FALSE) {

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -10,11 +10,12 @@ test_that("simple Shiny app bundle is runnable", {
 })
 
 test_that("app.R Shiny app bundle is runnable", {
+  skip_on_cran()
+  skip_if_not_installed("shiny")
+
   # shiny:::shinyAppDir() attach shiny so do it here so we can do it quietly
   library(shiny, warn.conflicts = FALSE, quietly = TRUE)
 
-  skip_on_cran()
-  skip_if_not_installed("shiny")
   bundleTempDir <- local_shiny_bundle(
     "app_r_shiny",
     test_path("shinyapp-appR"),

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -1,12 +1,14 @@
 # snapshotRenvDependencies() ----------------------------------------------
 
 test_that("non-R apps don't have packages", {
+  skip_on_cran()
   app_dir <- local_temp_app(list(index.html = ""))
   out <- snapshotRenvDependencies(app_dir)
   expect_equal(out, data.frame())
 })
 
 test_that("manifest has correct data types", {
+  skip_on_cran()
   withr::local_options(renv.verbose = TRUE)
   app <- local_temp_app(list("index.Rmd" = ""))
   deps <- snapshotRenvDependencies(app)
@@ -15,6 +17,7 @@ test_that("manifest has correct data types", {
 })
 
 test_that("recommended packages are snapshotted", {
+  skip_on_cran()
   withr::local_options(renv.verbose = TRUE)
   app <- local_temp_app(list("index.Rmd" = c(
     "```{r}",
@@ -23,6 +26,14 @@ test_that("recommended packages are snapshotted", {
   )))
   deps <- snapshotRenvDependencies(app)
   expect_true("MASS" %in% deps$Package)
+})
+
+test_that("extra packages are snapshotted", {
+  skip_on_cran()
+  withr::local_options(renv.verbose = TRUE)
+  app <- local_temp_app(list("index.Rmd" = ""))
+  deps <- snapshotRenvDependencies(app, extraPackages = c("foreign"))
+  expect_true("foreign" %in% deps$Package)
 })
 
 test_that("works with BioC packages", {
@@ -58,6 +69,7 @@ test_that("works with BioC packages", {
 
 # https://github.com/rstudio/rsconnect/issues/968
 test_that("large directories are analyzed", {
+  skip_on_cran()
   app_dir <- local_temp_app(list("foo.R" = "library(foreign)"))
   data_dir <- file.path(app_dir, "data")
   dir.create(data_dir)

--- a/tests/testthat/test-client-cloud.R
+++ b/tests/testthat/test-client-cloud.R
@@ -794,6 +794,8 @@ deployAppMockServerFactory <- function(expectedAppType, outputState) {
 }
 
 test_that("deployApp() for shiny results in correct Cloud API calls", {
+  skip_on_cran()
+
   withr::local_options(renv.verbose = TRUE)
 
   mock <- deployAppMockServerFactory(expectedAppType = "connect", outputState = "active")

--- a/tests/testthat/test-writeManifest.R
+++ b/tests/testthat/test-writeManifest.R
@@ -8,6 +8,8 @@ makeManifest <- function(appDir, appPrimaryDoc = NULL, ...) {
 }
 
 test_that("renv.lock is included for renv projects", {
+  skip_on_cran()
+
   withr::local_options(renv.verbose = FALSE)
 
   app_dir <- local_temp_app(list(app.R = "library(foreign); library(MASS)"))
@@ -20,6 +22,8 @@ test_that("renv.lock is included for renv projects", {
 })
 
 test_that("renv.lock is not included for non-renv projects", {
+  skip_on_cran()
+
   withr::local_options(renv.verbose = FALSE)
 
   app_dir <- local_temp_app(list(app.R = "library(foreign); library(MASS)"))
@@ -88,6 +92,7 @@ test_that("Rmd without a python block doesn't include reticulate or python in th
 # Quarto Tests
 
 test_that("Quarto website includes quarto in the manifest", {
+  skip_on_cran()
   skip_if_no_quarto()
 
   appDir <- test_path("quarto-website-r")
@@ -99,6 +104,7 @@ test_that("Quarto website includes quarto in the manifest", {
 })
 
 test_that("Quarto document includes quarto in the manifest", {
+  skip_on_cran()
   skip_if_no_quarto()
 
   appDir <- test_path("quarto-doc-none")
@@ -111,6 +117,7 @@ test_that("Quarto document includes quarto in the manifest", {
 })
 
 test_that("Specifying quarto arg includes quarto in the manifest, even with no appPrimaryDoc specified (.qmd)", {
+  skip_on_cran()
   skip_if_no_quarto()
 
   appDir <- test_path("quarto-doc-none")
@@ -123,6 +130,7 @@ test_that("Specifying quarto arg includes quarto in the manifest, even with no a
 })
 
 test_that("Specifying quarto arg includes quarto in the manifest, even with no appPrimaryDoc specified (.Rmd)", {
+  skip_on_cran()
   skip_if_no_quarto()
 
   appDir <- test_path("shiny-rmds")
@@ -135,6 +143,7 @@ test_that("Specifying quarto arg includes quarto in the manifest, even with no a
 })
 
 test_that("specifying quarto arg with non-quarto app does not include quarto in the manifest", {
+  skip_on_cran()
   skip_if_no_quarto()
 
   appDir <- test_path("shinyapp-singleR")
@@ -145,6 +154,7 @@ test_that("specifying quarto arg with non-quarto app does not include quarto in 
 })
 
 test_that("Quarto shiny project includes quarto in the manifest", {
+  skip_on_cran()
   skip_if_no_quarto()
 
   appDir <- test_path("quarto-proj-r-shiny")
@@ -156,6 +166,7 @@ test_that("Quarto shiny project includes quarto in the manifest", {
 })
 
 test_that("Quarto R + Python website includes quarto and python in the manifest", {
+  skip_on_cran()
   skip_if_not_installed("reticulate")
   skip_if_no_quarto()
   python <- pythonPathOrSkip()
@@ -172,6 +183,7 @@ test_that("Quarto R + Python website includes quarto and python in the manifest"
 })
 
 test_that("Quarto Python-only website gets correct manifest data", {
+  skip_on_cran()
   skip_if_not_installed("reticulate")
   skip_if_no_quarto()
 
@@ -190,6 +202,7 @@ test_that("Quarto Python-only website gets correct manifest data", {
 })
 
 test_that("Deploying a Quarto project without Quarto is an error", {
+  skip_on_cran()
   local_mocked_bindings(quarto_path = function() NULL)
 
   appDir <- test_path("quarto-website-r")
@@ -197,6 +210,7 @@ test_that("Deploying a Quarto project without Quarto is an error", {
 })
 
 test_that("Deploying R Markdown content with Quarto gives a Quarto app mode", {
+  skip_on_cran()
   skip_if_no_quarto()
 
   manifest <- makeManifest(test_path("test-rmds"), "simple.Rmd", quarto = TRUE)
@@ -207,6 +221,7 @@ test_that("Deploying R Markdown content with Quarto gives a Quarto app mode", {
 })
 
 test_that("Deploying static content with _quarto.yaml succeeds without quartoInfo", {
+  skip_on_cran()
 
   manifest <- makeManifest(test_path("static-with-quarto-yaml"))
 
@@ -214,6 +229,8 @@ test_that("Deploying static content with _quarto.yaml succeeds without quartoInf
 })
 
 test_that("Sets environment.image in the manifest if one is provided", {
+  skip_on_cran()
+
   withr::local_options(renv.verbose = TRUE)
 
   appDir <- test_path("shinyapp-simple")
@@ -226,6 +243,8 @@ test_that("Sets environment.image in the manifest if one is provided", {
 })
 
 test_that("Sets environment.environment_management in the manifest if envManagement is defined", {
+  skip_on_cran()
+
   withr::local_options(renv.verbose = TRUE)
 
   appDir <- test_path("shinyapp-simple")
@@ -251,6 +270,8 @@ test_that("Sets environment.environment_management in the manifest if envManagem
 # appMode Inference tests
 
 test_that("content type (appMode) is inferred and can be overridden", {
+  skip_on_cran()
+
   appDir <- local_temp_app(list(
     "app.R" = "",
     "index.html" = "",


### PR DESCRIPTION
Avoid (revdep) test situations where a test project has a dependency that may be installed from source. We encountered this first with curl, but could occur with any package required by content (e.g. Shiny, Plumber).

The now-skipped tests were identified by installing shiny, plumber, rmarkdown, and https://github.com/jeroen/curl from source and then running tests. Each failing test (caused by renv snapshot failures related to from-source installs) was marked for CRAN skipping.