### PR TITLE
Sys.setlocale returns the updated locale, not the previous one

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rsconnect (development version)
 
+* Restore the `LC_TIME` locale after computing an RFC-2616 date. (#1035)
+
 # rsconnect 1.2.0
 
 * Addressed a number of republishing and collaboration issues where the

--- a/R/http.R
+++ b/R/http.R
@@ -518,10 +518,11 @@ signatureHeaders <- function(authInfo, method, path, file = NULL) {
 
 rfc2616Date <- function(time = Sys.time()) {
   # set locale to POSIX/C to ensure ASCII date
-  old <- Sys.setlocale("LC_TIME", "C")
+  old <- Sys.getlocale("LC_TIME")
+  Sys.setlocale("LC_TIME", "C")
   defer(Sys.setlocale("LC_TIME", old))
 
-  strftime(Sys.time(), "%a, %d %b %Y %H:%M:%S GMT", tz = "GMT")
+  strftime(time, "%a, %d %b %Y %H:%M:%S GMT", tz = "GMT")
 }
 
 # Helpers -----------------------------------------------------------------

--- a/tests/testthat/test-http.R
+++ b/tests/testthat/test-http.R
@@ -177,3 +177,12 @@ test_that("parse and build are symmetric", {
   round_trip("https://google.com:80/a/b")
   round_trip("https://google.com:80/a/b/")
 })
+
+test_that("rcf2616 returns an ASCII date and undoes changes to the locale", {
+  old <- Sys.getlocale("LC_TIME")
+  defer(Sys.setlocale("LC_TIME", old))
+
+  date <- rfc2616Date(time = as.POSIXct("2024-01-01 01:02:03", tz = "EST"))
+  expect_equal(date, "Mon, 01 Jan 2024 06:02:03 GMT")
+  expect_equal(Sys.getlocale("LC_TIME"), old)
+})


### PR DESCRIPTION
As identified by https://github.com/rstudio/rsconnect/commit/972dc8d0b47d72da36bc9149cfc510b495e89457#r137282282.

@Upipa, would you be able to test this change? It closely resembles your suggestion.