### PR TITLE
add envVars to example in deployApp()

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -198,7 +198,8 @@
 #' # find the Quarto binary
 #' deployApp("~/projects/quarto/site1")
 #'
-#' # deploy application with environment variables (e.g., `SECRET_PASSWORD=XYZ` is set via an ~/.Renviron file)
+#' # deploy application with environment variables
+#' # (e.g., `SECRET_PASSWORD=XYZ` is set via an ~/.Renviron file)
 #' rsconnect::deployApp(envVars = c("SECRET_PASSWORD"))
 #' }
 #' @seealso [applications()], [terminateApp()], and [restartApp()]

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -198,9 +198,8 @@
 #' # find the Quarto binary
 #' deployApp("~/projects/quarto/site1")
 #'
-#' # deploy application with environment variables
-#' Sys.setenv(SECRET = "mytoken")
-#' rsconnect::deployApp(envVars = c("SECRET"))
+#' # deploy application with environment variables (e.g., `SECRET_PASSWORD=XYZ` is set via an ~/.Renviron file)
+#' rsconnect::deployApp(envVars = c("SECRET_PASSWORD"))
 #' }
 #' @seealso [applications()], [terminateApp()], and [restartApp()]
 #' @family Deployment functions

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -197,6 +197,10 @@
 #' # deploy a Quarto website, using the quarto package to
 #' # find the Quarto binary
 #' deployApp("~/projects/quarto/site1")
+#'
+#' # deploy application with environment variables
+#' Sys.setenv(SECRET = "mytoken")
+#' rsconnect::deployApp(envVars = c("SECRET"))
 #' }
 #' @seealso [applications()], [terminateApp()], and [restartApp()]
 #' @family Deployment functions

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -269,9 +269,8 @@ deployApp(launch.browser = FALSE)
 # find the Quarto binary
 deployApp("~/projects/quarto/site1")
 
-# deploy application with environment variables
-Sys.setenv(SECRET = "mytoken")
-rsconnect::deployApp(envVars = c("SECRET"))
+# deploy application with environment variables (e.g., `SECRET_PASSWORD=XYZ` is set via an ~/.Renviron file)
+rsconnect::deployApp(envVars = c("SECRET_PASSWORD"))
 }
 }
 \seealso{

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -269,7 +269,8 @@ deployApp(launch.browser = FALSE)
 # find the Quarto binary
 deployApp("~/projects/quarto/site1")
 
-# deploy application with environment variables (e.g., `SECRET_PASSWORD=XYZ` is set via an ~/.Renviron file)
+# deploy application with environment variables
+# (e.g., `SECRET_PASSWORD=XYZ` is set via an ~/.Renviron file)
 rsconnect::deployApp(envVars = c("SECRET_PASSWORD"))
 }
 }

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -268,6 +268,10 @@ deployApp(launch.browser = FALSE)
 # deploy a Quarto website, using the quarto package to
 # find the Quarto binary
 deployApp("~/projects/quarto/site1")
+
+# deploy application with environment variables
+Sys.setenv(SECRET = "mytoken")
+rsconnect::deployApp(envVars = c("SECRET"))
 }
 }
 \seealso{


### PR DESCRIPTION
Pulls out helpful example from https://github.com/rstudio/rsconnect/issues/859#issuecomment-1600949465

This workflow and messaging was _very_ clear and easy!

Additionally, it'd be helpful to mention `rsconnect` as an option to set env vars _prior_ to deployment in the [Posit Connect User Guide](https://docs.posit.co/connect/user/content-settings/index.html#content-vars), which currently only references the Connect API.

