### PR TITLE
republishing and collaborating

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,7 @@
 linters: linters_with_defaults(
     line_length_linter(160),
     indentation_linter = NULL,
+    object_length_linter(60),
     object_name_linter = NULL,
     object_usage_linter = NULL,
     brace_linter = NULL,

--- a/R/account-find.R
+++ b/R/account-find.R
@@ -1,3 +1,6 @@
+# Return a list containing the name and server associated with a matching account.
+#
+# Use `accountInfo()` and `findAccountInfo()` to load credentials associated with this account.
 findAccount <- function(accountName = NULL, server = NULL, error_call = caller_env()) {
   check_string(accountName, allow_null = TRUE, arg = "account", call = error_call)
   check_string(server, allow_null = TRUE, call = error_call)

--- a/R/accounts.R
+++ b/R/accounts.R
@@ -283,7 +283,13 @@ findShinyAppsAccountId <- function(name,
 #' @family Account functions
 #' @export
 accountInfo <- function(name = NULL, server = NULL) {
-  fullAccount <- findAccount(name, server)
+  findAccountInfo(name, server)
+}
+
+# Discovers then loads details about an account from disk.
+# Internal equivalent to accountInfo that lets callers provide error context.
+findAccountInfo <- function(name = NULL, server = NULL, error_call = caller_env()) {
+  fullAccount <- findAccount(name, server, error_call = error_call)
   configFile <- accountConfigFile(fullAccount$name, fullAccount$server)
 
   accountDcf <- read.dcf(configFile, all = TRUE)

--- a/R/accounts.R
+++ b/R/accounts.R
@@ -352,5 +352,7 @@ registerAccount <- function(serverName,
 }
 
 accountLabel <- function(account, server) {
+  # Note: The incoming "account" may correspond to our local account name, which does not always
+  # match the remote username.
   paste0("server: ", server, " / username: ", account)
 }

--- a/R/applications.R
+++ b/R/applications.R
@@ -128,9 +128,7 @@ getAppByName <- function(client, accountInfo, name) {
   if (length(app)) {
     return(app[[1]])
   }
-
-  stop("No application found. Specify the application's directory, name, ",
-       "and/or associated account.", call. = FALSE)
+  return(NULL)
 }
 
 # Use the API to list all applications then filter the results client-side.
@@ -240,6 +238,10 @@ showLogs <- function(appPath = getwd(), appFile = NULL, appName = NULL,
   accountDetails <- accountInfo(deployment$account, deployment$server)
   client <- clientForAccount(accountDetails)
   application <- getAppByName(client, accountDetails, deployment$name)
+  if (is.null(application)) {
+    stop("No application found. Specify the application's directory, name, ",
+         "and/or associated account.", call. = FALSE)
+  }
 
   if (streaming) {
     # streaming; poll for the entries directly

--- a/R/applications.R
+++ b/R/applications.R
@@ -121,14 +121,21 @@ applications <- function(account = NULL, server = NULL) {
   return(res)
 }
 
-# Use the API to filter applications by name.
+# Use the API to filter applications by name and error when it does not exist.
 getAppByName <- function(client, accountInfo, name) {
   # NOTE: returns a list with 0 or 1 elements
   app <- client$listApplications(accountInfo$accountId, filters = list(name = name))
   if (length(app)) {
     return(app[[1]])
   }
-  return(NULL)
+  cli::cli_abort(
+    c(
+      "No application found",
+      i = "Specify the application directory, name, and/or associated account."
+    ),
+    call = NULL,
+    class = "rsconnect_app_not_found"
+  )
 }
 
 # Use the API to list all applications then filter the results client-side.
@@ -238,10 +245,6 @@ showLogs <- function(appPath = getwd(), appFile = NULL, appName = NULL,
   accountDetails <- accountInfo(deployment$account, deployment$server)
   client <- clientForAccount(accountDetails)
   application <- getAppByName(client, accountDetails, deployment$name)
-  if (is.null(application)) {
-    stop("No application found. Specify the application's directory, name, ",
-         "and/or associated account.", call. = FALSE)
-  }
 
   if (streaming) {
     # streaming; poll for the entries directly

--- a/R/applications.R
+++ b/R/applications.R
@@ -122,7 +122,7 @@ applications <- function(account = NULL, server = NULL) {
 }
 
 # Use the API to filter applications by name and error when it does not exist.
-getAppByName <- function(client, accountInfo, name) {
+getAppByName <- function(client, accountInfo, name, error_call = caller_env()) {
   # NOTE: returns a list with 0 or 1 elements
   app <- client$listApplications(accountInfo$accountId, filters = list(name = name))
   if (length(app)) {
@@ -133,7 +133,7 @@ getAppByName <- function(client, accountInfo, name) {
       "No application found",
       i = "Specify the application directory, name, and/or associated account."
     ),
-    call = NULL,
+    call = error_call,
     class = "rsconnect_app_not_found"
   )
 }

--- a/R/configureApp.R
+++ b/R/configureApp.R
@@ -111,10 +111,6 @@ setProperty <- function(propertyName, propertyValue, appPath = getwd(),
 
   client <- clientForAccount(accountDetails)
   application <- getAppByName(client, accountDetails, deployment$name)
-  if (is.null(application)) {
-    stop("No application found. Specify the application's directory, name, ",
-         "and/or associated account.", call. = FALSE)
-  }
 
   invisible(client$setApplicationProperty(application$id,
                                          propertyName,
@@ -154,10 +150,6 @@ unsetProperty <- function(propertyName, appPath = getwd(), appName = NULL,
 
   client <- clientForAccount(accountDetails)
   application <- getAppByName(client, accountInfo, deployment$name)
-  if (is.null(application)) {
-    stop("No application found. Specify the application's directory, name, ",
-         "and/or associated account.", call. = FALSE)
-  }
 
   invisible(client$unsetApplicationProperty(application$id,
                                            propertyName,
@@ -190,10 +182,6 @@ showProperties <- function(appPath = getwd(), appName = NULL, account = NULL, se
 
   client <- clientForAccount(accountDetails)
   application <- getAppByName(client, accountDetails, deployment$name)
-  if (is.null(application)) {
-    stop("No application found. Specify the application's directory, name, ",
-         "and/or associated account.", call. = FALSE)
-  }
 
   # convert to data frame
   res <- do.call(rbind, application$deployment$properties)

--- a/R/configureApp.R
+++ b/R/configureApp.R
@@ -111,6 +111,10 @@ setProperty <- function(propertyName, propertyValue, appPath = getwd(),
 
   client <- clientForAccount(accountDetails)
   application <- getAppByName(client, accountDetails, deployment$name)
+  if (is.null(application)) {
+    stop("No application found. Specify the application's directory, name, ",
+         "and/or associated account.", call. = FALSE)
+  }
 
   invisible(client$setApplicationProperty(application$id,
                                          propertyName,
@@ -150,6 +154,10 @@ unsetProperty <- function(propertyName, appPath = getwd(), appName = NULL,
 
   client <- clientForAccount(accountDetails)
   application <- getAppByName(client, accountInfo, deployment$name)
+  if (is.null(application)) {
+    stop("No application found. Specify the application's directory, name, ",
+         "and/or associated account.", call. = FALSE)
+  }
 
   invisible(client$unsetApplicationProperty(application$id,
                                            propertyName,
@@ -182,6 +190,10 @@ showProperties <- function(appPath = getwd(), appName = NULL, account = NULL, se
 
   client <- clientForAccount(accountDetails)
   application <- getAppByName(client, accountDetails, deployment$name)
+  if (is.null(application)) {
+    stop("No application found. Specify the application's directory, name, ",
+         "and/or associated account.", call. = FALSE)
+  }
 
   # convert to data frame
   res <- do.call(rbind, application$deployment$properties)

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -325,34 +325,20 @@ deployApp <- function(appDir = getwd(),
     cli::cli_rule("Preparing for deployment")
   }
 
+  forceUpdate <- forceUpdate %||% getOption("rsconnect.force.update.apps") %||% fromIDE()
+
   # determine the deployment target and target account info
   recordPath <- findRecordPath(appDir, recordDir, appPrimaryDoc)
-  if (!is.null(appId) && is.null(appName)) {
-    # User has supplied only appId, so retrieve app data from server
-    # IDE supplies both appId and appName so should never hit this branch
-    target <- deploymentTargetForApp(
-      appId = appId,
-      appTitle = appTitle,
-      account = account,
-      server = server
-    )
-  } else {
-    forceUpdate <- forceUpdate %||% getOption("rsconnect.force.update.apps") %||%
-      fromIDE()
-
-    # Use name/account/server to look up existing deployment;
-    # create new deployment if no match found
-    target <- deploymentTarget(
-      recordPath = recordPath,
-      appId = appId,
-      appName = appName,
-      appTitle = appTitle,
-      envVars = envVars,
-      account = account,
-      server = server,
-      forceUpdate = forceUpdate
-    )
-  }
+  target <- deploymentTarget(
+    recordPath = recordPath,
+    appId = appId,
+    appName = appName,
+    appTitle = appTitle,
+    envVars = envVars,
+    account = account,
+    server = server,
+    forceUpdate = forceUpdate
+  )
   if (is.null(target$appId)) {
     dest <- accountLabel(target$username, target$server)
     taskComplete(quiet, "Deploying {.val {target$appName}} to {.val {dest}}")

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -414,7 +414,7 @@ deployApp <- function(appDir = getwd(),
   }
   saveDeployment(
     recordPath,
-    previous = deployment,
+    deployment = deployment,
     application = application,
     metadata = metadata
   )
@@ -467,7 +467,7 @@ deployApp <- function(appDir = getwd(),
 
     saveDeployment(
       recordPath,
-      previous = deployment,
+      deployment = deployment,
       application = application,
       bundleId = bundle$id,
       metadata = metadata

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -271,15 +271,6 @@ deployApp <- function(appDir = getwd(),
     recordDir <- appSourceDoc
   }
 
-  cat(paste("deployApp entry:",
-            "appDir:", appDir,
-            "appId:", appId,
-            "appName:", appName,
-            "appTitle:", appTitle,
-            "account:", account,
-            "server:", server,
-            "\n"))
-
   # set up logging helpers
   logLevel <- match.arg(logLevel)
   quiet <- identical(logLevel, "quiet")

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -277,9 +277,9 @@ deployApp <- function(appDir = getwd(),
             "appName:", appName,
             "appTitle:", appTitle,
             "account:", account,
-            "server:",server,
+            "server:", server,
             "\n"))
- 
+
   # set up logging helpers
   logLevel <- match.arg(logLevel)
   quiet <- identical(logLevel, "quiet")

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -329,7 +329,7 @@ deployApp <- function(appDir = getwd(),
 
   # determine the target deployment record and deploying account
   recordPath <- findRecordPath(appDir, recordDir, appPrimaryDoc)
-  target <- deploymentTarget(
+  target <- findDeploymentTarget(
     recordPath = recordPath,
     appId = appId,
     appName = appName,

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -344,10 +344,10 @@ deployApp <- function(appDir = getwd(),
 
   if (is.null(deployment$appId)) {
     dest <- accountLabel(accountDetails$name, accountDetails$server)
-    taskComplete(quiet, "Deploying {.val {deployment$appName}} using {.val {dest}}")
+    taskComplete(quiet, "Deploying {.val {deployment$name}} using {.val {dest}}")
   } else {
     dest <- accountLabel(accountDetails$name, accountDetails$server)
-    taskComplete(quiet, "Re-deploying {.val {deployment$appName}} using {.val {dest}}")
+    taskComplete(quiet, "Re-deploying {.val {deployment$name}} using {.val {dest}}")
   }
 
   # Run checks prior to first saveDeployment() to avoid errors that will always
@@ -383,8 +383,8 @@ deployApp <- function(appDir = getwd(),
   if (is.null(deployment$appId)) {
     taskStart(quiet, "Creating application on server...")
     application <- client$createApplication(
-      deployment$appName,
-      deployment$appTitle,
+      deployment$name,
+      deployment$title,
       "shiny",
       accountDetails$accountId,
       appMetadata$appMode,
@@ -441,7 +441,7 @@ deployApp <- function(appDir = getwd(),
 
     taskStart(quiet, "Bundling {length(appFiles)} file{?s}: {.file {appFiles}}")
     bundlePath <- bundleApp(
-      appName = deployment$appName,
+      appName = deployment$name,
       appDir = appDir,
       appFiles = appFiles,
       appMetadata = appMetadata,
@@ -589,7 +589,7 @@ applicationDeleted <- function(client, deployment, recordPath, appMetadata) {
 
   path <- deploymentConfigFile(
     recordPath,
-    deployment$appName,
+    deployment$name,
     deployment$account,
     deployment$server
   )
@@ -597,8 +597,8 @@ applicationDeleted <- function(client, deployment, recordPath, appMetadata) {
 
   accountDetails <- accountInfo(deployment$account, deployment$server)
   client$createApplication(
-    deployment$appName,
-    deployment$appTitle,
+    deployment$name,
+    deployment$title,
     "shiny",
     accountDetails$accountId,
     appMetadata$appMode

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -414,7 +414,7 @@ deployApp <- function(appDir = getwd(),
   }
   saveDeployment(
     recordPath,
-    target = deployment,
+    previous = deployment,
     application = application,
     metadata = metadata
   )
@@ -467,7 +467,7 @@ deployApp <- function(appDir = getwd(),
 
     saveDeployment(
       recordPath,
-      target = deployment,
+      previous = deployment,
       application = application,
       bundleId = bundle$id,
       metadata = metadata

--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -10,6 +10,19 @@ deploymentTarget <- function(recordPath = ".",
                              forceUpdate = FALSE,
                              error_call = caller_env()) {
 
+  if (!is.null(appId) && is.null(appName)) {
+    # User has supplied only appId, so retrieve app data from server
+    # IDE supplies both appId and appName so should never hit this branch
+    return(deploymentTargetForApp(
+      appId = appId,
+      appTitle = appTitle,
+      account = account,
+      server = server
+    ))
+  }
+
+  # Use name/account/server to look up existing deployment;
+  # create new deployment if no match found
   appDeployments <- deployments(
     appPath = recordPath,
     nameFilter = appName,

--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -1,28 +1,168 @@
 # calculate the deployment target based on the passed parameters and
 # any saved deployments that we have
-deploymentTarget <- function(recordPath = ".",
-                             appId = NULL,
-                             appName = NULL,
-                             appTitle = NULL,
-                             envVars = NULL,
-                             account = NULL,
-                             server = NULL,
-                             forceUpdate = FALSE,
-                             error_call = caller_env()) {
+deploymentTarget <- function(
+  recordPath = ".",
+  appId = NULL,
+  appName = NULL,
+  appTitle = NULL,
+  envVars = NULL,
+  account = NULL,
+  server = NULL,
+  forceUpdate = FALSE,
+  error_call = caller_env()
+) {
 
-  if (!is.null(appId) && is.null(appName)) {
-    # User has supplied only appId, so retrieve app data from server
-    # IDE supplies both appId and appName so should never hit this branch
-    return(deploymentTargetForApp(
+  if (!is.null(appId)) {
+    return(deploymentTargetFromAppId(
+      recordPath = recordPath,
       appId = appId,
+      appName = appName,
       appTitle = appTitle,
+      envVars = envVars,
       account = account,
-      server = server
+      server = server,
+      error_call = error_call
     ))
   }
 
-  # Use name/account/server to look up existing deployment;
-  # create new deployment if no match found
+  if (!is.null(appName)) {
+    return(deploymentTargetFromAppName(
+      recordPath = recordPath,
+      appName = appName,
+      appTitle = appTitle,
+      envVars = envVars,
+      account = account,
+      server = server,
+      forceUpdate = forceUpdate,
+      error_call = error_call
+    ))
+  }
+
+  # No identifying appId or appName.
+
+  # When there are existing deployments, ask the user to select one and use
+  # it. Only deployments associated with locally configured account+server
+  # combinations are considered.
+  allDeployments <- deployments(
+    appPath = recordPath,
+    accountFilter = account,
+    serverFilter = server
+  )
+  if (nrow(allDeployments) > 0) {
+    deployment <- disambiguateDeployments(allDeployments, error_call = error_call)
+    deployment <- updateDeploymentTarget(deployment, appTitle, envVars)
+    accountDetails <- accountInfo(deployment$account, deployment$server)
+    return(list(
+      accountDetails = accountDetails,
+      deployment = deployment
+    ))
+  }
+
+  # Otherwise, identify a target account (given just one available or prompted
+  # by the user), generate a name, and locate the deployment.
+  accountDetails <- accountInfo(account, server)
+  appName <- generateAppName(appTitle, recordPath, accountDetails$name, unique = FALSE)
+  return(deploymentTargetFromAppName(
+    recordPath = recordPath,
+    appName = appName,
+    appTitle = appTitle,
+    envVars = envVars,
+    account = accountDetails$name,
+    server = accountDetails$server,
+    forceUpdate = forceUpdate,
+    error_call = error_call
+  ))
+}
+
+# Discover the deployment target given appId.
+#
+# When appId is provided, all other information is secondary. An appId is an indication from the
+# caller that the content has already been deployed elsewhere. If we cannot locate that content,
+# deployment fails.
+#
+# The target content may have been created by some other user; the account for this session may
+# differ from the account used when creating the content.
+deploymentTargetFromAppId <- function(
+  recordPath = ".",
+  appId = NULL,
+  appName = NULL,
+  appTitle = NULL,
+  envVars = NULL,
+  account = NULL,
+  server = NULL,
+  error_call = caller_env()
+) {
+
+  # We must have a target account+server in order to use the appId.
+  # The selected account may not be the original creator of the content.
+  accountDetails <- accountInfo(account, server)
+
+  # Filtering is only by server and includes all deployments in case we have a deployment record
+  # from a collaborator.
+  appDeployments <- deployments(
+    appPath = recordPath,
+    serverFilter = server,
+    excludeOrphaned = FALSE
+  )
+  appDeployments <- appDeployments[appDeployments$appId == appId, ]
+  if (nrow(appDeployments) > 1) {
+    cli::cli_abort(
+      c(
+        "Supplied {.arg appId} ({appId}) identifies multiple deployments.",
+        i = "Manage obsolete deployments with rsconnect::forgetDeployment()."
+      ),
+      call = error_call
+    )
+  }
+
+  # Existing local deployment record.
+  if (nrow(appDeployments) == 1) {
+    deployment <- appDeployments[1, ]
+    deployment <- updateDeploymentTarget(deployment, appTitle, envVars)
+    return(list(
+      accountDetails = accountDetails,
+      deployment = deployment
+    ))
+  }
+
+  # No local deployment record. Get it from the server.
+  application <- getApplication(accountDetails$name, accountDetails$server, appId)
+
+  # Note: The account+server of this deployment record may
+  # not correspond to the original content creator.
+  deployment <- createDeploymentTarget(
+    appName = application$name,
+    appTitle = application$title %||% appTitle,
+    appId = application$id,
+    envVars = envVars,
+    username = application$owner_username %||% accountDetails$name,
+    account = accountDetails$name,
+    server = accountDetails$server
+  )
+
+  return(list(
+    accountDetails = accountDetails,
+    deployment = deployment
+  ))
+}
+
+# Discover the deployment target given appName.
+#
+# When appName is provided it identifies content previously created by a locally configured account.
+#
+# The account details from the deployment record identify the final credentials we will use, as
+# account+server may not have been specified by the caller.
+deploymentTargetFromAppName <- function(
+  recordPath = ".",
+  appName = NULL,
+  appTitle = NULL,
+  envVars = NULL,
+  account = NULL,
+  server = NULL,
+  forceUpdate = FALSE,
+  error_call = caller_env()
+) {
+
   appDeployments <- deployments(
     appPath = recordPath,
     nameFilter = appName,
@@ -30,77 +170,72 @@ deploymentTarget <- function(recordPath = ".",
     serverFilter = server
   )
 
-  if (nrow(appDeployments) == 0) {
-    fullAccount <- findAccount(account, server)
-    if (is.null(appName)) {
-      appName <- defaultAppName(recordPath, fullAccount$server)
-    } else {
-      check_string(appName, call = error_call)
-    }
+  # When the appName along with the (optional) account+server identifies exactly one previous
+  # deployment, use it.
+  if (nrow(appDeployments) == 1) {
+    deployment <- appDeployments[1, ]
+    deployment <- updateDeploymentTarget(deployment, appTitle, envVars)
+    accountDetails <- accountInfo(deployment$account, deployment$server)
+    return(list(
+      accountDetails = accountDetails,
+      deployment = deployment
+    ))
+  }
 
-    appId <- NULL
-    if (!isPositCloudServer(fullAccount$server)) {
-      # Have we previously deployed elsewhere? We can't do this on cloud
-      # because it assigns random app names (see #808 for details).
-      existing <- applications(fullAccount$name, fullAccount$server)
-      if (appName %in% existing$name) {
-        thisApp <- existing[appName == existing$name, , drop = FALSE]
-        uniqueName <- findUnique(appName, existing$name)
+  # When the appName identifies multiple targets, we may not have had an account+server constraint.
+  # Ask the user to choose.
+  if (nrow(appDeployments) > 1) {
+    deployment <- disambiguateDeployments(appDeployments, error_call = error_call)
+    deployment <- updateDeploymentTarget(deployment, appTitle, envVars)
+    accountDetails <- accountInfo(deployment$account, deployment$server)
+    return(list(
+      accountDetails = accountDetails,
+      deployment = deployment
+    ))
+  }
 
-        if (shouldUpdateApp(thisApp, uniqueName, forceUpdate)) {
-          appId <- thisApp$id
-          appName <- thisApp$name
-        } else {
-          appName <- uniqueName
-        }
+  # When the appName does not identify a target, see if it exists on the server. That content is
+  # conditionally used. A resolved account is required.
+  accountDetails <- accountInfo(account, server)
+  if (!isPositCloudServer(accountDetails$server)) {
+    client <- clientForAccount(accountDetails)
+    application <- getAppByName(client, accountDetails, appName)
+    if (!is.null(application)) {
+      uniqueName <- findUnique(appName, application$name)
+      if (shouldUpdateApp(application, uniqueName, forceUpdate)) {
+        deployment <- createDeploymentTarget(
+          appName = application$name,
+          appTitle = application$title %||% appTitle,
+          appId = application$id,
+          envVars = envVars,
+          username = application$owner_username %||% accountDetails$name,
+          account = accountDetails$name,
+          server = accountDetails$server
+        )
+        return(list(
+          accountDetails = accountDetails,
+          deployment = deployment
+        ))
+      } else {
+        appName <- uniqueName
       }
     }
-
-    createDeploymentTarget(
-      appName = appName,
-      appTitle = appTitle,
-      appId = appId,
-      envVars = envVars,
-      username = fullAccount$name, # first deploy must be to own account
-      account = fullAccount$name,
-      server = fullAccount$server
-    )
-  } else if (nrow(appDeployments) == 1) {
-    # If both appName and appId supplied, check that they're consistent.
-    if (!is.null(appId) && appDeployments$appId != appId) {
-      cli::cli_abort(
-        c(
-          "Supplied {.arg appId} ({appId}) does not match deployment record ({appDeployments$appId}).",
-          i = "Omit {.arg appId} to use existing for deployment for app {.str {appName}}, or",
-          i = "Omit {.arg appName} to create new deployment record."
-        ),
-        call = error_call
-      )
-    }
-
-    updateDeploymentTarget(appDeployments, appTitle, envVars)
-  } else {
-    deployment <- disambiguateDeployments(appDeployments, error_call = error_call)
-    updateDeploymentTarget(deployment, appTitle, envVars)
   }
-}
 
-deploymentTargetForApp <- function(appId,
-                                   appTitle = NULL,
-                                   account = NULL,
-                                   server = NULL) {
-  accountDetails <- findAccount(account, server)
-  application <- getApplication(accountDetails$name, accountDetails$server, appId)
-
-  createDeploymentTarget(
-    appName = application$name,
-    appTitle = application$title %||% appTitle,
-    appId = application$id,
-    envVars = NULL,
-    username = application$owner_username %||% accountDetails$name,
+  # No existing target, or the caller does not want to re-use that content.
+  deployment <- createDeploymentTarget(
+    appName = appName,
+    appTitle = appTitle,
+    appId = NULL,
+    envVars = envVars,
+    username = accountDetails$name,
     account = accountDetails$name,
     server = accountDetails$server
   )
+  return(list(
+    accountDetails = accountDetails,
+    deployment = deployment
+  ))
 }
 
 createDeploymentTarget <- function(appName,

--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -158,16 +158,8 @@ findDeploymentTargetByAppId <- function(
 
   # Note: The account+server of this deployment record may
   # not correspond to the original content creator.
-  deployment <- createDeployment(
-    appName = application$name,
-    appTitle = application$title %||% appTitle,
-    appId = application$id,
-    envVars = envVars,
-    username = application$owner_username %||% accountDetails$name,
-    account = accountDetails$name,
-    server = accountDetails$server
-  )
-
+  deployment <- createDeploymentFromApplication(application, accountDetails)
+  deployment <- updateDeployment(deployment, appTitle, envVars)
   return(list(
     accountDetails = accountDetails,
     deployment = deployment
@@ -234,15 +226,8 @@ findDeploymentTargetByAppName <- function(
     if (!is.null(application)) {
       uniqueName <- findUnique(appName, application$name)
       if (shouldUpdateApp(application, uniqueName, forceUpdate)) {
-        deployment <- createDeployment(
-          appName = application$name,
-          appTitle = application$title %||% appTitle,
-          appId = application$id,
-          envVars = envVars,
-          username = application$owner_username %||% accountDetails$name,
-          account = accountDetails$name,
-          server = accountDetails$server
-        )
+        deployment <- createDeploymentFromApplication(application, accountDetails)
+        deployment <- updateDeployment(deployment, appTitle, envVars)
         return(list(
           accountDetails = accountDetails,
           deployment = deployment
@@ -277,15 +262,34 @@ createDeployment <- function(appName,
                              account,
                              server,
                              version = deploymentRecordVersion) {
+  # Consider merging this object with the object returned by
+  # deploymentRecord().
+  #
+  # Field names are shared with deploymentRecord() objects to avoid lots of
+  # record rewriting. Objects returned by findDeploymentTargetByAppName may
+  # have fields from the on-disk records, which were created by
+  # deploymentRecord().
   list(
-    appName = appName,
-    appTitle = appTitle %||% "",
+    name = appName,
+    title = appTitle %||% "",
     envVars = envVars,
     appId = appId,
     username = username,
     account = account,
     server = server,
     version = version
+  )
+}
+
+createDeploymentFromApplication <- function(application, accountDetails) {
+  createDeployment(
+    appName = application$name,
+    appTitle = application$title,
+    appId = application$id,
+    envVars = NULL,
+    username = application$owner_username %||% accountDetails$name,
+    account = accountDetails$name,
+    server = accountDetails$server
   )
 }
 

--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -199,7 +199,10 @@ deploymentTargetFromAppName <- function(
   accountDetails <- accountInfo(account, server)
   if (!isPositCloudServer(accountDetails$server)) {
     client <- clientForAccount(accountDetails)
-    application <- getAppByName(client, accountDetails, appName)
+    application <- tryCatch(
+      getAppByName(client, accountDetails, appName),
+      rsconnect_app_not_found = function(err) NULL
+    )
     if (!is.null(application)) {
       uniqueName <- findUnique(appName, application$name)
       if (shouldUpdateApp(application, uniqueName, forceUpdate)) {

--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -5,14 +5,25 @@
 #
 # When appId is provided, it must identify an existing application. The
 # application may have been created by some other user. That application may
-# or may not have an existing deployment record on disk. It is an error when
-# appId does not identify an application.
+# or may not have an existing deployment record on disk.
+#
+# When using appId, a search across all deployment records occurs, even when
+# there is no local account+server referenced by the deployment record. This
+# lets us identify on-disk deployment records created by some collaborator.
+#
+# It is an error when appId does not identify an existing application.
 #
 # When appName is provided, it may identify an existing application owned by
 # the calling user (e.g. associated with a locally known account).
 #
-# Without appId or appName to identify an existing deployment, local
-# deployment records are considered before falling back to a generated name.
+# When using appName, the search across deployment records is restricted to
+# the incoming account+server. When there is no incoming account+server, the
+# search is restricted to deployments which have a corresponding local
+# account.
+#
+# Without appId or appName to identify an existing deployment, deployment
+# records associated with local accounts (possibly restricted by incoming
+# account+server) are considered before falling back to a generated name.
 #
 # When the targeted name does not exist, a deployment record with NULL appId
 # is returned, which signals to the caller that an application should be
@@ -93,12 +104,12 @@ findDeploymentTarget <- function(
 
 # Discover the deployment target given appId.
 #
-# When appId is provided, all other information is secondary. An appId is an indication from the
-# caller that the content has already been deployed elsewhere. If we cannot locate that content,
-# deployment fails.
+# When appId is provided, all other information is secondary. An appId is an
+# indication from the caller that the content has already been deployed
+# elsewhere. If we cannot locate that content, deployment fails.
 #
-# The target content may have been created by some other user; the account for this session may
-# differ from the account used when creating the content.
+# The target content may have been created by some other user; the account for
+# this session may differ from the account used when creating the content.
 findDeploymentTargetByAppId <- function(
   recordPath = ".",
   appId = NULL,

--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -79,7 +79,7 @@ findDeploymentTarget <- function(
   if (nrow(allDeployments) > 0) {
     deployment <- disambiguateDeployments(allDeployments, error_call = error_call)
     deployment <- updateDeployment(deployment, appTitle, envVars)
-    accountDetails <- accountInfo(deployment$account, deployment$server)
+    accountDetails <- findAccountInfo(deployment$account, deployment$server, error_call = error_call)
     return(list(
       accountDetails = accountDetails,
       deployment = deployment
@@ -88,7 +88,7 @@ findDeploymentTarget <- function(
 
   # Otherwise, identify a target account (given just one available or prompted
   # by the user), generate a name, and locate the deployment.
-  accountDetails <- accountInfo(account, server)
+  accountDetails <- findAccountInfo(account, server, error_call = error_call)
   appName <- generateAppName(appTitle, recordPath, accountDetails$name, unique = FALSE)
   return(findDeploymentTargetByAppName(
     recordPath = recordPath,
@@ -123,7 +123,7 @@ findDeploymentTargetByAppId <- function(
 
   # We must have a target account+server in order to use the appId.
   # The selected account may not be the original creator of the content.
-  accountDetails <- accountInfo(account, server)
+  accountDetails <- findAccountInfo(account, server, error_call = error_call)
 
   # Filtering is only by server and includes all deployments in case we have a deployment record
   # from a collaborator.
@@ -195,7 +195,7 @@ findDeploymentTargetByAppName <- function(
   if (nrow(appDeployments) == 1) {
     deployment <- appDeployments[1, ]
     deployment <- updateDeployment(deployment, appTitle, envVars)
-    accountDetails <- accountInfo(deployment$account, deployment$server)
+    accountDetails <- findAccountInfo(deployment$account, deployment$server, error_call = error_call)
     return(list(
       accountDetails = accountDetails,
       deployment = deployment
@@ -207,7 +207,7 @@ findDeploymentTargetByAppName <- function(
   if (nrow(appDeployments) > 1) {
     deployment <- disambiguateDeployments(appDeployments, error_call = error_call)
     deployment <- updateDeployment(deployment, appTitle, envVars)
-    accountDetails <- accountInfo(deployment$account, deployment$server)
+    accountDetails <- findAccountInfo(deployment$account, deployment$server, error_call = error_call)
     return(list(
       accountDetails = accountDetails,
       deployment = deployment
@@ -216,7 +216,7 @@ findDeploymentTargetByAppName <- function(
 
   # When the appName does not identify a target, see if it exists on the server. That content is
   # conditionally used. A resolved account is required.
-  accountDetails <- accountInfo(account, server)
+  accountDetails <- findAccountInfo(account, server, error_call = error_call)
   if (!isPositCloudServer(accountDetails$server)) {
     client <- clientForAccount(accountDetails)
     application <- tryCatch(

--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -220,7 +220,7 @@ findDeploymentTargetByAppName <- function(
   if (!isPositCloudServer(accountDetails$server)) {
     client <- clientForAccount(accountDetails)
     application <- tryCatch(
-      getAppByName(client, accountDetails, appName),
+      getAppByName(client, accountDetails, appName, error_call = error_call),
       rsconnect_app_not_found = function(err) NULL
     )
     if (!is.null(application)) {

--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -225,7 +225,7 @@ findDeploymentTargetByAppName <- function(
     )
     if (!is.null(application)) {
       uniqueName <- findUnique(appName, application$name)
-      if (shouldUpdateApp(application, uniqueName, forceUpdate)) {
+      if (shouldUpdateApp(application, uniqueName, forceUpdate, error_call = error_call)) {
         deployment <- createDeploymentFromApplication(application, accountDetails)
         deployment <- updateDeployment(deployment, appTitle, envVars)
         return(list(
@@ -333,7 +333,10 @@ defaultAppName <- function(recordPath, server = NULL) {
   name
 }
 
-shouldUpdateApp <- function(application, uniqueName, forceUpdate = FALSE) {
+shouldUpdateApp <- function(application,
+                            uniqueName,
+                            forceUpdate = FALSE,
+                            error_call = caller_env()) {
   if (forceUpdate) {
     return(TRUE)
   }
@@ -356,7 +359,7 @@ shouldUpdateApp <- function(application, uniqueName, forceUpdate = FALSE) {
     i = "Supply a unique `appName` to deploy a new application."
   )
 
-  cli_menu(message, prompt, choices, not_interactive, quit = 3) == 1
+  cli_menu(message, prompt, choices, not_interactive, quit = 3, error_call = error_call) == 1
 }
 
 

--- a/R/deployments-find.R
+++ b/R/deployments-find.R
@@ -32,6 +32,10 @@ findDeployment <- function(appPath = getwd(),
 }
 
 disambiguateDeployments <- function(appDeployments, error_call = caller_env()) {
+  if (nrow(appDeployments) == 1) {
+    return(appDeployments[1, ])
+  }
+
   apps <- paste0(
     appDeployments$name, " ",
     "(", accountLabel(appDeployments$account, appDeployments$server), "): ",

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -85,28 +85,32 @@ deploymentFields <- c(
 
 deploymentRecordVersion <- 1L
 
+# Save a deployment record to disk using an incoming record (which may or may
+# not correspond to an existing on-disk deployment record). Created by
+# deploymentRecord() or by findDeploymentTarget(), and possibly loaded from
+# disk.
 saveDeployment <- function(recordDir,
-                           target,
+                           previous,
                            application,
                            bundleId = NULL,
-                           hostUrl = serverInfo(target$server)$url,
+                           hostUrl = serverInfo(previous$server)$url,
                            metadata = list(),
                            addToHistory = TRUE) {
   deployment <- deploymentRecord(
-    name = target$name,
-    title = target$title,
-    username = target$username,
-    account = target$account,
-    server = target$server,
-    envVars = target$envVars,
-    version = target$version,
+    name = previous$name,
+    title = previous$title,
+    username = previous$username,
+    account = previous$account,
+    server = previous$server,
+    envVars = previous$envVars,
+    version = previous$version,
     hostUrl = hostUrl,
     appId = application$id,
     bundleId = bundleId,
     url = application$url,
     metadata = metadata
   )
-  path <- deploymentConfigFile(recordDir, target$name, target$account, target$server)
+  path <- deploymentConfigFile(recordDir, previous$name, previous$account, previous$server)
   writeDeploymentRecord(deployment, path)
 
   # also save to global history

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -93,8 +93,8 @@ saveDeployment <- function(recordDir,
                            metadata = list(),
                            addToHistory = TRUE) {
   deployment <- deploymentRecord(
-    name = target$appName,
-    title = target$appTitle,
+    name = target$name,
+    title = target$title,
     username = target$username,
     account = target$account,
     server = target$server,
@@ -106,7 +106,7 @@ saveDeployment <- function(recordDir,
     url = application$url,
     metadata = metadata
   )
-  path <- deploymentConfigFile(recordDir, target$appName, target$account, target$server)
+  path <- deploymentConfigFile(recordDir, target$name, target$account, target$server)
   writeDeploymentRecord(deployment, path)
 
   # also save to global history

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -90,27 +90,27 @@ deploymentRecordVersion <- 1L
 # deploymentRecord() or by findDeploymentTarget(), and possibly loaded from
 # disk.
 saveDeployment <- function(recordDir,
-                           previous,
+                           deployment,
                            application,
                            bundleId = NULL,
-                           hostUrl = serverInfo(previous$server)$url,
+                           hostUrl = serverInfo(deployment$server)$url,
                            metadata = list(),
                            addToHistory = TRUE) {
   deployment <- deploymentRecord(
-    name = previous$name,
-    title = previous$title,
-    username = previous$username,
-    account = previous$account,
-    server = previous$server,
-    envVars = previous$envVars,
-    version = previous$version,
+    name = deployment$name,
+    title = deployment$title,
+    username = deployment$username,
+    account = deployment$account,
+    server = deployment$server,
+    envVars = deployment$envVars,
+    version = deployment$version,
     hostUrl = hostUrl,
     appId = application$id,
     bundleId = bundleId,
     url = application$url,
     metadata = metadata
   )
-  path <- deploymentConfigFile(recordDir, previous$name, previous$account, previous$server)
+  path <- deploymentConfigFile(recordDir, deployment$name, deployment$account, deployment$server)
   writeDeploymentRecord(deployment, path)
 
   # also save to global history

--- a/tests/testthat/_snaps/deploymentTarget.md
+++ b/tests/testthat/_snaps/deploymentTarget.md
@@ -1,7 +1,7 @@
 # errors if no accounts
 
     Code
-      deploymentTarget()
+      findDeploymentTarget()
     Condition
       Error in `accountInfo()`:
       ! No accounts registered.
@@ -10,13 +10,13 @@
 # errors if unknown account or server
 
     Code
-      deploymentTarget(server = "unknown")
+      findDeploymentTarget(server = "unknown")
     Condition
       Error in `accountInfo()`:
       ! Can't find any accounts with `server` = "unknown".
       i Known servers are "bar".
     Code
-      deploymentTarget(account = "john")
+      findDeploymentTarget(account = "john")
     Condition
       Error in `accountInfo()`:
       ! Can't find any accounts with `account` = "john".
@@ -25,7 +25,7 @@
 # errors if no previous deployments and multiple accounts
 
     Code
-      deploymentTarget(app_dir)
+      findDeploymentTarget(app_dir)
     Condition
       Error in `accountInfo()`:
       ! Found multiple accounts.
@@ -33,7 +33,7 @@
       i Available servers: "foo1" and "foo2".
       i Available account names: "ron".
     Code
-      deploymentTarget(app_dir, appName = "test")
+      findDeploymentTarget(app_dir, appName = "test")
     Condition
       Error in `accountInfo()`:
       ! Found multiple accounts.
@@ -44,7 +44,7 @@
 # handles accounts if only server specified
 
     Code
-      deploymentTarget(app_dir, server = "foo")
+      findDeploymentTarget(app_dir, server = "foo")
     Condition
       Error in `accountInfo()`:
       ! Found multiple accounts for `server` = "foo".
@@ -54,7 +54,7 @@
 # errors/prompts if multiple deployments
 
     Code
-      deploymentTarget(app_dir, appName = "test")
+      findDeploymentTarget(app_dir, appName = "test")
     Condition
       Error:
       ! This directory has been previously deployed in multiple places.
@@ -63,7 +63,7 @@
       * test (server: server1.com / username: ron): <https://server1.com/ron/123>
       * test (server: server2.com / username: ron): <https://server2.com/ron/123>
     Code
-      deploymentTarget(app_dir)
+      findDeploymentTarget(app_dir)
     Condition
       Error:
       ! This directory has been previously deployed in multiple places.
@@ -75,7 +75,7 @@
 ---
 
     Code
-      target <- deploymentTarget(app_dir)
+      target <- findDeploymentTarget(app_dir)
     Message
       This directory has been previously deployed in multiple places.
       Which deployment do you want to use?
@@ -86,7 +86,7 @@
 # succeeds if there are no deployments and a single account
 
     Code
-      deploymentTarget(app_dir)
+      findDeploymentTarget(app_dir)
     Condition
       Error in `shouldUpdateApp()`:
       ! Discovered a previously deployed app named "remotename"

--- a/tests/testthat/_snaps/deploymentTarget.md
+++ b/tests/testthat/_snaps/deploymentTarget.md
@@ -3,7 +3,7 @@
     Code
       deploymentTarget()
     Condition
-      Error in `deploymentTarget()`:
+      Error in `accountInfo()`:
       ! No accounts registered.
       i Call `rsconnect::setAccountInfo()` to register an account.
 
@@ -12,13 +12,13 @@
     Code
       deploymentTarget(server = "unknown")
     Condition
-      Error in `deploymentTarget()`:
+      Error in `accountInfo()`:
       ! Can't find any accounts with `server` = "unknown".
       i Known servers are "bar".
     Code
       deploymentTarget(account = "john")
     Condition
-      Error in `deploymentTarget()`:
+      Error in `accountInfo()`:
       ! Can't find any accounts with `account` = "john".
       i Available account names: "foo".
 
@@ -27,7 +27,7 @@
     Code
       deploymentTarget(app_dir)
     Condition
-      Error in `deploymentTarget()`:
+      Error in `accountInfo()`:
       ! Found multiple accounts.
       Please disambiguate by setting `server` and/or `account`.
       i Available servers: "foo1" and "foo2".
@@ -35,7 +35,7 @@
     Code
       deploymentTarget(app_dir, appName = "test")
     Condition
-      Error in `deploymentTarget()`:
+      Error in `accountInfo()`:
       ! Found multiple accounts.
       Please disambiguate by setting `server` and/or `account`.
       i Available servers: "foo1" and "foo2".
@@ -46,7 +46,7 @@
     Code
       deploymentTarget(app_dir, server = "foo")
     Condition
-      Error in `deploymentTarget()`:
+      Error in `accountInfo()`:
       ! Found multiple accounts for `server` = "foo".
       Please disambiguate by setting `account`.
       i Known account names are "john" and "ron".
@@ -75,7 +75,7 @@
 ---
 
     Code
-      out <- deploymentTarget(app_dir)
+      target <- deploymentTarget(app_dir)
     Message
       This directory has been previously deployed in multiple places.
       Which deployment do you want to use?
@@ -83,15 +83,16 @@
       2: test (server: server2.com / username: ron): <https://server2.com/ron/123>
       Selection: 1
 
-# errors if single deployment and appId doesn't match
+# succeeds if there are no deployments and a single account
 
     Code
-      deploymentTarget(app_dir, appName = "test", appId = "2")
+      deploymentTarget(app_dir)
     Condition
-      Error:
-      ! Supplied `appId` (2) does not match deployment record (1).
-      i Omit `appId` to use existing for deployment for app "test", or
-      i Omit `appName` to create new deployment record.
+      Error in `shouldUpdateApp()`:
+      ! Discovered a previously deployed app named "remotename"
+      (View it at <app-url>)
+      i Set `forceUpdate = TRUE` to update it.
+      i Supply a unique `appName` to deploy a new application.
 
 # shouldUpdateApp errors when non-interactive
 

--- a/tests/testthat/_snaps/deploymentTarget.md
+++ b/tests/testthat/_snaps/deploymentTarget.md
@@ -3,7 +3,7 @@
     Code
       findDeploymentTarget()
     Condition
-      Error in `accountInfo()`:
+      Error:
       ! No accounts registered.
       i Call `rsconnect::setAccountInfo()` to register an account.
 
@@ -12,13 +12,13 @@
     Code
       findDeploymentTarget(server = "unknown")
     Condition
-      Error in `accountInfo()`:
+      Error:
       ! Can't find any accounts with `server` = "unknown".
       i Known servers are "bar".
     Code
       findDeploymentTarget(account = "john")
     Condition
-      Error in `accountInfo()`:
+      Error:
       ! Can't find any accounts with `account` = "john".
       i Available account names: "foo".
 
@@ -27,7 +27,7 @@
     Code
       findDeploymentTarget(app_dir)
     Condition
-      Error in `accountInfo()`:
+      Error:
       ! Found multiple accounts.
       Please disambiguate by setting `server` and/or `account`.
       i Available servers: "foo1" and "foo2".
@@ -35,7 +35,7 @@
     Code
       findDeploymentTarget(app_dir, appName = "test")
     Condition
-      Error in `accountInfo()`:
+      Error:
       ! Found multiple accounts.
       Please disambiguate by setting `server` and/or `account`.
       i Available servers: "foo1" and "foo2".
@@ -46,7 +46,7 @@
     Code
       findDeploymentTarget(app_dir, server = "foo")
     Condition
-      Error in `accountInfo()`:
+      Error:
       ! Found multiple accounts for `server` = "foo".
       Please disambiguate by setting `account`.
       i Known account names are "john" and "ron".

--- a/tests/testthat/_snaps/deploymentTarget.md
+++ b/tests/testthat/_snaps/deploymentTarget.md
@@ -88,7 +88,7 @@
     Code
       findDeploymentTarget(app_dir)
     Condition
-      Error in `shouldUpdateApp()`:
+      Error:
       ! Discovered a previously deployed app named "remotename"
       (View it at <app-url>)
       i Set `forceUpdate = TRUE` to update it.
@@ -99,7 +99,7 @@
     Code
       shouldUpdateApp(app, "my_app-1")
     Condition
-      Error in `shouldUpdateApp()`:
+      Error:
       ! Discovered a previously deployed app named "my_app"
       (View it at <https://example.com>)
       i Set `forceUpdate = TRUE` to update it.

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -117,7 +117,7 @@ addTestDeployment <- function(path,
                               metadata = list()) {
   saveDeployment(
     path,
-    createDeploymentTarget(
+    createDeployment(
       appName = appName,
       appTitle = appTitle,
       appId = appId,

--- a/tests/testthat/test-client-cloud.R
+++ b/tests/testthat/test-client-cloud.R
@@ -587,7 +587,7 @@ test_that("Create application with linked source project", {
   expect_equal(app$url, "http://fake-url.test.me/")
 })
 
-test_that("deploymentTarget() results in correct Cloud API calls when given appId", {
+test_that("findDeploymentTarget() results in correct Cloud API calls when given appId", {
   local_temp_config()
 
   mockServer <- mockServerFactory(list(
@@ -623,7 +623,7 @@ test_that("deploymentTarget() results in correct Cloud API calls when given appI
   testAccount <- configureTestAccount()
   withr::defer(removeAccount(testAccount))
 
-  target <- deploymentTarget(
+  target <- findDeploymentTarget(
     appId = 3,
     account = testAccount,
     server = "posit.cloud",

--- a/tests/testthat/test-client-cloud.R
+++ b/tests/testthat/test-client-cloud.R
@@ -632,7 +632,7 @@ test_that("findDeploymentTarget() results in correct Cloud API calls when given 
   accountDetails <- target$accountDetails
   deployment <- target$deployment
 
-  expect_equal(deployment$appName, "my output")
+  expect_equal(deployment$name, "my output")
   expect_equal(deployment$account, testAccount)
   expect_equal(deployment$server, "posit.cloud")
   expect_equal(deployment$appId, 3)

--- a/tests/testthat/test-client-cloud.R
+++ b/tests/testthat/test-client-cloud.R
@@ -587,7 +587,9 @@ test_that("Create application with linked source project", {
   expect_equal(app$url, "http://fake-url.test.me/")
 })
 
-test_that("deploymentTargetForApp() results in correct Cloud API calls", {
+test_that("deploymentTarget() results in correct Cloud API calls when given appId", {
+  local_temp_config()
+
   mockServer <- mockServerFactory(list(
     "^GET /v1/applications/([0-9]+)" = list(
       content = function(methodAndPath, match, ...) {
@@ -621,16 +623,19 @@ test_that("deploymentTargetForApp() results in correct Cloud API calls", {
   testAccount <- configureTestAccount()
   withr::defer(removeAccount(testAccount))
 
-  target <- deploymentTargetForApp(
+  target <- deploymentTarget(
     appId = 3,
     account = testAccount,
     server = "posit.cloud",
   )
 
-  expect_equal(target$appName, "my output")
-  expect_equal(target$account, testAccount)
-  expect_equal(target$server, "posit.cloud")
-  expect_equal(target$appId, 3)
+  accountDetails <- target$accountDetails
+  deployment <- target$deployment
+
+  expect_equal(deployment$appName, "my output")
+  expect_equal(deployment$account, testAccount)
+  expect_equal(deployment$server, "posit.cloud")
+  expect_equal(deployment$appId, 3)
 })
 
 deployAppMockServerFactory <- function(expectedAppType, outputState) {
@@ -796,6 +801,8 @@ deployAppMockServerFactory <- function(expectedAppType, outputState) {
 test_that("deployApp() for shiny results in correct Cloud API calls", {
   skip_on_cran()
 
+  local_temp_config()
+
   withr::local_options(renv.verbose = TRUE)
 
   mock <- deployAppMockServerFactory(expectedAppType = "connect", outputState = "active")
@@ -891,6 +898,8 @@ test_that("deployApp() for shiny results in correct Cloud API calls", {
 })
 
 test_that("deployDoc() results in correct Cloud API calls", {
+  local_temp_config()
+
   mock <- deployAppMockServerFactory(expectedAppType = "static", outputState = "active")
   mockServer <- mock$server
 

--- a/tests/testthat/test-deployApp.R
+++ b/tests/testthat/test-deployApp.R
@@ -90,7 +90,7 @@ test_that("applicationDeleted() errors or prompts as needed", {
   addTestAccount("a", "s")
   app <- local_temp_app()
   addTestDeployment(app, appName = "name", account = "a", server = "s")
-  target <- createDeploymentTarget("name", "title", "id", NULL, "a", "a", "s", 1)
+  target <- createDeployment("name", "title", "id", NULL, "a", "a", "s", 1)
   client <- list(createApplication = function(...) NULL)
 
   expect_snapshot(applicationDeleted(client, target, app), error = TRUE)

--- a/tests/testthat/test-deploymentTarget.R
+++ b/tests/testthat/test-deploymentTarget.R
@@ -47,7 +47,7 @@ test_that("uses appId given a local deployment record; created by a local accoun
   expect_equal(accountDetails$name, "leslie")
   expect_equal(accountDetails$server, "local")
   expect_equal(deployment$appId, "the-appid")
-  expect_equal(deployment$appName, "local-record")
+  expect_equal(deployment$name, "local-record")
   expect_equal(deployment$username, "leslie")
   expect_equal(deployment$account, "leslie")
   expect_equal(deployment$server, "local")
@@ -70,7 +70,7 @@ test_that("uses appId given a local deployment record; created by a collaborator
   expect_equal(accountDetails$name, "leslie")
   expect_equal(accountDetails$server, "local")
   expect_equal(deployment$appId, "the-appid")
-  expect_equal(deployment$appName, "local-record")
+  expect_equal(deployment$name, "local-record")
   expect_equal(deployment$username, "ron")
   expect_equal(deployment$account, "ron")
   expect_equal(deployment$server, "local")
@@ -97,7 +97,7 @@ test_that("uses appId without local deployment record; created by local account"
   expect_equal(accountDetails$name, "leslie")
   expect_equal(accountDetails$server, "local")
   expect_equal(deployment$appId, "the-appid")
-  expect_equal(deployment$appName, "remote-record")
+  expect_equal(deployment$name, "remote-record")
   expect_equal(deployment$username, "leslie")
   expect_equal(deployment$account, "leslie")
   expect_equal(deployment$server, "local")
@@ -124,7 +124,7 @@ test_that("uses appId without local deployment record; created by collaborator",
   expect_equal(accountDetails$name, "leslie")
   expect_equal(accountDetails$server, "local")
   expect_equal(deployment$appId, "the-appid")
-  expect_equal(deployment$appName, "remote-record")
+  expect_equal(deployment$name, "remote-record")
   expect_equal(deployment$username, "ron")
   # note: account+server does not correspond to the "ron" account, but this is
   # the best we can do, as we do not have the original deployment record.
@@ -181,7 +181,7 @@ test_that("errors/prompts if multiple deployments", {
   deployment <- target$deployment
   expect_equal(accountDetails$name, "ron")
   expect_equal(accountDetails$server, "server1.com")
-  expect_equal(deployment$appName, "test")
+  expect_equal(deployment$name, "test")
 })
 
 test_that("succeeds if there's a single existing deployment", {
@@ -208,7 +208,7 @@ test_that("succeeds if there's a single existing deployment", {
   expect_equal(accountDetails$name, "ron")
   expect_equal(accountDetails$server, "example.com")
   expect_equal(deployment$appId, "1")
-  expect_equal(deployment$appName, "test")
+  expect_equal(deployment$name, "test")
   expect_equal(deployment$username, "ron")
   expect_equal(deployment$account, "ron")
   expect_equal(deployment$server, "example.com")
@@ -220,7 +220,7 @@ test_that("succeeds if there's a single existing deployment", {
   expect_equal(accountDetails$name, "ron")
   expect_equal(accountDetails$server, "example.com")
   expect_equal(deployment$appId, "1")
-  expect_equal(deployment$appName, "test")
+  expect_equal(deployment$name, "test")
   expect_equal(deployment$username, "ron")
   expect_equal(deployment$account, "ron")
   expect_equal(deployment$server, "example.com")
@@ -254,11 +254,11 @@ test_that("new title overrides existing title", {
 
   target <- findDeploymentTarget(app_dir)
   deployment <- target$deployment
-  expect_equal(deployment$appTitle, "old title")
+  expect_equal(deployment$title, "old title")
 
   target <- findDeploymentTarget(app_dir, appTitle = "new title")
   deployment <- target$deployment
-  expect_equal(deployment$appTitle, "new title")
+  expect_equal(deployment$title, "new title")
 })
 
 test_that("new env vars overrides existing", {
@@ -319,7 +319,7 @@ test_that("succeeds if there are no deployments and a single account", {
   deployment <- target$deployment
   expect_equal(accountDetails$name, "ron")
   expect_equal(accountDetails$server, "example.com")
-  expect_equal(deployment$appName, "remotename")
+  expect_equal(deployment$name, "remotename")
   expect_equal(deployment$username, "ron")
   expect_equal(deployment$account, "ron")
   expect_equal(deployment$server, "example.com")
@@ -329,7 +329,7 @@ test_that("succeeds if there are no deployments and a single account", {
   deployment <- target$deployment
   expect_equal(accountDetails$name, "ron")
   expect_equal(accountDetails$server, "example.com")
-  expect_equal(deployment$appName, "remotename")
+  expect_equal(deployment$name, "remotename")
   expect_equal(deployment$username, "ron")
   expect_equal(deployment$account, "ron")
   expect_equal(deployment$server, "example.com")
@@ -339,7 +339,7 @@ test_that("succeeds if there are no deployments and a single account", {
   deployment <- target$deployment
   expect_equal(accountDetails$name, "ron")
   expect_equal(accountDetails$server, "example.com")
-  expect_equal(deployment$appName, "remotename")
+  expect_equal(deployment$name, "remotename")
   expect_equal(deployment$username, "ron")
   expect_equal(deployment$account, "ron")
   expect_equal(deployment$server, "example.com")
@@ -350,7 +350,7 @@ test_that("succeeds if there are no deployments and a single account", {
   deployment <- target$deployment
   expect_equal(accountDetails$name, "ron")
   expect_equal(accountDetails$server, "example.com")
-  expect_equal(deployment$appName, "remotename")
+  expect_equal(deployment$name, "remotename")
   expect_equal(deployment$username, "ron")
   expect_equal(deployment$account, "ron")
   expect_equal(deployment$server, "example.com")
@@ -367,7 +367,7 @@ test_that("default title is the empty string", {
   app_dir <- withr::local_tempdir()
   target <- findDeploymentTarget(app_dir, forceUpdate = TRUE)
   deployment <- target$deployment
-  expect_equal(deployment$appTitle, "")
+  expect_equal(deployment$title, "")
 })
 
 confirm_existing_app_used <- function(server) {
@@ -413,7 +413,7 @@ confirm_existing_app_not_used <- function(server) {
   app_dir <- withr::local_tempdir()
   target <- findDeploymentTarget(app_dir, appName = "my_app", server = server)
   deployment <- target$deployment
-  expect_equal(deployment$appName, "my_app-1")
+  expect_equal(deployment$name, "my_app-1")
   expect_equal(deployment$appId, NULL)
 }
 
@@ -471,4 +471,80 @@ test_that("findUnique always returns unique name", {
   expect_equal(findUnique("x", c("x", "y")), "x-1")
   expect_equal(findUnique("x", c("x", "x-1")), "x-2")
   expect_equal(findUnique("x", c("x", "x-1", "x-2")), "x-3")
+})
+
+test_that("createDeploymentFromApplication promotes fields", {
+  expect_equal(createDeploymentFromApplication(
+    application = list(
+      id = "1",
+      name = "app-name",
+      title = "app-title",
+      owner_username = "alice.username"
+    ),
+    accountDetails = list(
+      name = "alice",
+      server = "example.com"
+    )
+  ), list(
+    name = "app-name",
+    title = "app-title",
+    envVars = NULL,
+    appId = "1",
+    username = "alice.username",
+    account = "alice",
+    server = "example.com",
+    version = deploymentRecordVersion
+  ))
+})
+
+test_that("updateDeployment updates fields", {
+  expect_equal(updateDeployment(
+    list(
+      name = "app-name",
+      title = "app-title",
+      envVars = NULL,
+      appId = "1",
+      username = "alice.username",
+      account = "alice",
+      server = "example.com",
+      version = deploymentRecordVersion
+    ),
+    appTitle = "updated-title",
+    envVars = c("VAR-NAME")
+  ), list(
+    name = "app-name",
+    title = "updated-title",
+    envVars = c("VAR-NAME"),
+    appId = "1",
+    username = "alice.username",
+    account = "alice",
+    server = "example.com",
+    version = deploymentRecordVersion
+  ))
+})
+
+test_that("updateDeployment ignores NULL updates", {
+  expect_equal(updateDeployment(
+    list(
+      name = "app-name",
+      title = "app-title",
+      envVars = c("VAR-NAME"),
+      appId = "1",
+      username = "alice.username",
+      account = "alice",
+      server = "example.com",
+      version = deploymentRecordVersion
+    ),
+    appTitle = NULL,
+    envVars = NULL
+  ), list(
+    name = "app-name",
+    title = "app-title",
+    envVars = c("VAR-NAME"),
+    appId = "1",
+    username = "alice.username",
+    account = "alice",
+    server = "example.com",
+    version = deploymentRecordVersion
+  ))
 })

--- a/tests/testthat/test-deploymentTarget.R
+++ b/tests/testthat/test-deploymentTarget.R
@@ -85,7 +85,8 @@ test_that("uses appId without local deployment record; created by local account"
     getApplication = function(...) data.frame(
       id = "the-appid",
       name = "remote-record",
-      owner_username = "leslie"
+      owner_username = "leslie",
+      stringsAsFactors = FALSE
     )
   )
 
@@ -114,7 +115,8 @@ test_that("uses appId without local deployment record; created by collaborator",
     getApplication = function(...) data.frame(
       id = "the-appid",
       name = "remote-record",
-      owner_username = "ron"
+      owner_username = "ron",
+      stringsAsFactors = FALSE
     )
   )
 
@@ -304,7 +306,11 @@ test_that("succeeds if there are no deployments and a single account", {
   addTestServer()
   addTestAccount("ron")
   local_mocked_bindings(
-    getAppByName = function(...) data.frame(name = "remotename", url = "app-url")
+    getAppByName = function(...) data.frame(
+      name = "remotename",
+      url = "app-url",
+      stringsAsFactors = FALSE
+    )
   )
 
   app_dir <- dirCreate(file.path(withr::local_tempdir(), "my_app"))
@@ -361,7 +367,11 @@ test_that("default title is the empty string", {
   addTestServer()
   addTestAccount("ron")
   local_mocked_bindings(
-    getAppByName = function(...) data.frame(name = "remotename", url = "app-url")
+    getAppByName = function(...) data.frame(
+      name = "remotename",
+      url = "app-url",
+      stringsAsFactors = FALSE
+    )
   )
 
   app_dir <- withr::local_tempdir()

--- a/tests/testthat/test-deploymentTarget.R
+++ b/tests/testthat/test-deploymentTarget.R
@@ -303,7 +303,9 @@ test_that("succeeds if there are no deployments and a single account", {
   local_temp_config()
   addTestServer()
   addTestAccount("ron")
-  local_mocked_bindings(getAppByName = function(...) data.frame(name="remotename", url="app-url"))
+  local_mocked_bindings(
+    getAppByName = function(...) data.frame(name = "remotename", url = "app-url")
+  )
 
   app_dir <- dirCreate(file.path(withr::local_tempdir(), "my_app"))
 
@@ -358,7 +360,9 @@ test_that("default title is the empty string", {
   local_temp_config()
   addTestServer()
   addTestAccount("ron")
-  local_mocked_bindings(getAppByName = function(...) data.frame(name="remotename", url="app-url"))
+  local_mocked_bindings(
+    getAppByName = function(...) data.frame(name = "remotename", url = "app-url")
+  )
 
   app_dir <- withr::local_tempdir()
   target <- deploymentTarget(app_dir, forceUpdate = TRUE)

--- a/tests/testthat/test-deploymentTarget.R
+++ b/tests/testthat/test-deploymentTarget.R
@@ -1,7 +1,7 @@
 test_that("errors if no accounts", {
   local_temp_config()
 
-  expect_snapshot(deploymentTarget(), error = TRUE)
+  expect_snapshot(findDeploymentTarget(), error = TRUE)
 })
 
 test_that("errors if unknown account or server", {
@@ -10,8 +10,8 @@ test_that("errors if unknown account or server", {
   addTestAccount("foo", "bar")
 
   expect_snapshot(error = TRUE, {
-    deploymentTarget(server = "unknown")
-    deploymentTarget(account = "john")
+    findDeploymentTarget(server = "unknown")
+    findDeploymentTarget(account = "john")
   })
 })
 
@@ -26,8 +26,8 @@ test_that("errors if no previous deployments and multiple accounts", {
   file.create(file.path(app_dir, "app.R"))
 
   expect_snapshot(error = TRUE, {
-    deploymentTarget(app_dir)
-    deploymentTarget(app_dir, appName = "test")
+    findDeploymentTarget(app_dir)
+    findDeploymentTarget(app_dir, appName = "test")
   })
 })
 
@@ -41,7 +41,7 @@ test_that("uses appId given a local deployment record; created by a local accoun
   app_dir <- withr::local_tempdir()
   addTestDeployment(app_dir, appName = "local-record", appId = "the-appid", account = "leslie", server = "local")
 
-  target <- deploymentTarget(app_dir, appId = "the-appid")
+  target <- findDeploymentTarget(app_dir, appId = "the-appid")
   accountDetails <- target$accountDetails
   deployment <- target$deployment
   expect_equal(accountDetails$name, "leslie")
@@ -64,7 +64,7 @@ test_that("uses appId given a local deployment record; created by a collaborator
   app_dir <- withr::local_tempdir()
   addTestDeployment(app_dir, appName = "local-record", appId = "the-appid", account = "ron", server = "local")
 
-  target <- deploymentTarget(app_dir, appId = "the-appid")
+  target <- findDeploymentTarget(app_dir, appId = "the-appid")
   accountDetails <- target$accountDetails
   deployment <- target$deployment
   expect_equal(accountDetails$name, "leslie")
@@ -91,7 +91,7 @@ test_that("uses appId without local deployment record; created by local account"
 
   app_dir <- withr::local_tempdir()
 
-  target <- deploymentTarget(app_dir, appId = "the-appid")
+  target <- findDeploymentTarget(app_dir, appId = "the-appid")
   accountDetails <- target$accountDetails
   deployment <- target$deployment
   expect_equal(accountDetails$name, "leslie")
@@ -118,7 +118,7 @@ test_that("uses appId without local deployment record; created by collaborator",
     )
   )
 
-  target <- deploymentTarget(app_dir, appId = "the-appid")
+  target <- findDeploymentTarget(app_dir, appId = "the-appid")
   accountDetails <- target$accountDetails
   deployment <- target$deployment
   expect_equal(accountDetails$name, "leslie")
@@ -143,9 +143,9 @@ test_that("handles accounts if only server specified", {
   app_dir <- withr::local_tempdir()
   file.create(file.path(app_dir, "app.R"))
 
-  expect_snapshot(deploymentTarget(app_dir, server = "foo"), error = TRUE)
+  expect_snapshot(findDeploymentTarget(app_dir, server = "foo"), error = TRUE)
 
-  target <- deploymentTarget(
+  target <- findDeploymentTarget(
     app_dir,
     server = "foo",
     account = "ron"
@@ -171,12 +171,12 @@ test_that("errors/prompts if multiple deployments", {
   addTestDeployment(app_dir, server = "server2.com")
 
   expect_snapshot(error = TRUE, {
-    deploymentTarget(app_dir, appName = "test")
-    deploymentTarget(app_dir)
+    findDeploymentTarget(app_dir, appName = "test")
+    findDeploymentTarget(app_dir)
   })
 
   simulate_user_input(1)
-  expect_snapshot(target <- deploymentTarget(app_dir))
+  expect_snapshot(target <- findDeploymentTarget(app_dir))
   accountDetails <- target$accountDetails
   deployment <- target$deployment
   expect_equal(accountDetails$name, "ron")
@@ -202,7 +202,7 @@ test_that("succeeds if there's a single existing deployment", {
   expect_equal(nrow(deployments(app_dir, accountFilter = "ron", serverFilter = "example.com")), 1)
   expect_equal(nrow(deployments(app_dir)), 1)
 
-  target <- deploymentTarget(app_dir)
+  target <- findDeploymentTarget(app_dir)
   accountDetails <- target$accountDetails
   deployment <- target$deployment
   expect_equal(accountDetails$name, "ron")
@@ -214,7 +214,7 @@ test_that("succeeds if there's a single existing deployment", {
   expect_equal(deployment$server, "example.com")
   expect_equal(deployment$version, "999")
 
-  target <- deploymentTarget(app_dir, appName = "test")
+  target <- findDeploymentTarget(app_dir, appName = "test")
   accountDetails <- target$accountDetails
   deployment <- target$deployment
   expect_equal(accountDetails$name, "ron")
@@ -236,7 +236,7 @@ test_that("appId is used even when name does not match", {
   addTestDeployment(app_dir, appName = "test", appId = "1", username = "ron")
   addTestDeployment(app_dir, appName = "second", appId = "2", username = "ron")
 
-  target <- deploymentTarget(app_dir, appName = "mismatched", appId = "1")
+  target <- findDeploymentTarget(app_dir, appName = "mismatched", appId = "1")
   accountDetails <- target$accountDetails
   deployment <- target$deployment
   expect_equal(accountDetails$name, "ron")
@@ -252,11 +252,11 @@ test_that("new title overrides existing title", {
   app_dir <- withr::local_tempdir()
   addTestDeployment(app_dir, appTitle = "old title")
 
-  target <- deploymentTarget(app_dir)
+  target <- findDeploymentTarget(app_dir)
   deployment <- target$deployment
   expect_equal(deployment$appTitle, "old title")
 
-  target <- deploymentTarget(app_dir, appTitle = "new title")
+  target <- findDeploymentTarget(app_dir, appTitle = "new title")
   deployment <- target$deployment
   expect_equal(deployment$appTitle, "new title")
 })
@@ -268,21 +268,21 @@ test_that("new env vars overrides existing", {
   addTestAccount()
   addTestDeployment(app, envVars = "TEST1")
 
-  target <- deploymentTarget(app)
+  target <- findDeploymentTarget(app)
   deployment <- target$deployment
   expect_equal(deployment$envVars, "TEST1")
 
-  target <- deploymentTarget(app, envVars = "TEST2")
+  target <- findDeploymentTarget(app, envVars = "TEST2")
   deployment <- target$deployment
   expect_equal(deployment$envVars, "TEST2")
 
   # And check that it works with vectors
   addTestDeployment(app, envVars = c("TEST1", "TEST2"))
-  target <- deploymentTarget(app)
+  target <- findDeploymentTarget(app)
   deployment <- target$deployment
   expect_equal(deployment$envVars, c("TEST1", "TEST2"))
 
-  target <- deploymentTarget(app, envVars = "TEST2")
+  target <- findDeploymentTarget(app, envVars = "TEST2")
   deployment <- target$deployment
   expect_equal(deployment$envVars, "TEST2")
 })
@@ -294,7 +294,7 @@ test_that("empty character vector removes env vars", {
   addTestAccount()
   addTestDeployment(app, envVars = "TEST1")
 
-  target <- deploymentTarget(app, envVars = character())
+  target <- findDeploymentTarget(app, envVars = character())
   deployment <- target$deployment
   expect_equal(deployment$envVars, character())
 })
@@ -310,11 +310,11 @@ test_that("succeeds if there are no deployments and a single account", {
   app_dir <- dirCreate(file.path(withr::local_tempdir(), "my_app"))
 
   expect_snapshot(error = TRUE, {
-    deploymentTarget(app_dir)
+    findDeploymentTarget(app_dir)
   })
 
   simulate_user_input(1)
-  target <- deploymentTarget(app_dir)
+  target <- findDeploymentTarget(app_dir)
   accountDetails <- target$accountDetails
   deployment <- target$deployment
   expect_equal(accountDetails$name, "ron")
@@ -324,7 +324,7 @@ test_that("succeeds if there are no deployments and a single account", {
   expect_equal(deployment$account, "ron")
   expect_equal(deployment$server, "example.com")
 
-  target <- deploymentTarget(app_dir, forceUpdate = TRUE)
+  target <- findDeploymentTarget(app_dir, forceUpdate = TRUE)
   accountDetails <- target$accountDetails
   deployment <- target$deployment
   expect_equal(accountDetails$name, "ron")
@@ -334,7 +334,7 @@ test_that("succeeds if there are no deployments and a single account", {
   expect_equal(deployment$account, "ron")
   expect_equal(deployment$server, "example.com")
 
-  target <- deploymentTarget(app_dir, envVars = c("TEST1", "TEST2"), forceUpdate = TRUE)
+  target <- findDeploymentTarget(app_dir, envVars = c("TEST1", "TEST2"), forceUpdate = TRUE)
   accountDetails <- target$accountDetails
   deployment <- target$deployment
   expect_equal(accountDetails$name, "ron")
@@ -345,7 +345,7 @@ test_that("succeeds if there are no deployments and a single account", {
   expect_equal(deployment$server, "example.com")
   expect_equal(deployment$envVars, c("TEST1", "TEST2"))
 
-  target <- deploymentTarget(app_dir, appName = "foo", forceUpdate = TRUE)
+  target <- findDeploymentTarget(app_dir, appName = "foo", forceUpdate = TRUE)
   accountDetails <- target$accountDetails
   deployment <- target$deployment
   expect_equal(accountDetails$name, "ron")
@@ -365,7 +365,7 @@ test_that("default title is the empty string", {
   )
 
   app_dir <- withr::local_tempdir()
-  target <- deploymentTarget(app_dir, forceUpdate = TRUE)
+  target <- findDeploymentTarget(app_dir, forceUpdate = TRUE)
   deployment <- target$deployment
   expect_equal(deployment$appTitle, "")
 })
@@ -384,7 +384,7 @@ confirm_existing_app_used <- function(server) {
   )
 
   app_dir <- withr::local_tempdir()
-  target <- deploymentTarget(app_dir, appName = "my_app", server = server)
+  target <- findDeploymentTarget(app_dir, appName = "my_app", server = server)
   deployment <- target$deployment
   expect_equal(deployment$appId, 123)
 }
@@ -411,7 +411,7 @@ confirm_existing_app_not_used <- function(server) {
   )
 
   app_dir <- withr::local_tempdir()
-  target <- deploymentTarget(app_dir, appName = "my_app", server = server)
+  target <- findDeploymentTarget(app_dir, appName = "my_app", server = server)
   deployment <- target$deployment
   expect_equal(deployment$appName, "my_app-1")
   expect_equal(deployment$appId, NULL)

--- a/tests/testthat/test-deployments.R
+++ b/tests/testthat/test-deployments.R
@@ -141,7 +141,7 @@ test_that("saveDeployment appends to global history", {
 
   saveDeployment(
     dir,
-    createDeploymentTarget(
+    createDeployment(
       appName = "my-app",
       appTitle = "",
       appId = 10,
@@ -168,7 +168,7 @@ test_that("saveDeployment captures hostUrl", {
   dir <- local_temp_app()
   saveDeployment(
     dir,
-    createDeploymentTarget(
+    createDeployment(
       appName = "my-app",
       appTitle = "",
       appId = 10,


### PR DESCRIPTION
Revisit how the deployment target is selected.

Use 0.8.29 implementation when reviewing this work. In particular, that version of `deploymentTarget()` did not offer any separation between the "owning" account and the "deploying" account. Details recorded in the in-memory deployment record were not necessarily consistent with the on-disk deployment record. Additionally, resolving that deployment record to an actual remote application occurred much later, in `applicationForTarget()`.
https://github.com/rstudio/rsconnect/blob/v0.8.29/R/deployApp.R

The implementation available in 1.0.0 until now did a good job consolidating this logic, but lost track of the fact that we may have a local user attempting to re-use deployment records created by some other user.

This change sees us use the following prioritized techniques to locate a deployment record:

1. When `appId` is provided, it must be used to locate the target content. A target (local) account is required to make this determination. When a local deployment record is not available, the application is loaded from the server. The target deployment record does not need to be owned by the local target account.
2. When `appName` is provided without `appId`, it must be used to locate the target content or create a new deployment target.
3. When neither `appName` nor `appId` is provided, the user is asked to choose from the available deployment records (which must correspond to a locally available account).
4. When there are no deployment records, a generated name is used along with a target account to remotely probe for that name (owned by the target account) before creating a new item.

Some collaboration instructions from the Connect user guide: https://docs.posit.co/connect/user/publishing/#publishing-collaboration

Related issues: #1019, #1013, #1007, #981 along with multiple internal reports.

This change may fix each of those issues, but they need more review to be sure.