### PR TITLE
expand certificate paths, as curl does not like tilde

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 * Quarto documents which specify a server must include executable code or an
   engine declaration. (#1145)
 
+* Expand tilde when resolving the `rsconnect.ca.bundle` option. (#1152)
+
 # rsconnect 1.3.4
 
 * Use base64 encoded test data. Addresses CRAN test failures when run with

--- a/R/certificates.R
+++ b/R/certificates.R
@@ -16,7 +16,7 @@ createCertificateFile <- function(certificate) {
   # start by checking for a cert file specified in an environment variable
   if (!is.null(systemStore) && nzchar(systemStore)) {
     if (file.exists(systemStore)) {
-      certificateFile <- systemStore
+      certificateFile <- path.expand(systemStore)
     } else {
       warning("The certificate store '", systemStore, "' specified in the ",
               if (identical(systemStore, getOption("rsconnect.ca.bundle")))


### PR DESCRIPTION
This lets RStudio configure publishing when using a Connect development environment having a local CA.

fixes #1152