### PR TITLE
isDocumentPath no longer treats directories as documents

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rsconnect (development version)
 
+* Content directories with a period in their name are no longer treated as a
+  document path when computing the location for deployment records. (#1138)
+
 # rsconnect 1.3.4
 
 * Use base64 encoded test data. Addresses CRAN test failures when run with

--- a/R/config.R
+++ b/R/config.R
@@ -131,6 +131,10 @@ deploymentConfigFiles <- function(recordPath) {
 }
 
 # Does the path point to an individual piece of content?
-isDocumentPath <- function(path) {
-  tools::file_ext(path) != ""
+isDocumentPath <- function(recordPath) {
+  # deployDoc and deployApp have already decided if the record path corresponds to a file
+  # (single-file document deploys) or a directory (all other content).
+  #
+  # The record path is a document path whenever it is not a directory.
+  !dir.exists(recordPath)
 }

--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -315,32 +315,6 @@ updateDeployment <- function(previous, appTitle = NULL, envVars = NULL) {
   )
 }
 
-defaultAppName <- function(recordPath, server = NULL) {
-  if (isDocumentPath(recordPath)) {
-    name <- file_path_sans_ext(basename(recordPath))
-    if (name == "index") {
-      # parent directory will give more informative name
-      name <- basename(dirname(recordPath))
-    } else {
-      # deploying a document
-    }
-  } else {
-    # deploying a directory
-    name <- basename(recordPath)
-  }
-
-  if (isShinyappsServer(server)) {
-    # Replace non-alphanumerics with underscores, trim to length 64
-    name <- tolower(gsub("[^[:alnum:]_-]+", "_", name, perl = TRUE))
-    name <- gsub("_+", "_", name)
-    if (nchar(name) > 64) {
-      name <- substr(name, 1, 64)
-    }
-  }
-
-  name
-}
-
 shouldUpdateApp <- function(application,
                             uniqueName,
                             forceUpdate = FALSE,

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -55,7 +55,11 @@ local_temp_app <- function(files = list(), env = caller_env()) {
     if (!hier == ".") {
       dir.create(file.path(dir, hier), recursive = TRUE)
     }
-    writeLines(content, file.path(dir, name))
+    if (length(content) > 0) {
+      writeLines(content, file.path(dir, name))
+    } else {
+      file.create(file.path(dir, name))
+    }
   }
 
   dir

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -22,3 +22,13 @@ test_that("account file containing pattern characters found with server name", {
   dir <- accountConfigFile("hatter+mad@example.com", server = "complex")
   expect_equal(dir, expected)
 })
+
+test_that("isDocumentPath", {
+  stuff <- local_temp_app(list(
+    "shiny.app/app.R" = c(),
+    "doc/research.Rmd" = c()
+  ))
+  expect_false(isDocumentPath(file.path(stuff, "shiny.app")))
+  expect_false(isDocumentPath(file.path(stuff, "doc")))
+  expect_true(isDocumentPath(file.path(stuff, "doc/research.Rmd")))
+})

--- a/tests/testthat/test-deploymentTarget.R
+++ b/tests/testthat/test-deploymentTarget.R
@@ -435,23 +435,6 @@ test_that("can find existing application on shinyapps.io & not use it", {
   confirm_existing_app_not_used("shinyapps.io")
 })
 
-# defaultAppName ----------------------------------------------------------
-
-test_that("defaultAppName works with sites, documents, and directories", {
-  expect_equal(defaultAppName("foo/bar.Rmd"), "bar")
-  expect_equal(defaultAppName("foo/index.html"), "foo")
-  expect_equal(defaultAppName("foo/bar"), "bar")
-})
-
-test_that("defaultAppName reifies appNames for shinyApps", {
-  expect_equal(defaultAppName("a b c", "shinyapps.io"), "a_b_c")
-  expect_equal(defaultAppName("a!b!c", "shinyapps.io"), "a_b_c")
-  expect_equal(defaultAppName("a  b  c", "shinyapps.io"), "a_b_c")
-
-  long_name <- strrep("abcd", 64 / 4)
-  expect_equal(defaultAppName(paste(long_name, "..."), "shinyapps.io"), long_name)
-})
-
 # helpers -----------------------------------------------------------------
 
 test_that("shouldUpdateApp errors when non-interactive", {


### PR DESCRIPTION
Additionally, remove the uncalled defaultAppName, which removes one use of isDocumentPath.

fixes #1138