### PR TITLE
cran: use America/New_York rather than EST

### DIFF
--- a/tests/testthat/test-http.R
+++ b/tests/testthat/test-http.R
@@ -238,7 +238,7 @@ test_that("rcf2616 returns an ASCII date and undoes changes to the locale", {
   old <- Sys.getlocale("LC_TIME")
   defer(Sys.setlocale("LC_TIME", old))
 
-  date <- rfc2616Date(time = as.POSIXct("2024-01-01 01:02:03", tz = "EST"))
+  date <- rfc2616Date(time = as.POSIXct("2024-01-01 01:02:03", tz = "America/New_York"))
   expect_equal(date, "Mon, 01 Jan 2024 06:02:03 GMT")
   expect_equal(Sys.getlocale("LC_TIME"), old)
 })


### PR DESCRIPTION
From https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/rsconnect-00check.html

```
  ── Failure ('test-http.R:242:3'): rcf2616 returns an ASCII date and undoes changes to the locale ──
  `date` (`actual`) not equal to "Mon, 01 Jan 2024 06:02:03 GMT" (`expected`).
  
  `actual`:   "Mon, 01 Jan 2024 01:02:03 GMT"
  `expected`: "Mon, 01 Jan 2024 06:02:03 GMT"
  
  [ FAIL 1 | WARN 0 | SKIP 156 | PASS 619 ]
  Error: Test failures
```

These test failures are because debian is updating to tzdata 2024b, which moved names like "EST" into its "legacy" bundle.

https://packages.debian.org/unstable/tzdata
https://packages.debian.org/unstable/tzdata-legacy
