### PR TITLE
produce an error when Quarto content cannot be inspected

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
   needed to be quoted. The resulting manifest lacked information about the
   Quarto runtime, which caused difficult-to-understand deployment errors.
   (#1037)
+* Produce an error when Quarto content cannot be inspected. (#1032)
 
 # rsconnect 1.2.0
 

--- a/R/appMetadata-quarto.R
+++ b/R/appMetadata-quarto.R
@@ -55,13 +55,12 @@ quartoInspect <- function(appDir = NULL, appPrimaryDoc = NULL) {
   if (!is.null(status)) {
     cli::cli_abort(
       c(
-        "Unable to run `quarto inspect` against your content:",
+        "Failed to run `quarto inspect` against your content:",
         json
       )
     )
   }
-  parsed <- jsonlite::fromJSON(json)
-  return(parsed)
+  jsonlite::fromJSON(json)
 }
 
 # inlined from quarto::quarto_path()

--- a/tests/testthat/_snaps/appMetadata-quarto.md
+++ b/tests/testthat/_snaps/appMetadata-quarto.md
@@ -7,3 +7,21 @@
       ! `quarto` not found.
       i Check that it is installed and available on your `PATH`.
 
+# quartoInspect produces an error when a document cannot be inspected
+
+    Code
+      quartoInspect(dir, "bad.qmd")
+    Condition
+      Error in `quartoInspect()`:
+      ! Failed to run `quarto inspect` against your content:
+      [91mERROR: Unknown format unsupported[39m
+
+# quartoInspect produces an error when a project cannot be inspected
+
+    Code
+      quartoInspect(dir, "bad.qmd")
+    Condition
+      Error in `quartoInspect()`:
+      ! Failed to run `quarto inspect` against your content:
+      [91mERROR: Unsupported project type unsupported[39m
+

--- a/tests/testthat/_snaps/appMetadata-quarto.md
+++ b/tests/testthat/_snaps/appMetadata-quarto.md
@@ -14,7 +14,7 @@
     Condition
       Error in `quartoInspect()`:
       ! Failed to run `quarto inspect` against your content:
-      [91mERROR: Unknown format unsupported[39m
+      ERROR: Unknown format unsupported
 
 # quartoInspect produces an error when a project cannot be inspected
 
@@ -23,5 +23,5 @@
     Condition
       Error in `quartoInspect()`:
       ! Failed to run `quarto inspect` against your content:
-      [91mERROR: Unsupported project type unsupported[39m
+      ERROR: Unsupported project type unsupported
 

--- a/tests/testthat/test-appMetadata-quarto.R
+++ b/tests/testthat/test-appMetadata-quarto.R
@@ -29,7 +29,7 @@ test_that("inferQuartoInfo correctly detects info when quarto is provided alone"
   expect_equal(quartoInfo$engines, I(c("knitr")))
 })
 
-test_that("inferQuartoInfo extracts info from metadata", {
+test_that("inferQuartoInfo prefers metadata over quarto inspect", {
   metadata <- fakeQuartoMetadata(version = "99.9.9", engines = c("internal-combustion"))
 
   quartoInfo <- inferQuartoInfo(
@@ -43,30 +43,6 @@ test_that("inferQuartoInfo extracts info from metadata", {
   ))
 })
 
-test_that("inferQuartoInfo prefers using metadata over quarto inspect", {
-  skip_if_no_quarto()
-
-  metadata <- fakeQuartoMetadata(version = "99.9.9", engines = c("internal-combustion"))
-
-  quartoInfo <- inferQuartoInfo(
-    appDir = test_path("quarto-website-r"),
-    appPrimaryDoc = NULL,
-    metadata = metadata
-  )
-  expect_equal(quartoInfo$engines, I(c("internal-combustion")))
-})
-
-test_that("inferQuartoInfo returns NULL for non-quarto content", {
-  skip_if_no_quarto()
-
-  quartoInfo <- inferQuartoInfo(
-    appDir = test_path("shinyapp-simple"),
-    appPrimaryDoc = NULL,
-    metadata = list()
-  )
-  expect_null(quartoInfo)
-})
-
 test_that("quartoInspect requires quarto", {
   local_mocked_bindings(quarto_path = function() NULL)
   expect_snapshot(error = TRUE, {
@@ -74,7 +50,7 @@ test_that("quartoInspect requires quarto", {
   })
 })
 
-test_that("quartoInspect identifies on Quarto projects", {
+test_that("quartoInspect identifies Quarto projects", {
   skip_if_no_quarto()
 
   inspect <- quartoInspect(test_path("quarto-website-r"))
@@ -123,9 +99,42 @@ test_that("quartoInspect processes content with filenames containing spaces", {
   expect_equal(inspect$engines, c("markdown"))
 })
 
-test_that("quartoInspect returns NULL on non-quarto Quarto content", {
+test_that("quartoInspect produces an error when a document cannot be inspected", {
   skip_if_no_quarto()
 
-  inspect <- quartoInspect(test_path("shinyapp-simple"))
-  expect_null(inspect)
+  dir <- local_temp_app(list("bad.qmd" = c(
+    "---",
+    "format: unsupported",
+    "---",
+    "this is a document using an unsupported format."
+  )))
+  expect_error(
+    quartoInspect(dir, "bad.qmd"),
+    "Unable to run `quarto inspect` against your content",
+    fixed = TRUE
+  )
+})
+
+test_that("quartoInspect produces an error when a project cannot be inspected", {
+  skip_if_no_quarto()
+
+  dir <- local_temp_app(
+    list(
+      "_quarto.yml" = c(
+        "project:",
+        "  type: unsupported"
+      ),
+      "bad.qmd" = c(
+        "---",
+        "title: bad",
+        "---",
+        "this is a document using an unsupported format."
+      )
+    )
+  )
+  expect_error(
+    quartoInspect(dir, "bad.qmd"),
+    "Unable to run `quarto inspect` against your content",
+    fixed = TRUE
+  )
 })

--- a/tests/testthat/test-appMetadata-quarto.R
+++ b/tests/testthat/test-appMetadata-quarto.R
@@ -114,6 +114,9 @@ strip_quarto_trace <- function(lines) {
 test_that("quartoInspect produces an error when a document cannot be inspected", {
   skip_if_no_quarto()
 
+  # Suppress colors from Quarto errors.
+  withr::local_envvar(NO_COLOR = "1")
+
   dir <- local_temp_app(list("bad.qmd" = c(
     "---",
     "format: unsupported",
@@ -129,6 +132,9 @@ test_that("quartoInspect produces an error when a document cannot be inspected",
 
 test_that("quartoInspect produces an error when a project cannot be inspected", {
   skip_if_no_quarto()
+
+  # Suppress colors from Quarto errors.
+  withr::local_envvar(NO_COLOR = "1")
 
   dir <- local_temp_app(
     list(

--- a/tests/testthat/test-appMetadata-quarto.R
+++ b/tests/testthat/test-appMetadata-quarto.R
@@ -99,6 +99,18 @@ test_that("quartoInspect processes content with filenames containing spaces", {
   expect_equal(inspect$engines, c("markdown"))
 })
 
+# Some versions of Quarto show Quarto stack traces with source references when
+# inspect fails.
+#
+# Only preserve:
+#
+#   Error in `quartoInspect()`:
+#   ! Failed to run `quarto inspect` against your content:
+#   ERROR: Unsupported project type unsupported
+strip_quarto_trace <- function(lines) {
+  head(lines, 3)
+}
+
 test_that("quartoInspect produces an error when a document cannot be inspected", {
   skip_if_no_quarto()
 
@@ -108,10 +120,10 @@ test_that("quartoInspect produces an error when a document cannot be inspected",
     "---",
     "this is a document using an unsupported format."
   )))
-  expect_error(
+  expect_snapshot(
     quartoInspect(dir, "bad.qmd"),
-    "Unable to run `quarto inspect` against your content",
-    fixed = TRUE
+    error = TRUE,
+    transform = strip_quarto_trace
   )
 })
 
@@ -132,9 +144,9 @@ test_that("quartoInspect produces an error when a project cannot be inspected", 
       )
     )
   )
-  expect_error(
+  expect_snapshot(
     quartoInspect(dir, "bad.qmd"),
-    "Unable to run `quarto inspect` against your content",
-    fixed = TRUE
+    error = TRUE,
+    transform = strip_quarto_trace
   )
 })


### PR DESCRIPTION
fixes #1032

Note: Builds upon https://github.com/rstudio/rsconnect/pull/1038.