### PR TITLE
connect: use the public /v1/tasks/{id} endpoint

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rsconnect (development version)
 
+* Use the public Connect server API endpoint `/v1/tasks/{id}` to poll task
+  progress. (#1088)
+
 # rsconnect 1.3.1
 
 * Skip tests when packages "foreign" and "MASS" are not available. (#1081)

--- a/R/client-connect.R
+++ b/R/client-connect.R
@@ -103,14 +103,18 @@ connectClient <- function(service, authInfo) {
     },
 
     waitForTask = function(taskId, quiet = FALSE) {
-      start <- 0
+      first <- 0
+      wait <- 1
       while (TRUE) {
-        path <- paste0(file.path("/tasks", taskId), "?first_status=", start)
+        path <- paste0(
+          "/v1/tasks/", taskId,
+          "?first=", first,
+          "&wait=", wait)
         response <- GET(service, authInfo, path)
 
-        if (length(response$status) > 0) {
+        if (length(response$output) > 0) {
           if (!quiet) {
-            messages <- unlist(response$status)
+            messages <- unlist(response$output)
             messages <- stripConnectTimestamps(messages)
 
             # Made headers more prominent.
@@ -119,13 +123,12 @@ connectClient <- function(service, authInfo) {
             cat(paste0(messages, "\n", collapse = ""))
           }
 
-          start <- response$last_status
+          first <- response$last
         }
 
         if (length(response$finished) > 0 && response$finished) {
           return(response)
         }
-        Sys.sleep(1)
       }
     },
 

--- a/tests/testthat/test-client-connect.R
+++ b/tests/testthat/test-client-connect.R
@@ -37,12 +37,12 @@ test_that("waitForTask", {
 
   task_app <- webfakes::new_app()
   task_app$use(webfakes::mw_json())
-  task_app$get("/tasks/:id", function(req, res) {
+  task_app$get("/v1/tasks/:id", function(req, res) {
     res$set_status(200L)$send_json(
       list(
         id = I(req$params$id),
         user_id = I(42),
-        status = c(
+        output = c(
           "2024/04/24 13:08:04.901698921 [rsc-session] Content GUID: 3bfbd98a-6d6d-41bd-a15f-cab52025742f",
           "2024/04/24 13:08:04.901734307 [rsc-session] Content ID: 43888",
           "2024/04/24 13:08:04.901742487 [rsc-session] Bundle ID: 94502",
@@ -52,7 +52,7 @@ test_that("waitForTask", {
         finished = TRUE,
         code = 0,
         error = "",
-        last_status = 4
+        last = 4
       ), auto_unbox = TRUE
     )
   })


### PR DESCRIPTION
Adjusts request/response fields and uses "wait" for long-polling rather than client-side sleep.

fixes #1088