### PR TITLE
tasks() and taskLog() are only for shinyapps.io and posit.cloud

### DIFF
--- a/R/client-connect.R
+++ b/R/client-connect.R
@@ -102,23 +102,6 @@ connectClient <- function(service, authInfo) {
       GET(service, authInfo, paste0("/applications/", applicationId))
     },
 
-    ## Tasks API
-
-    listTasks = function() {
-      path <- "/tasks"
-      GET(service, authInfo, path)
-    },
-
-    getTask = function(taskId) {
-      path <- file.path("/tasks", taskId)
-      GET(service, authInfo, path)
-    },
-
-    killTask = function(taskId) {
-      path <- file.path("/tasks", taskId, "kill")
-      POST_JSON(service, authInfo, path, list())
-    },
-
     waitForTask = function(taskId, quiet = FALSE) {
       start <- 0
       while (TRUE) {

--- a/R/tasks.R
+++ b/R/tasks.R
@@ -18,11 +18,14 @@
 #'
 #' }
 #' @seealso [taskLog()]
+#' @note This function works only with shinyapps.io and posit.cloud.
 #' @export
 tasks <- function(account = NULL, server = NULL) {
 
   # resolve account and create connect client
   accountDetails <- accountInfo(account, server)
+  checkCloudServer(accountDetails$server)
+
   client <- clientForAccount(accountDetails)
 
   # list tasks
@@ -55,10 +58,13 @@ tasks <- function(account = NULL, server = NULL) {
 #'
 #' }
 #' @seealso [tasks()]
+#' @note This function works only with shinyapps.io and posit.cloud.
 #' @export
 taskLog <- function(taskId, account = NULL, server = NULL, output = NULL) {
 
   accountDetails <- accountInfo(account, server)
+  checkCloudServer(accountDetails$server)
+
   client <- clientForAccount(accountDetails)
 
   if (identical(output, "stderr")) {

--- a/man/taskLog.Rd
+++ b/man/taskLog.Rd
@@ -20,6 +20,9 @@ Use \code{\link[=accounts]{accounts()}} to see the full list of available option
 \description{
 Writes the task log for the given task
 }
+\note{
+This function works only with shinyapps.io and posit.cloud.
+}
 \examples{
 \dontrun{
 

--- a/man/tasks.Rd
+++ b/man/tasks.Rd
@@ -26,6 +26,9 @@ Returns a data frame with the following columns:
 \description{
 List Tasks
 }
+\note{
+This function works only with shinyapps.io and posit.cloud.
+}
 \examples{
 \dontrun{
 


### PR DESCRIPTION
While auditing the Connect APIs used by rsconnect, noticed that some paths are not APIs, which led to this change.

* trim listTasks() and killTask() from the Connect client - non-APIs
* trim getTask() from the Connect client - waitForTask is used