### PR TITLE
require an executable engine when quarto doc indicates a server

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 
 * A `_server.yml` file indicates that the content is an API. (#1144)
 
+* Quarto documents which specify a server must include executable code or an
+  engine declaration. (#1145)
+
 # rsconnect 1.3.4
 
 * Use base64 encoded test data. Addresses CRAN test failures when run with

--- a/R/appMetadata.R
+++ b/R/appMetadata.R
@@ -67,6 +67,14 @@ appMetadata <- function(appDir,
       appDir = appDir,
       appPrimaryDoc = appPrimaryDoc
     )
+    if (appMode == "quarto-shiny") {
+      if (!"knitr" %in% quartoInfo[["engines"]]) {
+        cli::cli_abort(c(
+          "The Quarto document requires a server but does not use an executable engine.",
+          "Consider including some executable code, specifying an engine, or removing the server configuration."
+        ))
+      }
+    }
   } else {
     quartoInfo <- NULL
   }

--- a/R/appMetadata.R
+++ b/R/appMetadata.R
@@ -68,7 +68,7 @@ appMetadata <- function(appDir,
       appPrimaryDoc = appPrimaryDoc
     )
     if (appMode == "quarto-shiny") {
-      if (!"knitr" %in% quartoInfo[["engines"]]) {
+      if (!any(c("knitr", "jupyter") %in% quartoInfo[["engines"]])) {
         cli::cli_abort(c(
           "The Quarto document requires a server but does not use an executable engine.",
           "Consider including some executable code, specifying an engine, or removing the server configuration."

--- a/tests/testthat/_snaps/appMetadata.md
+++ b/tests/testthat/_snaps/appMetadata.md
@@ -15,6 +15,15 @@
       Error in `appMetadata()`:
       ! `quarto` must be `TRUE`, `FALSE`, or `NA`, not the number 1.
 
+# Shiny Quarto without an appropriate engine is an error
+
+    Code
+      appMetadata(dir, files)
+    Condition
+      Error in `appMetadata()`:
+      ! The Quarto document requires a server but does not use an executable engine.
+      Consider including some executable code, specifying an engine, or removing the server configuration.
+
 # errors if no files with needed extension
 
     Code

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -73,6 +73,28 @@ test_that("Shiny Quarto without an appropriate engine is an error", {
   expect_snapshot(appMetadata(dir, files), error = TRUE)
 })
 
+test_that("Shiny Quarto with the knitr engine is OK", {
+  skip_on_cran()
+
+  dir <- local_temp_app(list(
+    "index.qmd" = c("---", "server: shiny", "engine: knitr", "---"))
+  )
+  files <- list.files(dir)
+  metadata <- appMetadata(dir, files)
+  expect_contains(metadata$quartoInfo$engines, "knitr")
+})
+
+test_that("Shiny Quarto with the jupyter engine is OK", {
+  skip_on_cran()
+
+  dir <- local_temp_app(list(
+    "index.qmd" = c("---", "server: shiny", "engine: jupyter", "---"))
+  )
+  files <- list.files(dir)
+  metadata <- appMetadata(dir, files)
+  expect_contains(metadata$quartoInfo$engines, "jupyter")
+})
+
 
 # checkLayout -------------------------------------------------------------
 

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -63,6 +63,17 @@ test_that("content type (appMode) is inferred and can be overridden", {
   expect_equal(metadata$appMode, "static")
 })
 
+test_that("Shiny Quarto without an appropriate engine is an error", {
+  skip_on_cran()
+
+  dir <- local_temp_app(list(
+    "index.qmd" = c("---", "server: shiny", "---"))
+  )
+  files <- list.files(dir)
+  expect_snapshot(appMetadata(dir, files), error = TRUE)
+})
+
+
 # checkLayout -------------------------------------------------------------
 
 # inferAppMode ------------------------------------------------------------
@@ -168,7 +179,11 @@ test_that("can infer mode for shiny rmd docs", {
 
 test_that("can infer mode for shiny qmd docs", {
   yaml_runtime <- function(runtime) {
-    c("---", paste0("runtime: ", runtime), "---")
+    c(
+      "---",
+      paste0("runtime: ", runtime),
+      paste0("engine: knitr"),
+      "---")
   }
 
   dir <- local_temp_app(list("index.Qmd" = yaml_runtime("shiny")))


### PR DESCRIPTION
@toph-allen - this error handling feels like it's in an arbitrary location; any opinions about its placement?

fixes #1145