### PR TITLE
serialize multi-value metadata entries as comma-separated values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@
 * `rpubsUpload()` correctly records the initial RPubs destination, allowing
   republishing. (#976)
 
+* `deployApp()` and friends record multi-value `metadata` entries as
+  comma-separated values. (#1017)
+
 # rsconnect 1.1.1
 
 * Added `space` parameter to deploy directly to a space in Posit Cloud.

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -112,6 +112,9 @@
 #' @param metadata Additional metadata fields to save with the deployment
 #'   record. These fields will be returned on subsequent calls to
 #'   [deployments()].
+#'
+#'   Multi-value fields are recorded as comma-separated values and returned in
+#'   that form. Custom value serialization is the responsibility of the caller.
 #' @param forceUpdate What should happen if there's no deployment record for
 #'   the app, but there's an app with the same name on the server? If `TRUE`,
 #'   will always update the previously-deployed app. If `FALSE`, will ask

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -145,6 +145,9 @@ deploymentRecord <- function(name,
     url = url %||% "",
     version = version
   )
+  # convert any multi-value metadata entries into comma-separated values
+  # this prevents write.dcf from writing multiple records into one file.
+  metadata <- lapply(metadata, function(v) paste0(v, collapse = ", "))
   c(standard, metadata)
 }
 

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -144,7 +144,10 @@ potentially problematic code?}
 
 \item{metadata}{Additional metadata fields to save with the deployment
 record. These fields will be returned on subsequent calls to
-\code{\link[=deployments]{deployments()}}.}
+\code{\link[=deployments]{deployments()}}.
+
+Multi-value fields are recorded as comma-separated values and returned in
+that form. Custom value serialization is the responsibility of the caller.}
 
 \item{forceUpdate}{What should happen if there's no deployment record for
 the app, but there's an app with the same name on the server? If \code{TRUE},

--- a/man/deploySite.Rd
+++ b/man/deploySite.Rd
@@ -61,7 +61,10 @@ potentially problematic code?}
 
 \item{metadata}{Additional metadata fields to save with the deployment
 record. These fields will be returned on subsequent calls to
-\code{\link[=deployments]{deployments()}}.}
+\code{\link[=deployments]{deployments()}}.
+
+Multi-value fields are recorded as comma-separated values and returned in
+that form. Custom value serialization is the responsibility of the caller.}
 
 \item{python}{Full path to a python binary for use by \code{reticulate}.
 Required if \code{reticulate} is a dependency of the app being deployed.

--- a/man/showProperties.Rd
+++ b/man/showProperties.Rd
@@ -24,7 +24,7 @@ there are multiple options, you'll be prompted to pick one.
 Use \code{\link[=accounts]{accounts()}} to see the full list of available options.}
 }
 \description{
-Show propreties of an application deployed to ShinyApps.
+Show properties of an application deployed to ShinyApps.
 }
 \note{
 This function works only for ShinyApps servers.

--- a/tests/testthat/test-deployments.R
+++ b/tests/testthat/test-deployments.R
@@ -69,6 +69,15 @@ test_that("can read/write metadata", {
   expect_equal(out$meta2, "two")
 })
 
+test_that("can read/write metadata having multiple values", {
+  dir <- local_temp_app()
+
+  addTestDeployment(dir, metadata = list(engines = c("knitr","markdown")))
+  out <- deployments(dir, excludeOrphaned = FALSE)
+  expect_equal(nrow(out), 1)
+  expect_equal(out$engines, "knitr, markdown")
+})
+
 test_that("can read/write version", {
   dir <- local_temp_app()
 

--- a/tests/testthat/test-deployments.R
+++ b/tests/testthat/test-deployments.R
@@ -72,7 +72,7 @@ test_that("can read/write metadata", {
 test_that("can read/write metadata having multiple values", {
   dir <- local_temp_app()
 
-  addTestDeployment(dir, metadata = list(engines = c("knitr","markdown")))
+  addTestDeployment(dir, metadata = list(engines = c("knitr", "markdown")))
   out <- deployments(dir, excludeOrphaned = FALSE)
   expect_equal(nrow(out), 1)
   expect_equal(out$engines, "knitr, markdown")


### PR DESCRIPTION
fixes #1017

``` r
record <- rsconnect:::deploymentRecord(
    name = "the-name",
    title = "the-title",
    username = "the-username",
    account = "the-account",
    server = "the-server",
    metadata = list(quarto_engines = c("knitr","markdown"))
)
t <- tempfile()
rsconnect:::writeDeploymentRecord(record, t)
read.dcf(t)
#>      name       title       username       account       server       hostUrl
#> [1,] "the-name" "the-title" "the-username" "the-account" "the-server" ""     
#>      appId bundleId url version quarto_engines   
#> [1,] ""    ""       ""  "1"     "knitr, markdown"
```

This change does not adjust deployment records reads.