### PR TITLE
use base64 encoded secrets in test to avoid base64 errors with new libssl

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rsconnect (development version)
 
+* Use base64 encoded test data. Addresses CRAN test failures when run with
+  newer libssl. (#1130)
+
 # rsconnect 1.3.3
 
 * Avoid "legacy" time zone names in tests, as they are not available by

--- a/tests/testthat/_snaps/http.md
+++ b/tests/testthat/_snaps/http.md
@@ -11,11 +11,11 @@
 # authHeaders() picks correct method based on supplied fields
 
     Code
-      str(authHeaders(list(secret = "123"), url, "GET"))
+      str(authHeaders(list(secret = openssl::base64_encode("123")), url, "GET"))
     Output
       List of 3
        $ Date              : chr "Thu, 09 Mar 2023 14:29:00 GMT"
-       $ X-Auth-Signature  : chr "YmJiMjM1Y2E5MjFlNGFkOTMxZjQxNzU4NGQ1ZTk3MzYyYzg1YjcyMzUyMzhlYTY4Y2UxMjI1MzJkZWE1MDA3NQ==; version=1"
+       $ X-Auth-Signature  : chr "ZmQwNjkxNGVmZmZiN2FjNzkzZTkwYzE4OTg1Y2M5NTIxNGZjNTcxY2I5M2RhYzFiNWIxODY5NjFjODMzYjE3ZA==; version=1"
        $ X-Content-Checksum: chr "d41d8cd98f00b204e9800998ecf8427e"
     Code
       str(authHeaders(list(private_key = key), url, "GET"))

--- a/tests/testthat/test-client-cloud.R
+++ b/tests/testthat/test-client-cloud.R
@@ -120,7 +120,7 @@ configureTestAccount <- function(server = "posit.cloud", name = NULL) {
     setAccountInfo(
       name = name,
       token = "foo",
-      secret = "bar",
+      secret = openssl::base64_encode("bar"),
       server = server
     )
   }

--- a/tests/testthat/test-http.R
+++ b/tests/testthat/test-http.R
@@ -54,7 +54,7 @@ a3hEFijsjg/+FDMr+iAVzjry
   key <- openssl::base64_encode(openssl::read_key(key_string))
 
   expect_snapshot({
-    str(authHeaders(list(secret = "123"), url, "GET"))
+    str(authHeaders(list(secret = openssl::base64_encode("123")), url, "GET"))
     str(authHeaders(list(private_key = key), url, "GET"))
   })
 


### PR DESCRIPTION
Simple strings cannot be used as base64 encoded input. Encode values used downstream to construct auth headers.

```r
openssl::base64_decode("bar")
#> raw(0)
openssl::base64_decode("123")
#> raw(0)
```

fixes #1130