### PR TITLE
quarto: more flexible discovery

### DIFF
--- a/R/appDependencies.R
+++ b/R/appDependencies.R
@@ -123,7 +123,11 @@ appDependencies <- function(appDir = getwd(),
     ))
   }
 
-  bundleDir <- bundleAppDir(appDir, appFiles)
+  bundleDir <- bundleAppDir(
+    appDir = appDir,
+    appFiles = appFiles,
+    appMode = appMetadata$appMode
+  )
   defer(unlink(bundleDir, recursive = TRUE))
 
   extraPackages <- inferRPackageDependencies(appMetadata)

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -637,7 +637,9 @@ bundleApp <- function(appName,
   bundleDir <- bundleAppDir(
       appDir = appDir,
       appFiles = appFiles,
-      appPrimaryDoc = appMetadata$appPrimaryDoc)
+      appPrimaryDoc = appMetadata$appPrimaryDoc,
+      appMode = appMetadata$appMode
+  )
   defer(unlink(bundleDir, recursive = TRUE))
 
   # generate the manifest and write it into the bundle dir

--- a/R/writeManifest.R
+++ b/R/writeManifest.R
@@ -50,7 +50,8 @@ writeManifest <- function(appDir = getwd(),
   bundleDir <- bundleAppDir(
     appDir = appDir,
     appFiles = appFiles,
-    appPrimaryDoc = appMetadata$appPrimaryDoc
+    appPrimaryDoc = appMetadata$appPrimaryDoc,
+    appMode = appMetadata$appMode
   )
   defer(unlink(bundleDir, recursive = TRUE))
 

--- a/tests/testthat/_snaps/appMetadata.md
+++ b/tests/testthat/_snaps/appMetadata.md
@@ -29,12 +29,30 @@
       inferAppPrimaryDoc(NULL, "a.R", "static")
     Condition
       Error in `inferAppPrimaryDoc()`:
-      ! Failed to determine `appPrimaryDoc`.
+      ! Failed to determine `appPrimaryDoc` for "static" content.
       x No files matching "\\.html?$".
     Code
-      inferAppPrimaryDoc(NULL, "a.R", "rmd-shiny")
+      inferAppPrimaryDoc(NULL, "a.html", "rmd-static")
     Condition
       Error in `inferAppPrimaryDoc()`:
-      ! Failed to determine `appPrimaryDoc`.
-      x No files matching "\\.[Rq]md$".
+      ! Failed to determine `appPrimaryDoc` for "rmd-static" content.
+      x No files matching "\\.rmd$".
+    Code
+      inferAppPrimaryDoc(NULL, "a.html", "rmd-shiny")
+    Condition
+      Error in `inferAppPrimaryDoc()`:
+      ! Failed to determine `appPrimaryDoc` for "rmd-shiny" content.
+      x No files matching "\\.rmd$".
+    Code
+      inferAppPrimaryDoc(NULL, "a.html", "quarto-static")
+    Condition
+      Error in `inferAppPrimaryDoc()`:
+      ! Failed to determine `appPrimaryDoc` for "quarto-static" content.
+      x No files matching "\\.(r|rmd|qmd)".
+    Code
+      inferAppPrimaryDoc(NULL, "a.html", "quarto-shiny")
+    Condition
+      Error in `inferAppPrimaryDoc()`:
+      ! Failed to determine `appPrimaryDoc` for "quarto-shiny" content.
+      x No files matching "\\.(rmd|qmd)".
 

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -116,14 +116,45 @@ test_that("can infer mode for shiny apps", {
   expect_equal(inferAppMode("server.R"), "shiny")
 })
 
-test_that("can infer mode for static quarto and rmd docs", {
+test_that("can infer mode for static rmd", {
   dir <- local_temp_app(list("foo.Rmd" = ""))
   paths <- list.files(dir, full.names = TRUE)
-
   expect_equal(inferAppMode(paths), "rmd-static")
+})
+
+test_that("can infer mode for rmd as static quarto with guidance", {
+  dir <- local_temp_app(list("foo.Rmd" = ""))
+  paths <- list.files(dir, full.names = TRUE)
   expect_equal(inferAppMode(paths, usesQuarto = TRUE), "quarto-static")
+})
+
+test_that("can infer mode for rmd as shiny quarto with guidance", {
   # Static R Markdown treated as rmd-shiny for shinyapps targets
+  dir <- local_temp_app(list("foo.Rmd" = ""))
+  paths <- list.files(dir, full.names = TRUE)
   expect_equal(inferAppMode(paths, isShinyappsServer = TRUE), "rmd-shiny")
+})
+
+test_that("can infer mode for static quarto", {
+  dir <- local_temp_app(list("foo.qmd" = ""))
+  paths <- list.files(dir, full.names = TRUE)
+  expect_equal(inferAppMode(paths), "quarto-static")
+
+  dir <- local_temp_app(list("_quarto.yml" = "", "foo.qmd" = ""))
+  paths <- list.files(dir, full.names = TRUE)
+  expect_equal(inferAppMode(paths), "quarto-static")
+
+  dir <- local_temp_app(list("_quarto.yml" = "", "foo.rmd" = ""))
+  paths <- list.files(dir, full.names = TRUE)
+  expect_equal(inferAppMode(paths), "quarto-static")
+
+  dir <- local_temp_app(list("_quarto.yml" = "", "foo.r" = ""))
+  paths <- list.files(dir, full.names = TRUE)
+  expect_equal(inferAppMode(paths), "quarto-static")
+
+  dir <- local_temp_app(list("foo.r" = ""))
+  paths <- list.files(dir, full.names = TRUE)
+  expect_equal(inferAppMode(paths), "quarto-static")
 })
 
 test_that("can infer mode for shiny rmd docs", {
@@ -218,7 +249,10 @@ test_that("otherwise fails back to first file with matching extensions", {
 test_that("errors if no files with needed extension", {
   expect_snapshot(error = TRUE, {
     inferAppPrimaryDoc(NULL, "a.R", "static")
-    inferAppPrimaryDoc(NULL, "a.R", "rmd-shiny")
+    inferAppPrimaryDoc(NULL, "a.html", "rmd-static")
+    inferAppPrimaryDoc(NULL, "a.html", "rmd-shiny")
+    inferAppPrimaryDoc(NULL, "a.html", "quarto-static")
+    inferAppPrimaryDoc(NULL, "a.html", "quarto-shiny")
   })
 })
 


### PR DESCRIPTION
* script.R with _quarto.yml is identified as quarto-static.
* script.R without _quarto.yml is identified as quarto-static assuming it is not identified as some other content type.
* script.R can be identified as the primary quarto-static document.
* bundling only renames the primary script.R for shiny content.

A rendered script `script.R` might look like:

````r
#' ---
#' title: cats are cats
#' ---

cat("i am a cat\n")
````

It may or may not have an accompanying `_quarto.yml` file. A simple version of the Quarto configuration might look like:

````yaml
project:
    type: default
````

* A directory containing this `script.R` is identified as quarto-static by `rsconnect::writeManifest()` and `rsconnect::deployApp()`.
* A directory containing this `script.R` and `_quarto.yml` is identified as quarto-static by `rsconnect::writeManifest()` and `rsconnect::deployApp()`.

## Other changes

This work also necessitated a change to how we bundle content. In particular, RStudio is able to run and deploy Shiny single-file applications which are contained in files _not_ named `app.R`. For example, if we create a project containing the default Geyser app and save it to `notapp.R` rather than `app.R`, RStudio can deploy that file. It is able to deploy the Shiny application because `notapp.R` is renamed to `app.R` when the content is bundled.

The action taken by RStudio is effectively:

```r
rsconnect::deployApp(appPrimaryDoc = "notapp.R")
```

This forces rsconnect to treat the content as a Shiny application and also forces the rename of `notapp.R` to `app.R`.

Prior to this change, rsconnect would rewrite _any_ `appPrimaryDoc=*.R` to `app.R` regardless of content type. Unfortunately, `appPrimaryDoc` is computed internally and used by Quarto content. Because that primary asset was an R script, bundling renamed it. To avoid this, the rename is now specific to Shiny content.

Test that RStudio can deploy a Shiny application in a `notapp.R` file. Download that deployed bundle and see that the application has been renamed to `app.R`.

Other types of content (e.g., Plumber APIs, Quarto rendered scripts) do not have their R scripts renamed when deployed.