### PR TITLE
Add support for _server.yml

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * Content directories with a period in their name are no longer treated as a
   document path when computing the location for deployment records. (#1138)
 
+* A `_server.yml` file indicates that the content is an API. (#1144)
+
 # rsconnect 1.3.4
 
 * Use base64 encoded test data. Addresses CRAN test failures when run with

--- a/R/appMetadata.R
+++ b/R/appMetadata.R
@@ -105,6 +105,12 @@ inferAppMode <- function(
     return("api")
   }
 
+  # general API
+  server_yml <- matchingNames(absoluteRootFiles, "^_server.yml$")
+  if (length(server_yml) > 0) {
+    return("api")
+  }
+
   # Shiny application using single-file app.R style.
   appR <- matchingNames(absoluteRootFiles, "^app.r$")
   if (length(appR) > 0) {

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -79,6 +79,12 @@ test_that("can infer mode for API with entrypoint.R", {
   expect_equal(inferAppMode(dir, paths), "api")
 })
 
+test_that("can infer mode for API with _server.yml", {
+  dir <- local_temp_app(list("_server.yml" = ""))
+  paths <- list.files(dir)
+  expect_equal(inferAppMode(dir, paths), "api")
+})
+
 test_that("can infer mode for shiny apps with app.R", {
   dir <- local_temp_app(list("app.R" = ""))
   paths <- list.files(dir)


### PR DESCRIPTION
This small PR adds support for recognising the existence of `_server.yml` as a signal that the project is an API type

I believe this is all that is needed but if I have missed anything please let me know