### PR TITLE
bugfix: .R, .Rmd, .qmd are extensions, not substrings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rsconnect (development version)
 
+* Primary Quarto document detection only considers `.R`, `.Rmd`, and `.qmd` as
+  end-of-file extensions. Previously, a file with `.R` elsewhere in its name,
+  such as `.Rprofile`, was incorrectly considered. (#1106)
+
 * Use the public Connect server API endpoint `/v1/tasks/{id}` to poll task
   progress. (#1088)
 

--- a/R/appMetadata.R
+++ b/R/appMetadata.R
@@ -267,8 +267,8 @@ inferAppPrimaryDoc <- function(appPrimaryDoc, appFiles, appMode) {
   # determine expected primary document extension
   ext <- switch(appMode,
                 "static"        = "\\.html?$",
-                "quarto-static" = "\\.(r|rmd|qmd)",
-                "quarto-shiny"  = "\\.(rmd|qmd)",
+                "quarto-static" = "\\.(r|rmd|qmd)$",
+                "quarto-shiny"  = "\\.(rmd|qmd)$",
                 "\\.rmd$")
 
   # use index file if it exists

--- a/rsconnect.Rproj
+++ b/rsconnect.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 3d8f30a6-9562-4255-8985-ba9413556e97
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/tests/testthat/_snaps/appMetadata.md
+++ b/tests/testthat/_snaps/appMetadata.md
@@ -48,11 +48,11 @@
     Condition
       Error in `inferAppPrimaryDoc()`:
       ! Failed to determine `appPrimaryDoc` for "quarto-static" content.
-      x No files matching "\\.(r|rmd|qmd)".
+      x No files matching "\\.(r|rmd|qmd)$".
     Code
       inferAppPrimaryDoc(NULL, "a.html", "quarto-shiny")
     Condition
       Error in `inferAppPrimaryDoc()`:
       ! Failed to determine `appPrimaryDoc` for "quarto-shiny" content.
-      x No files matching "\\.(rmd|qmd)".
+      x No files matching "\\.(rmd|qmd)$".
 

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -263,9 +263,20 @@ test_that("uses index file if present", {
 })
 
 test_that("otherwise fails back to first file with matching extensions", {
-  files <- c("a.html", "b.html", "a.Rmd", "b.Rmd")
+  files <- c(".Rprofile", "a.html", "b.html", "a.Rmd", "b.Rmd")
   expect_equal(inferAppPrimaryDoc(NULL, files, "static"), "a.html")
+  expect_equal(inferAppPrimaryDoc(NULL, files, "rmd-static"), "a.Rmd")
   expect_equal(inferAppPrimaryDoc(NULL, files, "rmd-shiny"), "a.Rmd")
+  expect_equal(inferAppPrimaryDoc(NULL, files, "quarto-static"), "a.Rmd")
+  expect_equal(inferAppPrimaryDoc(NULL, files, "quarto-shiny"), "a.Rmd")
+})
+
+test_that("can use R, Rmd, and qmd files for Quarto modes", {
+  expect_equal(inferAppPrimaryDoc(NULL, c(".Rprofile", "foo.R"), "quarto-static"), "foo.R")
+  expect_equal(inferAppPrimaryDoc(NULL, c(".Rprofile", "foo.Rmd"), "quarto-static"), "foo.Rmd")
+  expect_equal(inferAppPrimaryDoc(NULL, c(".Rprofile", "foo.qmd"), "quarto-static"), "foo.qmd")
+  expect_equal(inferAppPrimaryDoc(NULL, c(".Rprofile", "foo.Rmd"), "quarto-shiny"), "foo.Rmd")
+  expect_equal(inferAppPrimaryDoc(NULL, c(".Rprofile", "foo.qmd"), "quarto-shiny"), "foo.qmd")
 })
 
 test_that("errors if no files with needed extension", {


### PR DESCRIPTION
Consider files with .R, .Rmd, and .qmd as extensions when detecting the primary document.

fixes #1106