### PR TITLE
generate title and name; name is normalized

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,13 @@
   content was incorrectly published to a new location rather than reusing an
   existing deployment. (#981, #1007, #1013, #1019)
 
-* Generated application names are always normalized and lower-cased when
-  deploying to shinyapps.io. The name is derived from an incoming title, when
-  provided, and otherwise from the content path. (#1022)
+* When `deployApp()` is not given `appName`, the name is generated from an
+  incoming title, when provided. When the title is not provided, a title is
+  generated from the content path, which is then used to generate the
+  normalized application name. (#1022)
+
+* The application title recorded in the deployment record is updated with
+  server data. (#1008)
 
 * `showLogs()`, `configureApp()`, `setProperty()`, and `unsetProperty()`
   search for the application by name when there are no matching deployment

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
   content was incorrectly published to a new location rather than reusing an
   existing deployment. (#981, #1007, #1013, #1019)
 
+* Generated application names are always normalized and lower-cased when
+  deploying to shinyapps.io. The name is derived from an incoming title, when
+  provided, and otherwise from the content path. (#1022)
+
 * `showLogs()`, `configureApp()`, `setProperty()`, and `unsetProperty()`
   search for the application by name when there are no matching deployment
   records. (#985, #989)

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -98,7 +98,7 @@ saveDeployment <- function(recordDir,
                            addToHistory = TRUE) {
   deployment <- deploymentRecord(
     name = deployment$name,
-    title = deployment$title,
+    title = application$title %||% deployment$title,
     username = deployment$username,
     account = deployment$account,
     server = deployment$server,

--- a/R/title.R
+++ b/R/title.R
@@ -57,18 +57,7 @@ generateAppName <- function(appTitle, appPath = NULL, account = NULL, unique = T
   # if we wound up with too few characters, try generating from the directory
   # name instead
   if (nchar(name) < 3 && !is.null(appPath) && file.exists(appPath)) {
-    # strip extension if present
-    base <- basename(appPath)
-    if (nzchar(tools::file_ext(base))) {
-      base <- file_path_sans_ext(base)
-
-      # if we stripped an extension and the name is now "index", use the parent
-      # folder's name
-      if (identical(base, "index")) {
-        base <- basename(dirname(appPath))
-      }
-    }
-    name <- munge(base)
+    name <- munge(titleFromPath(appPath))
   }
 
   # validate that we wound up with a valid name

--- a/tests/testthat/test-deploymentTarget.R
+++ b/tests/testthat/test-deploymentTarget.R
@@ -435,21 +435,102 @@ test_that("can find existing application on shinyapps.io & not use it", {
   confirm_existing_app_not_used("shinyapps.io")
 })
 
-# defaultAppName ----------------------------------------------------------
+# generateDefaultName ---------------------------------------------------------
 
-test_that("defaultAppName works with sites, documents, and directories", {
-  expect_equal(defaultAppName("foo/bar.Rmd"), "bar")
-  expect_equal(defaultAppName("foo/index.html"), "foo")
-  expect_equal(defaultAppName("foo/bar"), "bar")
+test_that("generateDefaultName works with sites, documents, and directories", {
+  expect_equal(
+    generateDefaultName("foo/bar.Rmd", "This/is/a/TITLE"),
+    "This_is_a_TITLE"
+  )
+  expect_equal(
+    generateDefaultName("foo/bar.Rmd", "NO"),
+    "bar"
+  )
+
+  expect_equal(
+    generateDefaultName("foo/bar.Rmd"),
+    "bar"
+  )
+  expect_equal(
+    generateDefaultName("foo/index.html"),
+    "foo"
+  )
+  expect_equal(
+    generateDefaultName("foo/bar"),
+    "bar"
+  )
+
+  expect_equal(
+    generateDefaultName("foo/Awesome Document.Rmd"),
+    "Awesome_Document"
+  )
+  expect_equal(
+    generateDefaultName("My Report/index.html"),
+    "My_Report"
+  )
+  expect_equal(
+    generateDefaultName("foo/The-Application"),
+    "The-Application"
+  )
+
+  long_name <- strrep("AbCd", 64 / 4)
+  even_longer_name <- paste(long_name, "...")
+  expect_equal(
+    generateDefaultName(even_longer_name),
+    long_name
+  )
+  expect_equal(
+    generateDefaultName("short-file-path", even_longer_name),
+    long_name
+  )
 })
 
-test_that("defaultAppName reifies appNames for shinyApps", {
-  expect_equal(defaultAppName("a b c", "shinyapps.io"), "a_b_c")
-  expect_equal(defaultAppName("a!b!c", "shinyapps.io"), "a_b_c")
-  expect_equal(defaultAppName("a  b  c", "shinyapps.io"), "a_b_c")
+test_that("generateDefaultName lower-cases names shinyApps", {
+  expect_equal(
+    generateDefaultName("foo/bar.Rmd", "This/is/a/TITLE", server = "shinyapps.io"),
+    "this_is_a_title"
+  )
+  expect_equal(
+    generateDefaultName("foo/bar.Rmd", "NO", server = "shinyapps.io"),
+    "bar"
+  )
 
-  long_name <- strrep("abcd", 64 / 4)
-  expect_equal(defaultAppName(paste(long_name, "..."), "shinyapps.io"), long_name)
+  expect_equal(
+    generateDefaultName("foo/bar.Rmd", server = "shinyapps.io"),
+    "bar"
+  )
+  expect_equal(
+    generateDefaultName("foo/index.html", server = "shinyapps.io"),
+    "foo"
+  )
+  expect_equal(
+    generateDefaultName("foo/bar", server = "shinyapps.io"),
+    "bar"
+  )
+
+  expect_equal(
+    generateDefaultName("foo/Awesome Document.Rmd", server = "shinyapps.io"),
+    "awesome_document"
+  )
+  expect_equal(
+    generateDefaultName("My Report/index.html", server = "shinyapps.io"),
+    "my_report"
+  )
+  expect_equal(
+    generateDefaultName("foo/The-Application", server = "shinyapps.io"),
+    "the-application"
+  )
+
+  long_name <- strrep("AbCd", 64 / 4)
+  even_longer_name <- paste(long_name, "...")
+  expect_equal(
+    generateDefaultName(even_longer_name, server = "shinyapps.io"),
+    tolower(long_name)
+  )
+  expect_equal(
+    generateDefaultName("short-file-path", even_longer_name, server = "shinyapps.io"),
+    tolower(long_name)
+  )
 })
 
 # helpers -----------------------------------------------------------------


### PR DESCRIPTION
~When deploying from a directory named "Incredible Shiny Application", the generated name for Posit Connect is `Incredible_Shiny_Application` and for shinyapps.io is `incredible_shiny_application`. Both services require `a-zA-Z0-9-_` for names, but we lower-case only for shinyapps.io.~

~The name is derived from an incoming title, when available, and otherwise from the content path.~

~When deploying without a title, Connect uses the incoming name to seed the title. This behavior is not changing.~

When deploying from a directory named "Incredible Shiny Application", a generated title mirrors the directory name and name is generated from the title and normalized like `incredible_shiny_application`. 

A generated name is used only when one is not already provided.

Title changes on the server are now reflected in the deployment record.

fixes #1022
related to #1008 