### PR TITLE
Feature/add deployment timestamp

### DIFF
--- a/R/deployments.R
+++ b/R/deployments.R
@@ -132,7 +132,7 @@ deploymentRecord <- function(name,
                              bundleId = NULL,
                              url = NULL,
                              version = deploymentRecordVersion,
-                             timestamp = NULL,
+                             when = NULL,
                              metadata = list()) {
 
   check_character(envVars, allow_null = TRUE)
@@ -148,7 +148,7 @@ deploymentRecord <- function(name,
     appId = appId %||% "",
     bundleId = bundleId %||% "",
     url = url %||% "",
-    timestamp = timestamp %||% format(as.numeric(as.POSIXct(Sys.time())) * 1000, scientific = FALSE),
+    when = when %||% as.numeric(as.POSIXct(Sys.time())),
     version = version
   )
   # convert any multi-value metadata entries into comma-separated values
@@ -166,7 +166,7 @@ writeDeploymentRecord <- function(record, filePath) {
 addToDeploymentHistory <- function(appPath, deploymentRecord) {
   # add the appPath to the deploymentRecord
   deploymentRecord$appPath <- appPath
-  deploymentRecord$timestamp <- format(as.numeric(as.POSIXct(Sys.time())) * 1000, scientific = FALSE)
+  deploymentRecord$when <- as.numeric(as.POSIXct(Sys.time()))
 
   # write new history file
   newHistory <- deploymentHistoryPath(new = TRUE)

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -132,6 +132,7 @@ deploymentRecord <- function(name,
                              bundleId = NULL,
                              url = NULL,
                              version = deploymentRecordVersion,
+                             timestamp = NULL,
                              metadata = list()) {
 
   check_character(envVars, allow_null = TRUE)
@@ -147,6 +148,7 @@ deploymentRecord <- function(name,
     appId = appId %||% "",
     bundleId = bundleId %||% "",
     url = url %||% "",
+    timestamp = timestamp %||% format(as.numeric(as.POSIXct(Sys.time())) * 1000, scientific = FALSE),
     version = version
   )
   # convert any multi-value metadata entries into comma-separated values
@@ -164,6 +166,7 @@ writeDeploymentRecord <- function(record, filePath) {
 addToDeploymentHistory <- function(appPath, deploymentRecord) {
   # add the appPath to the deploymentRecord
   deploymentRecord$appPath <- appPath
+  deploymentRecord$timestamp <- format(as.numeric(as.POSIXct(Sys.time())) * 1000, scientific = FALSE)
 
   # write new history file
   newHistory <- deploymentHistoryPath(new = TRUE)


### PR DESCRIPTION
See: https://github.com/rstudio/rstudio-pro/issues/5597

We have this provisioning on the Workbench homepage to display the timestamp (unix epoch in seconds) for when you recently published something via rsconnect. For whatever reason, there are no timestamps added to the history entries in the `history.dcf` file that Workbench reads. This fixes that missing timestamp without requiring any changes on the Workbench side.

![image](https://github.com/user-attachments/assets/73b6be93-c031-484a-b247-78e4a469c41d)
