### PR TITLE
inherit original repository when one cannot be identified

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
   end-of-file extensions. Previously, a file with `.R` elsewhere in its name,
   such as `.Rprofile`, was incorrectly considered. (#1106)
 
+* Use the repository name identified by renv when `available.packages()` does
+  not enumerate the package, which occurs for archived packages. (#1110)
+
 * Remove remaining directory layout validation check. (#1102)
 
 * Use the public Connect server API endpoint `/v1/tasks/{id}` to poll task

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -108,8 +108,15 @@ standardizeRenvPackage <- function(pkg,
     } else {
       # $Repository comes from DESCRIPTION and is set by repo, so can be
       # anything. So we must look up from the package name
+      originalRepository <- pkg$Repository
       pkg$Repository <- findRepoUrl(pkg$Package, availablePackages)
       pkg$Source <- findRepoName(pkg$Repository, repos)
+      if (is.na(pkg$Source)) {
+        # Archived packages are not publicized by available.packages(). Use
+        # the renv.lock repository as source, expecting that the package is
+        # available through one of the repository URLs.
+        pkg$Source <- originalRepository
+      }
     }
   } else if (pkg$Source == "Bioconductor") {
     pkg$Repository <- findRepoUrl(pkg$Package, availablePackages)


### PR DESCRIPTION
If renv identifies that a package comes from a repository, retain that fact even if we cannot identify which repository. This helps archived packages (`rgdal`), which are not enumerated by `available.package()`.

fixes #1110