### PR TITLE
Add access to URL on deploy

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -686,7 +686,8 @@ openURL <- function(client, application, launch.browser, on.failure, deploymentS
   # Check to see if we should open config url or app url
   if (!is.null(client$configureApplication)) {
     config <- client$configureApplication(application$id)
-    url <- config$config_url
+    # Direct the publisher to the access pane to share
+    url <- paste0(config$config_url, "/access")
     if (!deploymentSucceeded && validURL(config$logs_url)) {
       # With 1.5.5+, Connect application configuration includes
       # a logs URL to be shown on unsuccessful deployment.


### PR DESCRIPTION
Adds `/access` to the URL at the end of a successful deployment so that the person publishing has easy access to sharing what they just published.

There is one open question if doing this in the publishers versus changing the API. If we do this in the client I'll open a matching PR to `rsconnect-python` as well.