### PR TITLE
air: formatting

### DIFF
--- a/.github/workflows/format-suggest.yaml
+++ b/.github/workflows/format-suggest.yaml
@@ -1,0 +1,29 @@
+# Workflow derived from https://github.com/posit-dev/setup-air/tree/main/examples
+on:
+  pull_request:
+
+name: format-suggest.yaml
+
+permissions: read-all
+
+jobs:
+  format-suggest:
+    name: format-suggest
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install
+        uses: posit-dev/setup-air@v1
+
+      - name: Format
+        run: air format .
+
+      - name: Suggest
+        uses: reviewdog/action-suggester@v1
+        with:
+          level: error
+          fail_level: error
+          tool_name: air

--- a/R/account-find.R
+++ b/R/account-find.R
@@ -26,11 +26,8 @@ findAccount <- function(
   }
 
   if (!is.null(accountName) && !is.null(server)) {
-    theseAccounts <- accounts[
-      accounts$server == server & accounts$name == accountName,
-      ,
-      drop = FALSE
-    ]
+    selected <- accounts$server == server & accounts$name == accountName
+    theseAccounts <- accounts[selected, , drop = FALSE]
     if (nrow(theseAccounts) == 0) {
       cli::cli_abort(
         c(
@@ -41,7 +38,8 @@ findAccount <- function(
       )
     }
   } else if (is.null(accountName) && !is.null(server)) {
-    theseAccounts <- accounts[accounts$server == server, , drop = FALSE]
+    selected <- accounts$server == server
+    theseAccounts <- accounts[selected, , drop = FALSE]
     if (nrow(theseAccounts) == 0) {
       cli::cli_abort(
         c(
@@ -61,7 +59,8 @@ findAccount <- function(
       )
     }
   } else if (!is.null(accountName) && is.null(server)) {
-    theseAccounts <- accounts[accounts$name == accountName, , drop = FALSE]
+    selected <- accounts$name == accountName
+    theseAccounts <- accounts[selected, , drop = FALSE]
     if (nrow(theseAccounts) == 0) {
       cli::cli_abort(
         c(

--- a/R/account-find.R
+++ b/R/account-find.R
@@ -1,8 +1,17 @@
 # Return a list containing the name and server associated with a matching account.
 #
 # Use `accountInfo()` and `findAccountInfo()` to load credentials associated with this account.
-findAccount <- function(accountName = NULL, server = NULL, error_call = caller_env()) {
-  check_string(accountName, allow_null = TRUE, arg = "account", call = error_call)
+findAccount <- function(
+  accountName = NULL,
+  server = NULL,
+  error_call = caller_env()
+) {
+  check_string(
+    accountName,
+    allow_null = TRUE,
+    arg = "account",
+    call = error_call
+  )
   check_string(server, allow_null = TRUE, call = error_call)
 
   accounts <- accounts()
@@ -17,7 +26,11 @@ findAccount <- function(accountName = NULL, server = NULL, error_call = caller_e
   }
 
   if (!is.null(accountName) && !is.null(server)) {
-    theseAccounts <- accounts[accounts$server == server & accounts$name == accountName, , drop = FALSE]
+    theseAccounts <- accounts[
+      accounts$server == server & accounts$name == accountName,
+      ,
+      drop = FALSE
+    ]
     if (nrow(theseAccounts) == 0) {
       cli::cli_abort(
         c(
@@ -91,7 +104,6 @@ findAccount <- function(accountName = NULL, server = NULL, error_call = caller_e
         )
       }
     }
-
   }
   as.list(theseAccounts)
 }

--- a/R/accounts.R
+++ b/R/accounts.R
@@ -54,7 +54,12 @@ accounts <- function(server = NULL) {
 #'   account.
 #' @family Account functions
 #' @export
-connectApiUser <- function(account = NULL, server = NULL, apiKey, quiet = FALSE) {
+connectApiUser <- function(
+  account = NULL,
+  server = NULL,
+  apiKey,
+  quiet = FALSE
+) {
   server <- findServer(server)
   user <- getAuthedUser(server, apiKey = apiKey)
 
@@ -87,7 +92,12 @@ connectApiUser <- function(account = NULL, server = NULL, apiKey, quiet = FALSE)
 #' @param snowflakeConnectionName Name for the Snowflake connection parameters
 #'   stored in `connections.toml`.
 #' @export
-connectSPCSUser <- function(account = NULL, server = NULL, snowflakeConnectionName, quiet = FALSE) {
+connectSPCSUser <- function(
+  account = NULL,
+  server = NULL,
+  snowflakeConnectionName,
+  quiet = FALSE
+) {
   server <- findServer(server)
   user <- getSPCSAuthedUser(server, snowflakeConnectionName)
 
@@ -107,11 +117,13 @@ connectSPCSUser <- function(account = NULL, server = NULL, snowflakeConnectionNa
 }
 
 getSPCSAuthedUser <- function(server, snowflakeConnectionName) {
-
   serverAddress <- serverInfo(server)
   account <- list(
     server = server,
-    snowflakeToken = getSnowflakeAuthToken(serverAddress$url, snowflakeConnectionName)
+    snowflakeToken = getSnowflakeAuthToken(
+      serverAddress$url,
+      snowflakeConnectionName
+    )
   )
 
   client <- clientForAccount(account)
@@ -120,10 +132,12 @@ getSPCSAuthedUser <- function(server, snowflakeConnectionName) {
 
 #' @rdname connectApiUser
 #' @export
-connectUser <- function(account = NULL,
-                        server = NULL,
-                        quiet = FALSE,
-                        launch.browser = getOption("rsconnect.launch.browser", interactive())) {
+connectUser <- function(
+  account = NULL,
+  server = NULL,
+  quiet = FALSE,
+  launch.browser = getOption("rsconnect.launch.browser", interactive())
+) {
   server <- findServer(server)
   resp <- getAuthTokenAndUser(server, launch.browser)
 
@@ -145,16 +159,20 @@ connectUser <- function(account = NULL,
 getAuthTokenAndUser <- function(server, launch.browser = TRUE) {
   token <- getAuthToken(server)
 
-  if (isTRUE(launch.browser))
-    utils::browseURL(token$claim_url)
-  else if (is.function(launch.browser))
+  if (isTRUE(launch.browser)) utils::browseURL(token$claim_url) else if (
+    is.function(launch.browser)
+  )
     launch.browser(token$claim_url)
 
   if (isFALSE(launch.browser)) {
     cli::cli_alert_warning("Open {.url {token$claim_url}} to authenticate")
   } else {
-    cli::cli_alert_info("A browser window should open to complete authentication")
-    cli::cli_alert_warning("If it doesn't open, please go to {.url {token$claim_url}}")
+    cli::cli_alert_info(
+      "A browser window should open to complete authentication"
+    )
+    cli::cli_alert_warning(
+      "If it doesn't open, please go to {.url {token$claim_url}}"
+    )
   }
 
   user <- waitForAuthedUser(
@@ -205,10 +223,12 @@ generateToken <- function() {
   )
 }
 
-waitForAuthedUser <- function(server,
-                              token = NULL,
-                              private_key = NULL,
-                              apiKey = NULL) {
+waitForAuthedUser <- function(
+  server,
+  token = NULL,
+  private_key = NULL,
+  apiKey = NULL
+) {
   # keep trying to authenticate until we're successful; server returns
   # 500 "Token is unclaimed error" while waiting for interactive auth to complete
   cli::cli_progress_bar(format = "{cli::pb_spin} Waiting for authentication...")
@@ -236,12 +256,16 @@ waitForAuthedUser <- function(server,
   user
 }
 
-getAuthedUser <- function(server,
-                          token = NULL,
-                          private_key = NULL,
-                          apiKey = NULL) {
+getAuthedUser <- function(
+  server,
+  token = NULL,
+  private_key = NULL,
+  apiKey = NULL
+) {
   if (!xor(is.null(token) && is.null(private_key), is.null(apiKey))) {
-    cli::cli_abort("Must supply either {.arg token} + {private_key} or {.arg apiKey}")
+    cli::cli_abort(
+      "Must supply either {.arg token} + {private_key} or {.arg apiKey}"
+    )
   }
 
   account <- list(
@@ -295,11 +319,13 @@ setAccountInfo <- function(name, token, secret, server = "shinyapps.io") {
 
 # A user can have multiple accounts, so iterate over all accounts looking
 # for one with the specified name
-findShinyAppsAccountId <- function(name,
-                                   token,
-                                   secret,
-                                   server,
-                                   error_call = caller_env()) {
+findShinyAppsAccountId <- function(
+  name,
+  token,
+  secret,
+  server,
+  error_call = caller_env()
+) {
   if (secret == "<SECRET>") {
     cli::cli_abort(
       c(
@@ -322,7 +348,9 @@ findShinyAppsAccountId <- function(name,
       return(account$id)
     }
   }
-  cli::cli_abort("Unable to determine {.arg accountId} for account {.str {name}}")
+  cli::cli_abort(
+    "Unable to determine {.arg accountId} for account {.str {name}}"
+  )
 }
 
 #' @rdname accounts
@@ -334,7 +362,11 @@ accountInfo <- function(name = NULL, server = NULL) {
 
 # Discovers then loads details about an account from disk.
 # Internal equivalent to accountInfo that lets callers provide error context.
-findAccountInfo <- function(name = NULL, server = NULL, error_call = caller_env()) {
+findAccountInfo <- function(
+  name = NULL,
+  server = NULL,
+  error_call = caller_env()
+) {
   fullAccount <- findAccount(name, server, error_call = error_call)
   configFile <- accountConfigFile(fullAccount$name, fullAccount$server)
 
@@ -375,16 +407,16 @@ removeAccount <- function(name = NULL, server = NULL) {
   invisible(NULL)
 }
 
-registerAccount <- function(serverName,
-                            accountName,
-                            accountId,
-                            token = NULL,
-                            secret = NULL,
-                            private_key = NULL,
-                            apiKey = NULL,
-                            snowflakeConnectionName = NULL)
-                            {
-
+registerAccount <- function(
+  serverName,
+  accountName,
+  accountId,
+  token = NULL,
+  secret = NULL,
+  private_key = NULL,
+  apiKey = NULL,
+  snowflakeConnectionName = NULL
+) {
   check_string(serverName)
   check_string(accountName)
   if (!is.null(secret)) {
@@ -407,8 +439,7 @@ registerAccount <- function(serverName,
   write.dcf(compact(fields), path, width = 100)
 
   # set restrictive permissions on it if possible
-  if (identical(.Platform$OS.type, "unix"))
-    Sys.chmod(path, mode = "0600")
+  if (identical(.Platform$OS.type, "unix")) Sys.chmod(path, mode = "0600")
 
   path
 }

--- a/R/accounts.R
+++ b/R/accounts.R
@@ -159,10 +159,11 @@ connectUser <- function(
 getAuthTokenAndUser <- function(server, launch.browser = TRUE) {
   token <- getAuthToken(server)
 
-  if (isTRUE(launch.browser)) utils::browseURL(token$claim_url) else if (
-    is.function(launch.browser)
-  )
+  if (isTRUE(launch.browser)) {
+    utils::browseURL(token$claim_url)
+  } else if (is.function(launch.browser)) {
     launch.browser(token$claim_url)
+  }
 
   if (isFALSE(launch.browser)) {
     cli::cli_alert_warning("Open {.url {token$claim_url}} to authenticate")
@@ -439,7 +440,9 @@ registerAccount <- function(
   write.dcf(compact(fields), path, width = 100)
 
   # set restrictive permissions on it if possible
-  if (identical(.Platform$OS.type, "unix")) Sys.chmod(path, mode = "0600")
+  if (identical(.Platform$OS.type, "unix")) {
+    Sys.chmod(path, mode = "0600")
+  }
 
   path
 }

--- a/R/appDependencies.R
+++ b/R/appDependencies.R
@@ -107,10 +107,12 @@
 #' }
 #' @seealso [rsconnectPackages](Using Packages with rsconnect)
 #' @export
-appDependencies <- function(appDir = getwd(),
-                            appFiles = NULL,
-                            appFileManifest = NULL,
-                            appMode = NULL) {
+appDependencies <- function(
+  appDir = getwd(),
+  appFiles = NULL,
+  appFileManifest = NULL,
+  appMode = NULL
+) {
   appFiles <- listDeploymentFiles(appDir, appFiles, appFileManifest)
   appMetadata <- appMetadata(appDir, appFiles = appFiles, appMode = appMode)
   if (!needsR(appMetadata)) {
@@ -148,7 +150,8 @@ needsR <- function(appMetadata) {
 }
 
 inferRPackageDependencies <- function(appMetadata) {
-  deps <- switch(appMetadata$appMode,
+  deps <- switch(
+    appMetadata$appMode,
     "rmd-static" = c("rmarkdown", if (appMetadata$hasParameters) "shiny"),
     "quarto-static" = "rmarkdown",
     "quarto-shiny" = c("rmarkdown", "shiny"),

--- a/R/appMetadata-quarto.R
+++ b/R/appMetadata-quarto.R
@@ -36,8 +36,10 @@ quartoInspect <- function(appDir = NULL, appPrimaryDoc = NULL) {
 
   json <- suppressWarnings(
     system2(
-      quarto, c("inspect", shQuote(appDir)),
-      stdout = TRUE, stderr = TRUE
+      quarto,
+      c("inspect", shQuote(appDir)),
+      stdout = TRUE,
+      stderr = TRUE
     )
   )
   status <- attr(json, "status")
@@ -45,8 +47,10 @@ quartoInspect <- function(appDir = NULL, appPrimaryDoc = NULL) {
   if (!is.null(status) && !is.null(appPrimaryDoc)) {
     json <- suppressWarnings(
       system2(
-        quarto, c("inspect", shQuote(file.path(appDir, appPrimaryDoc))),
-        stdout = TRUE, stderr = TRUE
+        quarto,
+        c("inspect", shQuote(file.path(appDir, appPrimaryDoc))),
+        stdout = TRUE,
+        stderr = TRUE
       )
     )
     status <- attr(json, "status")

--- a/R/appMetadata.R
+++ b/R/appMetadata.R
@@ -1,12 +1,13 @@
-appMetadata <- function(appDir,
-                        appFiles,
-                        appPrimaryDoc = NULL,
-                        quarto = NA,
-                        appMode = NULL,
-                        contentCategory = NULL,
-                        isShinyappsServer = FALSE,
-                        metadata = list()) {
-
+appMetadata <- function(
+  appDir,
+  appFiles,
+  appPrimaryDoc = NULL,
+  quarto = NA,
+  appMode = NULL,
+  contentCategory = NULL,
+  isShinyappsServer = FALSE,
+  metadata = list()
+) {
   if (is_string(quarto)) {
     lifecycle::deprecate_warn(
       when = "1.0.0",
@@ -31,8 +32,10 @@ appMetadata <- function(appDir,
     # applications. They may have name.R, not app.R or server.R.
     #
     # This file is later renamed to app.R when deployed by bundleAppDir().
-    if (!is.null(appPrimaryDoc) &&
-          tolower(tools::file_ext(appPrimaryDoc)) == "r") {
+    if (
+      !is.null(appPrimaryDoc) &&
+        tolower(tools::file_ext(appPrimaryDoc)) == "r"
+    ) {
       appMode <- "shiny"
     } else {
       # Inference only uses top-level files
@@ -96,8 +99,8 @@ inferAppMode <- function(
   appDir,
   appFiles,
   usesQuarto = NA,
-  isShinyappsServer = FALSE) {
-
+  isShinyappsServer = FALSE
+) {
   rootFiles <- appFiles[dirname(appFiles) == "."]
   absoluteRootFiles <- file.path(appDir, rootFiles)
   absoluteAppFiles <- file.path(appDir, appFiles)
@@ -142,11 +145,9 @@ inferAppMode <- function(
     #
     # Do not rely on _quarto.yml alone, as RStudio includes that file even when
     # publishing HTML. https://github.com/rstudio/rstudio/issues/11444
-    usesQuarto <- (
-      hasQmd ||
+    usesQuarto <- (hasQmd ||
       (hasQuartoYml && hasRmd) ||
-      (hasQuartoYml && hasR)
-    )
+      (hasQuartoYml && hasR))
   }
 
   # Documents with "server: shiny" in their YAML front matter need shiny too
@@ -196,7 +197,10 @@ inferAppMode <- function(
   }
 
   # TensorFlow model files are lower in the hierarchy, not at the root.
-  modelFiles <- matchingNames(absoluteAppFiles, "^(saved_model.pb|saved_model.pbtxt)$")
+  modelFiles <- matchingNames(
+    absoluteAppFiles,
+    "^(saved_model.pb|saved_model.pbtxt)$"
+  )
   if (length(modelFiles) > 0) {
     return("tensorflow-saved-model")
   }
@@ -224,8 +228,10 @@ yamlFromRmd <- function(filename) {
         # ...and the first --- line is not preceded by non-whitespace...
         if (diff(delim[1:2]) > 1) {
           # ...and there is actually something between the two --- lines...
-          yamlData <- paste(lines[(delim[[1]] + 1):(delim[[2]] - 1)],
-                            collapse = "\n")
+          yamlData <- paste(
+            lines[(delim[[1]] + 1):(delim[[2]] - 1)],
+            collapse = "\n"
+          )
           return(yaml::yaml.load(yamlData))
         }
       }
@@ -262,11 +268,13 @@ inferAppPrimaryDoc <- function(appPrimaryDoc, appFiles, appMode) {
   }
 
   # determine expected primary document extension
-  ext <- switch(appMode,
-                "static"        = "\\.html?$",
-                "quarto-static" = "\\.(r|rmd|qmd)$",
-                "quarto-shiny"  = "\\.(rmd|qmd)$",
-                "\\.rmd$")
+  ext <- switch(
+    appMode,
+    "static" = "\\.html?$",
+    "quarto-static" = "\\.(r|rmd|qmd)$",
+    "quarto-shiny" = "\\.(rmd|qmd)$",
+    "\\.rmd$"
+  )
 
   # use index file if it exists
   matching <- grepl(paste0("^index", ext), appFiles, ignore.case = TRUE)
@@ -291,23 +299,30 @@ inferAppPrimaryDoc <- function(appPrimaryDoc, appFiles, appMode) {
 }
 
 appIsDocument <- function(appMode) {
-  appMode %in% c(
-    "rmd-static",
-    "rmd-shiny",
-    "quarto-static",
-    "quarto-shiny"
-  )
+  appMode %in%
+    c(
+      "rmd-static",
+      "rmd-shiny",
+      "quarto-static",
+      "quarto-shiny"
+    )
 }
 
 appIsQuartoDocument <- function(appMode) {
-  appMode %in% c(
-    "quarto-static",
-    "quarto-shiny"
-  )
+  appMode %in%
+    c(
+      "quarto-static",
+      "quarto-shiny"
+    )
 }
 
 
-appHasParameters <- function(appDir, appPrimaryDoc, appMode, contentCategory = NULL) {
+appHasParameters <- function(
+  appDir,
+  appPrimaryDoc,
+  appMode,
+  contentCategory = NULL
+) {
   # Only Rmd deployments are marked as having parameters. Shiny applications
   # may distribute an Rmd alongside app.R, but that does not cause the
   # deployment to be considered parameterized.
@@ -340,7 +355,13 @@ detectPythonInDocuments <- function(appDir, files = NULL) {
     files <- bundleFiles(appDir)
   }
 
-  rmdFiles <- grep("^[^/\\\\]+\\.[rq]md$", files, ignore.case = TRUE, perl = TRUE, value = TRUE)
+  rmdFiles <- grep(
+    "^[^/\\\\]+\\.[rq]md$",
+    files,
+    ignore.case = TRUE,
+    perl = TRUE,
+    value = TRUE
+  )
   for (rmdFile in rmdFiles) {
     if (documentHasPythonChunk(file.path(appDir, rmdFile))) {
       return(TRUE)

--- a/R/applications.R
+++ b/R/applications.R
@@ -81,9 +81,13 @@ applications <- function(account = NULL, server = NULL) {
     lapply(res, function(x) {
       # promote the size and instance data to first-level fields
       x$size <- x$deployment$properties$application.instances.template
-      if (is.null(x$size)) x$size <- NA
+      if (is.null(x$size)) {
+        x$size <- NA
+      }
       x$instances <- x$deployment$properties$application.instances.count
-      if (is.null(x$instances)) x$instances <- NA
+      if (is.null(x$instances)) {
+        x$instances <- NA
+      }
       x$deployment <- NULL
       x$guid <- NA
       x$title <- NA_character_
@@ -113,10 +117,14 @@ applications <- function(account = NULL, server = NULL) {
 
   # Ensure the Connect and ShinyApps.io data frames have same column names
   idx <- match("last_deployed_time", names(res))
-  if (!is.na(idx)) names(res)[idx] <- "updated_time"
+  if (!is.na(idx)) {
+    names(res)[idx] <- "updated_time"
+  }
 
   idx <- match("build_status", names(res))
-  if (!is.na(idx)) names(res)[idx] <- "status"
+  if (!is.na(idx)) {
+    names(res)[idx] <- "status"
+  }
 
   return(res)
 }
@@ -146,7 +154,9 @@ resolveApplication <- function(accountDetails, appName) {
   client <- clientForAccount(accountDetails)
   apps <- client$listApplications(accountDetails$accountId)
   for (app in apps) {
-    if (identical(app$name, appName)) return(app)
+    if (identical(app$name, appName)) {
+      return(app)
+    }
   }
 
   stopWithApplicationNotFound(appName)
@@ -220,7 +230,11 @@ streamApplicationLogs <- function(authInfo, applicationId, entries, skip) {
   curl::curl_fetch_stream(
     url = url,
     fun = function(data) {
-      if (skip > 0) skip <<- skip - 1 else cat(rawToChar(data))
+      if (skip > 0) {
+        skip <<- skip - 1
+      } else {
+        cat(rawToChar(data))
+      }
     },
     handle = handle
   )

--- a/R/applications.R
+++ b/R/applications.R
@@ -1,4 +1,3 @@
-
 #' List Deployed Applications
 #'
 #' List all applications currently deployed for a given account.
@@ -35,7 +34,6 @@
 #' @family Deployment functions
 #' @export
 applications <- function(account = NULL, server = NULL) {
-
   # resolve account and create connect client
   accountDetails <- accountInfo(account, server)
   serverDetails <- serverInfo(accountDetails$server)
@@ -83,11 +81,9 @@ applications <- function(account = NULL, server = NULL) {
     lapply(res, function(x) {
       # promote the size and instance data to first-level fields
       x$size <- x$deployment$properties$application.instances.template
-      if (is.null(x$size))
-        x$size <- NA
+      if (is.null(x$size)) x$size <- NA
       x$instances <- x$deployment$properties$application.instances.count
-      if (is.null(x$instances))
-        x$instances <- NA
+      if (is.null(x$instances)) x$instances <- NA
       x$deployment <- NULL
       x$guid <- NA
       x$title <- NA_character_
@@ -102,7 +98,11 @@ applications <- function(account = NULL, server = NULL) {
       prefix <- sub("/__api__", "", serverDetails$url)
       row$config_url <- paste(prefix, "connect/#/apps", row$id, sep = "/")
     } else {
-      row$config_url <- paste("https://www.shinyapps.io/admin/#/application", row$id, sep = "/")
+      row$config_url <- paste(
+        "https://www.shinyapps.io/admin/#/application",
+        row$id,
+        sep = "/"
+      )
     }
     row
   })
@@ -124,7 +124,10 @@ applications <- function(account = NULL, server = NULL) {
 # Use the API to filter applications by name and error when it does not exist.
 getAppByName <- function(client, accountInfo, name, error_call = caller_env()) {
   # NOTE: returns a list with 0 or 1 elements
-  app <- client$listApplications(accountInfo$accountId, filters = list(name = name))
+  app <- client$listApplications(
+    accountInfo$accountId,
+    filters = list(name = name)
+  )
   if (length(app)) {
     return(app[[1]])
   }
@@ -143,8 +146,7 @@ resolveApplication <- function(accountDetails, appName) {
   client <- clientForAccount(accountDetails)
   apps <- client$listApplications(accountDetails$accountId)
   for (app in apps) {
-    if (identical(app$name, appName))
-      return(app)
+    if (identical(app$name, appName)) return(app)
   }
 
   stopWithApplicationNotFound(appName)
@@ -163,12 +165,18 @@ getApplication <- function(account, server, appId) {
 }
 
 stopWithApplicationNotFound <- function(appName) {
-  stop(paste("No application named '", appName, "' is currently deployed.",
-             sep = ""), call. = FALSE)
+  stop(
+    paste(
+      "No application named '",
+      appName,
+      "' is currently deployed.",
+      sep = ""
+    ),
+    call. = FALSE
+  )
 }
 
 applicationTask <- function(taskDef, appName, accountDetails, quiet) {
-
   # resolve target account and application
   application <- resolveApplication(accountDetails, appName)
 
@@ -188,26 +196,34 @@ applicationTask <- function(taskDef, appName, accountDetails, quiet) {
 # streams application logs from ShinyApps
 streamApplicationLogs <- function(authInfo, applicationId, entries, skip) {
   # build the URL
-  url <- paste0(serverInfo("shinyapps.io")$url, "/applications/", applicationId,
-                "/logs?", "count=", entries, "&tail=1")
+  url <- paste0(
+    serverInfo("shinyapps.io")$url,
+    "/applications/",
+    applicationId,
+    "/logs?",
+    "count=",
+    entries,
+    "&tail=1"
+  )
   parsed <- parseHttpUrl(url)
 
   # create the curl handle and perform the minimum necessary to create an
   # authenticated request. we ignore the rsconnect.http option here because only
   # curl supports the kind of streaming connection that we need.
   handle <- createCurlHandle("GET")
-  curl::handle_setheaders(handle,
+  curl::handle_setheaders(
+    handle,
     .list = signatureHeaders(authInfo, "GET", parsed$path, NULL)
   )
 
   # begin the stream
-  curl::curl_fetch_stream(url = url,
+  curl::curl_fetch_stream(
+    url = url,
     fun = function(data) {
-      if (skip > 0)
-        skip <<- skip - 1
-      else
-        cat(rawToChar(data))
-    }, handle = handle)
+      if (skip > 0) skip <<- skip - 1 else cat(rawToChar(data))
+    },
+    handle = handle
+  )
 }
 
 #' Show Application Logs
@@ -232,9 +248,15 @@ streamApplicationLogs <- function(authInfo, applicationId, entries, skip) {
 #'   ShinyApps servers.
 #'
 #' @export
-showLogs <- function(appPath = getwd(), appFile = NULL, appName = NULL,
-                     account = NULL, server = NULL, entries = 50, streaming = FALSE) {
-
+showLogs <- function(
+  appPath = getwd(),
+  appFile = NULL,
+  appName = NULL,
+  account = NULL,
+  server = NULL,
+  entries = 50,
+  streaming = FALSE
+) {
   # determine the log target and target account info
   deployment <- findDeployment(
     appPath = appPath,
@@ -250,22 +272,28 @@ showLogs <- function(appPath = getwd(), appFile = NULL, appName = NULL,
     # streaming; poll for the entries directly
     skip <- 0
     repeat {
-      tryCatch({
-         streamApplicationLogs(accountDetails, application$id, entries, skip)
-         # after the first fetch, we've seen all recent entries, so show
-         # only new entries. unfortunately /logs/ doesn't support getting 0
-         # entries, so get one and don't log it.
-         entries <- 1
-         skip <- 1
-       },
-       error = function(e) {
-         # if the server times out, ignore the error; otherwise, let it
-         # bubble through
-         if (!identical(e$message,
-                  "transfer closed with outstanding read data remaining")) {
-           stop(e)
-         }
-       })
+      tryCatch(
+        {
+          streamApplicationLogs(accountDetails, application$id, entries, skip)
+          # after the first fetch, we've seen all recent entries, so show
+          # only new entries. unfortunately /logs/ doesn't support getting 0
+          # entries, so get one and don't log it.
+          entries <- 1
+          skip <- 1
+        },
+        error = function(e) {
+          # if the server times out, ignore the error; otherwise, let it
+          # bubble through
+          if (
+            !identical(
+              e$message,
+              "transfer closed with outstanding read data remaining"
+            )
+          ) {
+            stop(e)
+          }
+        }
+      )
     }
   } else {
     # if not streaming, poll for the entries directly
@@ -302,7 +330,9 @@ syncAppMetadata <- function(appPath = ".") {
       rsconnect_http_404 = function(c) {
         # if the app has been deleted, delete the deployment record
         file.remove(curDeploy$deploymentFile)
-        cli::cli_inform("Deleting deployment record for deleted app {curDeploy$appId}.")
+        cli::cli_inform(
+          "Deleting deployment record for deleted app {curDeploy$appId}."
+        )
         NULL
       }
     )

--- a/R/auth.R
+++ b/R/auth.R
@@ -1,5 +1,4 @@
 cleanupPasswordFile <- function(appDir) {
-
   check_directory(appDir)
   appDir <- normalizePath(appDir)
 
@@ -11,11 +10,13 @@ cleanupPasswordFile <- function(appDir) {
 
   # check if password file exists
   if (file.exists(passwordFile)) {
-    message("WARNING: Password file found! This application is configured to use scrypt ",
-            "authentication, which is no longer supported.\nIf you choose to proceed, ",
-            "all existing users of this application will be removed, ",
-            "and will NOT be recoverable.\nFor for more information please visit: ",
-            "http://shiny.rstudio.com/articles/migration.html")
+    message(
+      "WARNING: Password file found! This application is configured to use scrypt ",
+      "authentication, which is no longer supported.\nIf you choose to proceed, ",
+      "all existing users of this application will be removed, ",
+      "and will NOT be recoverable.\nFor for more information please visit: ",
+      "http://shiny.rstudio.com/articles/migration.html"
+    )
     response <- readline("Do you want to proceed? [Y/n]: ")
     if (tolower(substring(response, 1, 1)) != "y") {
       stop("Cancelled", call. = FALSE)
@@ -43,16 +44,20 @@ cleanupPasswordFile <- function(appDir) {
 #' @seealso [removeAuthorizedUser()] and [showUsers()]
 #' @note This function works only for ShinyApps servers.
 #' @export
-addAuthorizedUser <- function(email, appDir = getwd(), appName = NULL,
-                              account = NULL, server = NULL, sendEmail = NULL,
-                              emailMessage = NULL) {
-
+addAuthorizedUser <- function(
+  email,
+  appDir = getwd(),
+  appName = NULL,
+  account = NULL,
+  server = NULL,
+  sendEmail = NULL,
+  emailMessage = NULL
+) {
   accountDetails <- accountInfo(account, server)
   checkShinyappsServer(accountDetails$server)
 
   # resolve application
-  if (is.null(appName))
-    appName <- basename(appDir)
+  if (is.null(appName)) appName <- basename(appDir)
   application <- resolveApplication(accountDetails, appName)
 
   # check for and remove password file
@@ -60,8 +65,12 @@ addAuthorizedUser <- function(email, appDir = getwd(), appName = NULL,
 
   # fetch authoriztion list
   api <- clientForAccount(accountDetails)
-  api$inviteApplicationUser(application$id, validateEmail(email), sendEmail,
-                            emailMessage)
+  api$inviteApplicationUser(
+    application$id,
+    validateEmail(email),
+    sendEmail,
+    emailMessage
+  )
 
   message(paste("Added:", email, "to application", sep = " "))
 
@@ -78,15 +87,18 @@ addAuthorizedUser <- function(email, appDir = getwd(), appName = NULL,
 #' @seealso [addAuthorizedUser()] and [showUsers()]
 #' @note This function works only for ShinyApps servers.
 #' @export
-removeAuthorizedUser <- function(user, appDir = getwd(), appName = NULL,
-                                 account = NULL, server = NULL) {
-
+removeAuthorizedUser <- function(
+  user,
+  appDir = getwd(),
+  appName = NULL,
+  account = NULL,
+  server = NULL
+) {
   accountDetails <- accountInfo(account, server)
   checkShinyappsServer(accountDetails$server)
 
   # resolve application
-  if (is.null(appName))
-    appName <- basename(appDir)
+  if (is.null(appName)) appName <- basename(appDir)
   application <- resolveApplication(accountDetails, appName)
 
   # check and remove password file
@@ -129,15 +141,17 @@ removeAuthorizedUser <- function(user, appDir = getwd(), appName = NULL,
 #' @seealso [addAuthorizedUser()] and [showInvited()]
 #' @note This function works only for ShinyApps servers.
 #' @export
-showUsers <- function(appDir = getwd(), appName = NULL, account = NULL,
-                      server = NULL) {
-
+showUsers <- function(
+  appDir = getwd(),
+  appName = NULL,
+  account = NULL,
+  server = NULL
+) {
   accountDetails <- accountInfo(account, server)
   checkShinyappsServer(accountDetails$server)
 
   # resolve application
-  if (is.null(appName))
-    appName <- basename(appDir)
+  if (is.null(appName)) appName <- basename(appDir)
   application <- resolveApplication(accountDetails, appName)
 
   # fetch authoriztion list
@@ -172,15 +186,17 @@ showUsers <- function(appDir = getwd(), appName = NULL, account = NULL,
 #' @seealso [addAuthorizedUser()] and [showUsers()]
 #' @note This function works only for ShinyApps servers.
 #' @export
-showInvited <- function(appDir = getwd(), appName = NULL, account = NULL,
-                        server = NULL) {
-
+showInvited <- function(
+  appDir = getwd(),
+  appName = NULL,
+  account = NULL,
+  server = NULL
+) {
   accountDetails <- accountInfo(account, server)
   checkShinyappsServer(accountDetails$server)
 
   # resolve application
-  if (is.null(appName))
-    appName <- basename(appDir)
+  if (is.null(appName)) appName <- basename(appDir)
   application <- resolveApplication(accountDetails, appName)
 
   # fetch invitation list
@@ -215,10 +231,14 @@ showInvited <- function(appDir = getwd(), appName = NULL, account = NULL,
 #' @seealso [showInvited()]
 #' @note This function works only for ShinyApps servers.
 #' @export
-resendInvitation <- function(invite, regenerate = FALSE,
-                             appDir = getwd(), appName = NULL,
-                             account = NULL, server = NULL) {
-
+resendInvitation <- function(
+  invite,
+  regenerate = FALSE,
+  appDir = getwd(),
+  appName = NULL,
+  account = NULL,
+  server = NULL
+) {
   accountDetails <- accountInfo(account, server)
   checkShinyappsServer(accountDetails$server)
 
@@ -270,7 +290,6 @@ authorizedUsers <- function(appDir = getwd()) {
 }
 
 validateEmail <- function(email) {
-
   if (is.null(email) || !grepl(".+\\@.+\\..+", email)) {
     stop("Invalid email address.", call. = FALSE)
   }
@@ -301,7 +320,6 @@ readPasswordFile <- function(path) {
 }
 
 writePasswordFile <- function(path, passwords) {
-
   # open and file
   f <- file(path, open = "w")
   defer(close(f))
@@ -311,5 +329,7 @@ writePasswordFile <- function(path, passwords) {
     l <- paste(r[1], ":", r[2], "\n", sep = "")
     cat(l, file = f, sep = "")
   })
-  message("Password file updated. You must deploy your application for these changes to take effect.")
+  message(
+    "Password file updated. You must deploy your application for these changes to take effect."
+  )
 }

--- a/R/auth.R
+++ b/R/auth.R
@@ -57,7 +57,9 @@ addAuthorizedUser <- function(
   checkShinyappsServer(accountDetails$server)
 
   # resolve application
-  if (is.null(appName)) appName <- basename(appDir)
+  if (is.null(appName)) {
+    appName <- basename(appDir)
+  }
   application <- resolveApplication(accountDetails, appName)
 
   # check for and remove password file
@@ -196,7 +198,9 @@ showInvited <- function(
   checkShinyappsServer(accountDetails$server)
 
   # resolve application
-  if (is.null(appName)) appName <- basename(appDir)
+  if (is.null(appName)) {
+    appName <- basename(appDir)
+  }
   application <- resolveApplication(accountDetails, appName)
 
   # fetch invitation list

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -28,9 +28,11 @@ bundleAppDir <- function(
       # will be discovered and run by shiny::runApp(getwd()).
       #
       # Note: We do not expect to see writeManifest(appPrimaryDoc="notapp.R").
-      if (is.character(appPrimaryDoc) &&
-            tolower(tools::file_ext(appPrimaryDoc)) == "r" &&
-            file == appPrimaryDoc) {
+      if (
+        is.character(appPrimaryDoc) &&
+          tolower(tools::file_ext(appPrimaryDoc)) == "r" &&
+          file == appPrimaryDoc
+      ) {
         to <- file.path(bundleDir, "app.R")
       }
     }
@@ -42,7 +44,6 @@ bundleAppDir <- function(
     if (basename(to) == ".Rprofile") {
       tweakRProfile(to)
     }
-
   }
   bundleDir
 }
@@ -53,21 +54,21 @@ tweakRProfile <- function(path) {
   packratLines <- grep('source("packrat/init.R")', lines, fixed = TRUE)
   if (length(packratLines) > 0) {
     lines[packratLines] <- paste0(
-       "# Packrat initialization disabled in published application\n",
-       '# source("packrat/init.R")'
-      )
+      "# Packrat initialization disabled in published application\n",
+      '# source("packrat/init.R")'
+    )
   }
 
   renvLines <- grep('source("renv/activate.R")', lines, fixed = TRUE)
   if (length(renvLines) > 0) {
     lines[renvLines] <- paste0(
-       "# renv initialization disabled in published application\n",
-       '# source("renv/activate.R")'
-      )
+      "# renv initialization disabled in published application\n",
+      '# source("renv/activate.R")'
+    )
   }
 
   if (length(renvLines) > 0 || length(packratLines) > 0) {
-    msg <-  sprintf(
+    msg <- sprintf(
       "# Modified by rsconnect package %s on %s",
       packageVersion("rsconnect"),
       Sys.time()
@@ -92,7 +93,12 @@ writeBundle <- function(bundleDir, bundlePath, verbose = FALSE) {
     detectLongNames(bundleDir)
   }
 
-  utils::tar(bundlePath, files = NULL, compression = "gzip", tar = tarImplementation)
+  utils::tar(
+    bundlePath,
+    files = NULL,
+    compression = "gzip",
+    tar = tarImplementation
+  )
 }
 
 
@@ -114,18 +120,19 @@ isWindows <- function() {
   Sys.info()[["sysname"]] == "Windows"
 }
 
-createAppManifest <- function(appDir,
-                              appMetadata,
-                              users = NULL,
-                              pythonConfig = NULL,
-                              retainPackratDirectory = TRUE,
-                              image = NULL,
-                              envManagement = NULL,
-                              envManagementR = NULL,
-                              envManagementPy = NULL,
-                              verbose = FALSE,
-                              quiet = FALSE) {
-
+createAppManifest <- function(
+  appDir,
+  appMetadata,
+  users = NULL,
+  pythonConfig = NULL,
+  retainPackratDirectory = TRUE,
+  image = NULL,
+  envManagement = NULL,
+  envManagementR = NULL,
+  envManagementPy = NULL,
+  verbose = FALSE,
+  quiet = FALSE
+) {
   if (is.null(image)) {
     imageEnv <- Sys.getenv("RSCONNECT_IMAGE", unset = NA)
     if (!is.na(imageEnv) && nchar(imageEnv) > 0) {
@@ -166,8 +173,12 @@ createAppManifest <- function(appDir,
   }
 
   # build the list of files to checksum
-  files <- list.files(appDir, recursive = TRUE, all.files = TRUE,
-                      full.names = FALSE)
+  files <- list.files(
+    appDir,
+    recursive = TRUE,
+    all.files = TRUE,
+    full.names = FALSE
+  )
 
   # provide checksums for all files
   filelist <- list()
@@ -198,15 +209,30 @@ createAppManifest <- function(appDir,
   metadata <- list(appmode = appMetadata$appMode)
 
   # emit appropriate primary document information
-  primaryDoc <- ifelse(is.null(appMetadata$appPrimaryDoc) ||
-                         tolower(tools::file_ext(appMetadata$appPrimaryDoc)) == "r",
-                       NA, appMetadata$appPrimaryDoc)
-  metadata$primary_rmd <- ifelse(appMetadata$appMode %in% c("rmd-shiny", "rmd-static", "quarto-shiny", "quarto-static"), primaryDoc, NA)
-  metadata$primary_html <- ifelse(appMetadata$appMode == "static", primaryDoc, NA)
+  primaryDoc <- ifelse(
+    is.null(appMetadata$appPrimaryDoc) ||
+      tolower(tools::file_ext(appMetadata$appPrimaryDoc)) == "r",
+    NA,
+    appMetadata$appPrimaryDoc
+  )
+  metadata$primary_rmd <- ifelse(
+    appMetadata$appMode %in%
+      c("rmd-shiny", "rmd-static", "quarto-shiny", "quarto-static"),
+    primaryDoc,
+    NA
+  )
+  metadata$primary_html <- ifelse(
+    appMetadata$appMode == "static",
+    primaryDoc,
+    NA
+  )
 
   # emit content category (plots, etc)
-  metadata$content_category <- ifelse(!is.null(appMetadata$contentCategory),
-                                      appMetadata$contentCategory, NA)
+  metadata$content_category <- ifelse(
+    !is.null(appMetadata$contentCategory),
+    appMetadata$contentCategory,
+    NA
+  )
   metadata$has_parameters <- appMetadata$hasParameters
 
   # add metadata

--- a/R/bundleFiles.R
+++ b/R/bundleFiles.R
@@ -29,12 +29,12 @@
 #'   use only.
 #' @return Character of paths to bundle, relative to `appDir`.
 #' @export
-listDeploymentFiles <- function(appDir,
-                                appFiles = NULL,
-                                appFileManifest = NULL,
-                                error_call = caller_env()) {
-
-
+listDeploymentFiles <- function(
+  appDir,
+  appFiles = NULL,
+  appFileManifest = NULL,
+  error_call = caller_env()
+) {
   no_content <- function(message) {
     cli::cli_abort(
       c("No content to deploy.", x = message),
@@ -121,12 +121,14 @@ explodeFiles <- function(dir, files, error_arg = "appFiles") {
   recursiveBundleFiles(dir, contents = files, ignoreFiles = FALSE)$contents
 }
 
-recursiveBundleFiles <- function(dir,
-                                 contents = NULL,
-                                 rootDir = dir,
-                                 totalFiles = 0,
-                                 totalSize = 0,
-                                 ignoreFiles = TRUE) {
+recursiveBundleFiles <- function(
+  dir,
+  contents = NULL,
+  rootDir = dir,
+  totalFiles = 0,
+  totalSize = 0,
+  ignoreFiles = TRUE
+) {
   # generate a list of files at this level
   if (is.null(contents)) {
     contents <- list.files(dir, all.files = TRUE, no.. = TRUE)
@@ -173,15 +175,24 @@ ignoreBundleFiles <- function(dir, contents) {
   # entries ignored regardless of type
   ignored <- c(
     # rsconnect packages
-    "rsconnect", "rsconnect-python", "manifest.json",
+    "rsconnect",
+    "rsconnect-python",
+    "manifest.json",
     # packrat + renv,
-    "renv", "packrat",
+    "renv",
+    "packrat",
     # version control
-    ".git", ".gitignore", ".svn",
+    ".git",
+    ".gitignore",
+    ".svn",
     # R/RStudio
-    ".Rhistory", ".Rproj.user",
+    ".Rhistory",
+    ".Rproj.user",
     # other
-    ".DS_Store", ".quarto", "app_cache", "__pycache__/"
+    ".DS_Store",
+    ".quarto",
+    "app_cache",
+    "__pycache__/"
   )
 
   contents <- setdiff(contents, ignored)
@@ -211,9 +222,9 @@ isKnitrCacheDir <- function(files) {
 # https://github.com/rstudio/rsconnect-python/blob/94dbd28797ee503d6/rsconnect/bundle.py#L541-L543
 isPythonEnv <- function(dir, files) {
   (file.exists(file.path(dir, files, "bin", "python")) |
-     file.exists(file.path(dir, files, "Scripts", "python.exe")) |
-     file.exists(file.path(dir, files, "Scripts", "pythond.exe")) |
-     file.exists(file.path(dir, files, "Scripts", "pythonw.exe")))
+    file.exists(file.path(dir, files, "Scripts", "python.exe")) |
+    file.exists(file.path(dir, files, "Scripts", "pythond.exe")) |
+    file.exists(file.path(dir, files, "Scripts", "pythonw.exe")))
 }
 
 enforceBundleLimits <- function(appDir, totalFiles, totalSize) {

--- a/R/bundlePackage.R
+++ b/R/bundlePackage.R
@@ -1,9 +1,10 @@
-bundlePackages <- function(bundleDir,
-                           extraPackages = character(),
-                           quiet = FALSE,
-                           verbose = FALSE,
-                           error_call = caller_env()) {
-
+bundlePackages <- function(
+  bundleDir,
+  extraPackages = character(),
+  quiet = FALSE,
+  verbose = FALSE,
+  error_call = caller_env()
+) {
   deps <- computePackageDependencies(
     bundleDir,
     extraPackages,
@@ -40,18 +41,23 @@ usePackrat <- function() {
   return(truthy(value))
 }
 
-computePackageDependencies <- function(bundleDir,
-                                       extraPackages = character(),
-                                       quiet = FALSE,
-                                       verbose = FALSE) {
-
+computePackageDependencies <- function(
+  bundleDir,
+  extraPackages = character(),
+  quiet = FALSE,
+  verbose = FALSE
+) {
   if (usePackrat()) {
     taskStart(quiet, "Capturing R dependencies with packrat")
     # Remove renv.lock so the packrat call to renv::dependencies does not report an implicit renv
     # dependency. Mirrors rsconnect before 1.0.0, which did not include renv.lock in bundles.
     # https://github.com/rstudio/rsconnect/blob/v0.8.29/R/bundle.R#L96
     removeRenv(bundleDir)
-    deps <- snapshotPackratDependencies(bundleDir, extraPackages, verbose = verbose)
+    deps <- snapshotPackratDependencies(
+      bundleDir,
+      extraPackages,
+      verbose = verbose
+    )
   } else if (file.exists(renvLockFile(bundleDir))) {
     # This ignores extraPackages; if you're using a lockfile it's your
     # responsibility to install any other packages you need
@@ -63,7 +69,12 @@ computePackageDependencies <- function(bundleDir,
   } else {
     taskStart(quiet, "Capturing R dependencies")
     # TODO: give user option to choose between implicit and explicit
-    deps <- snapshotRenvDependencies(bundleDir, extraPackages, quiet = quiet, verbose = verbose)
+    deps <- snapshotRenvDependencies(
+      bundleDir,
+      extraPackages,
+      quiet = quiet,
+      verbose = verbose
+    )
   }
   taskComplete(quiet, "Found {nrow(deps)} dependenc{?y/ies}")
 

--- a/R/bundlePackagePackrat.R
+++ b/R/bundlePackagePackrat.R
@@ -1,7 +1,8 @@
-snapshotPackratDependencies <- function(bundleDir,
-                                        implicit_dependencies = character(),
-                                        verbose = FALSE) {
-
+snapshotPackratDependencies <- function(
+  bundleDir,
+  implicit_dependencies = character(),
+  verbose = FALSE
+) {
   addPackratSnapshot(bundleDir, implicit_dependencies, verbose = verbose)
 
   lockFilePath <- packratLockFile(bundleDir)
@@ -10,7 +11,11 @@ snapshotPackratDependencies <- function(bundleDir,
 
   # get repos defined in the lockfile
   repos <- gsub("[\r\n]", " ", df[1, "Repos"])
-  repos <- strsplit(unlist(strsplit(repos, "\\s*,\\s*", perl = TRUE)), "=", fixed = TRUE)
+  repos <- strsplit(
+    unlist(strsplit(repos, "\\s*,\\s*", perl = TRUE)),
+    "=",
+    fixed = TRUE
+  )
   repos <- setNames(
     sapply(repos, "[[", 2),
     sapply(repos, "[[", 1)
@@ -55,7 +60,11 @@ standardizeRepos <- function(repos) {
   repos
 }
 
-standardizePackratPackage <- function(record, availablePackages, repos = character()) {
+standardizePackratPackage <- function(
+  record,
+  availablePackages,
+  repos = character()
+) {
   pkg <- record$Package
   source <- record$Source
 
@@ -68,7 +77,10 @@ standardizePackratPackage <- function(record, availablePackages, repos = charact
     # can't install source packages elsewhere
     repository <- NA_character_
     source <- NA_character_
-  } else if (source == "CustomCRANLikeRepository" && isDevVersion(record, availablePackages)) {
+  } else if (
+    source == "CustomCRANLikeRepository" &&
+      isDevVersion(record, availablePackages)
+  ) {
     # Package was installed from source, but packrat guessed it was installed
     # from a known repo.
     repository <- NA_character_
@@ -117,9 +129,11 @@ isDevVersion <- function(record, availablePackages) {
   package_version(local_version) > package_version(repo_version)
 }
 
-addPackratSnapshot <- function(bundleDir,
-                               implicit_dependencies = character(),
-                               verbose = FALSE) {
+addPackratSnapshot <- function(
+  bundleDir,
+  implicit_dependencies = character(),
+  verbose = FALSE
+) {
   # if we discovered any extra dependencies, write them to a file for packrat to
   # discover when it creates the snapshot
   recordExtraDependencies(bundleDir, implicit_dependencies)

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -1,7 +1,9 @@
-snapshotRenvDependencies <- function(bundleDir,
-                                     extraPackages = character(),
-                                     quiet = FALSE,
-                                     verbose = FALSE) {
+snapshotRenvDependencies <- function(
+  bundleDir,
+  extraPackages = character(),
+  quiet = FALSE,
+  verbose = FALSE
+) {
   recordExtraDependencies(bundleDir, extraPackages)
 
   old <- options(
@@ -25,7 +27,8 @@ snapshotRenvDependencies <- function(bundleDir,
     bundleDir,
     root = bundleDir,
     quiet = if (quiet) TRUE else NULL,
-    progress = FALSE)
+    progress = FALSE
+  )
   renv::snapshot(bundleDir, packages = deps$Package, prompt = FALSE)
   defer(removeRenv(bundleDir))
 
@@ -82,15 +85,21 @@ standardizeRenvPackages <- function(packages, repos, biocPackages = NULL) {
   rbind_fill(out)
 }
 
-standardizeRenvPackage <- function(pkg,
-                                   availablePackages,
-                                   biocPackages = NULL,
-                                   repos = character(),
-                                   bioc) {
+standardizeRenvPackage <- function(
+  pkg,
+  availablePackages,
+  biocPackages = NULL,
+  repos = character(),
+  bioc
+) {
   # Convert renv source to manifest source/repository
   # https://github.com/rstudio/renv/blob/0.17.2/R/snapshot.R#L730-L773
 
-  if (is.null(pkg$Repository) && !is.null(pkg$RemoteRepos) && grepl("bioconductor.org", pkg$RemoteRepos)) {
+  if (
+    is.null(pkg$Repository) &&
+      !is.null(pkg$RemoteRepos) &&
+      grepl("bioconductor.org", pkg$RemoteRepos)
+  ) {
     # Work around bug where renv fails to detect BioC package installed by pak
     # https://github.com/rstudio/renv/issues/1202
     pkg$Source <- "Bioconductor"

--- a/R/bundlePython.R
+++ b/R/bundlePython.R
@@ -1,8 +1,6 @@
 # Create anonymous function that we can later call to get all needed python
 # metdata for the manifest
-pythonConfigurator <- function(python,
-                               forceGenerate = FALSE) {
-
+pythonConfigurator <- function(python, forceGenerate = FALSE) {
   if (is.null(python)) {
     return(NULL)
   }
@@ -55,9 +53,11 @@ getPython <- function(path = NULL) {
   NULL
 }
 
-inferPythonEnv <- function(workdir,
-                           python = getPython(),
-                           forceGenerate = FALSE) {
+inferPythonEnv <- function(
+  workdir,
+  python = getPython(),
+  forceGenerate = FALSE
+) {
   # run the python introspection script
   env_py <- system.file("resources/environment.py", package = "rsconnect")
   args <- c(
@@ -75,14 +75,25 @@ inferPythonEnv <- function(workdir,
     conda <- getCondaExeForPrefix(prefix)
     args <- c("run", "-p", prefix, python, args)
     # conda run -p <prefix> python inst/resources/environment.py <flags> <dir>
-    output <- system2(command = conda, args = args, stdout = TRUE, stderr = NULL, wait = TRUE)
+    output <- system2(
+      command = conda,
+      args = args,
+      stdout = TRUE,
+      stderr = NULL,
+      wait = TRUE
+    )
   } else {
-    output <- system2(command = python, args = args, stdout = TRUE, stderr = NULL, wait = TRUE)
+    output <- system2(
+      command = python,
+      args = args,
+      stdout = TRUE,
+      stderr = NULL,
+      wait = TRUE
+    )
   }
 
   environment <- jsonlite::fromJSON(output)
   if (is.null(environment$error)) {
-
     list(
       version = environment$python,
       package_manager = list(
@@ -100,7 +111,11 @@ inferPythonEnv <- function(workdir,
 getCondaEnvPrefix <- function(python) {
   prefix <- dirname(dirname(python))
   if (!file.exists(file.path(prefix, "conda-meta"))) {
-    stop(paste("Python from", python, "does not look like a conda environment: cannot find `conda-meta`"))
+    stop(paste(
+      "Python from",
+      python,
+      "does not look like a conda environment: cannot find `conda-meta`"
+    ))
   }
   prefix
 }
@@ -112,7 +127,11 @@ getCondaExeForPrefix <- function(prefix) {
     conda <- paste(conda, ".exe", sep = "")
   }
   if (!file.exists(conda)) {
-    stop(paste("Conda env prefix", prefix, "does not have the `conda` command line interface."))
+    stop(paste(
+      "Conda env prefix",
+      prefix,
+      "does not have the `conda` command line interface."
+    ))
   }
   conda
 }

--- a/R/certificates.R
+++ b/R/certificates.R
@@ -21,16 +21,20 @@ createCertificateFile <- function(certificate) {
         "The certificate store '",
         systemStore,
         "' specified in the ",
-        if (identical(systemStore, getOption("rsconnect.ca.bundle")))
-          "rsconnect.ca.bundle option " else
-          "RSCONNECT_CA_BUNDLE environment variable ",
+        if (identical(systemStore, getOption("rsconnect.ca.bundle"))) {
+          "rsconnect.ca.bundle option "
+        } else {
+          "RSCONNECT_CA_BUNDLE environment variable "
+        },
         "does not exist. The system certificate store will be used instead."
       )
     }
   }
 
   # if no certificate contents specified, we're done
-  if (is.null(certificate)) return(certificateFile)
+  if (is.null(certificate)) {
+    return(certificateFile)
+  }
 
   # if we don't have a certificate file yet, try to find the system store
   if (is.null(certificateFile)) {
@@ -105,14 +109,19 @@ inferCertificateContents <- function(certificate) {
   # infer which we're dealing with
 
   # tolerate NULL, which is a valid case representing no certificate
-  if (is.null(certificate) || identical(certificate, "")) return(NULL)
+  if (is.null(certificate) || identical(certificate, "")) {
+    return(NULL)
+  }
 
   # collapse to a single string if we got a vector of lines
-  if (length(certificate) > 1)
+  if (length(certificate) > 1) {
     certificate <- paste(certificate, collapse = "\n")
+  }
 
   # looks like ASCII armored certificate data, return as-is
-  if (validateCertificate(substr(certificate, 1, 27))) return(certificate)
+  if (validateCertificate(substr(certificate, 1, 27))) {
+    return(certificate)
+  }
 
   # looks like a file; return its contents
   if (file.exists(certificate)) {
@@ -128,7 +137,9 @@ inferCertificateContents <- function(certificate) {
       readLines(con = certificate, warn = FALSE),
       collapse = "\n"
     )
-    if (validateCertificate(contents)) return(contents) else
+    if (validateCertificate(contents)) {
+      return(contents)
+    } else {
       stop(
         "The file '",
         certificate,
@@ -136,6 +147,7 @@ inferCertificateContents <- function(certificate) {
         "Certificate files should be in ASCII armored PEM format, with a ",
         "first line reading -----BEGIN CERTIFICATE-----."
       )
+    }
   }
 
   # doesn't look like something we can deal with; guess error based on length

--- a/R/certificates.R
+++ b/R/certificates.R
@@ -1,4 +1,3 @@
-
 # sanity check to make sure we're looking at an ASCII armored cert
 validateCertificate <- function(certificate) {
   return(any(grepl("-----BEGIN CERTIFICATE-----", certificate, fixed = TRUE)))
@@ -18,42 +17,52 @@ createCertificateFile <- function(certificate) {
     if (file.exists(systemStore)) {
       certificateFile <- path.expand(systemStore)
     } else {
-      warning("The certificate store '", systemStore, "' specified in the ",
-              if (identical(systemStore, getOption("rsconnect.ca.bundle")))
-                "rsconnect.ca.bundle option "
-              else
-                "RSCONNECT_CA_BUNDLE environment variable ",
-              "does not exist. The system certificate store will be used instead.")
+      warning(
+        "The certificate store '",
+        systemStore,
+        "' specified in the ",
+        if (identical(systemStore, getOption("rsconnect.ca.bundle")))
+          "rsconnect.ca.bundle option " else
+          "RSCONNECT_CA_BUNDLE environment variable ",
+        "does not exist. The system certificate store will be used instead."
+      )
     }
   }
 
   # if no certificate contents specified, we're done
-  if (is.null(certificate))
-    return(certificateFile)
+  if (is.null(certificate)) return(certificateFile)
 
   # if we don't have a certificate file yet, try to find the system store
   if (is.null(certificateFile)) {
     if (.Platform$OS.type == "unix") {
       # search known locations on Unix-like
-      stores <- c("/etc/ssl/certs/ca-certificates.crt",
-                  "/etc/pki/tls/certs/ca-bundle.crt",
-                  "/usr/share/ssl/certs/ca-bundle.crt",
-                  "/usr/local/share/certs/ca-root.crt",
-                  "/etc/ssl/cert.pem",
-                  "/var/lib/ca-certificates/ca-bundle.pem")
+      stores <- c(
+        "/etc/ssl/certs/ca-certificates.crt",
+        "/etc/pki/tls/certs/ca-bundle.crt",
+        "/usr/share/ssl/certs/ca-bundle.crt",
+        "/usr/local/share/certs/ca-root.crt",
+        "/etc/ssl/cert.pem",
+        "/var/lib/ca-certificates/ca-bundle.pem"
+      )
     } else {
       # mirror behavior of curl on Windows, which looks in system folders,
       # the working directory, and %PATH%.
-      stores <- c(file.path(getwd(), "curl-ca-bundle.crt"),
-                  "C:/Windows/System32/curl-ca-bundle.crt",
-                  "C:/Windows/curl-ca-bundle.crt",
-                  file.path(strsplit(Sys.getenv("PATH"), ";", fixed = TRUE),
-                            "curl-ca-bundle.crt"))
-
+      stores <- c(
+        file.path(getwd(), "curl-ca-bundle.crt"),
+        "C:/Windows/System32/curl-ca-bundle.crt",
+        "C:/Windows/curl-ca-bundle.crt",
+        file.path(
+          strsplit(Sys.getenv("PATH"), ";", fixed = TRUE),
+          "curl-ca-bundle.crt"
+        )
+      )
     }
 
     # use our own baked-in bundle as a last resort
-    stores <- c(stores, system.file(package = "rsconnect", "cert", "cacert.pem"))
+    stores <- c(
+      stores,
+      system.file(package = "rsconnect", "cert", "cacert.pem")
+    )
 
     for (store in stores) {
       if (file.exists(store)) {
@@ -96,39 +105,50 @@ inferCertificateContents <- function(certificate) {
   # infer which we're dealing with
 
   # tolerate NULL, which is a valid case representing no certificate
-  if (is.null(certificate) || identical(certificate, ""))
-    return(NULL)
+  if (is.null(certificate) || identical(certificate, "")) return(NULL)
 
   # collapse to a single string if we got a vector of lines
   if (length(certificate) > 1)
     certificate <- paste(certificate, collapse = "\n")
 
   # looks like ASCII armored certificate data, return as-is
-  if (validateCertificate(substr(certificate, 1, 27)))
-    return(certificate)
+  if (validateCertificate(substr(certificate, 1, 27))) return(certificate)
 
   # looks like a file; return its contents
   if (file.exists(certificate)) {
     if (file.size(certificate) > 1048576) {
-      stop("The file '", certificate, "' is too large. Certificate files must ",
-           "be less than 1MB.")
+      stop(
+        "The file '",
+        certificate,
+        "' is too large. Certificate files must ",
+        "be less than 1MB."
+      )
     }
-    contents <- paste(readLines(con = certificate, warn = FALSE), collapse = "\n")
-    if (validateCertificate(contents))
-      return(contents)
-    else
-      stop("The file '", certificate, "' does not appear to be a certificate. ",
-           "Certificate files should be in ASCII armored PEM format, with a ",
-           "first line reading -----BEGIN CERTIFICATE-----.")
+    contents <- paste(
+      readLines(con = certificate, warn = FALSE),
+      collapse = "\n"
+    )
+    if (validateCertificate(contents)) return(contents) else
+      stop(
+        "The file '",
+        certificate,
+        "' does not appear to be a certificate. ",
+        "Certificate files should be in ASCII armored PEM format, with a ",
+        "first line reading -----BEGIN CERTIFICATE-----."
+      )
   }
 
   # doesn't look like something we can deal with; guess error based on length
   if (nchar(certificate) < 200) {
     stop("The certificate file '", certificate, "' does not exist.")
   } else {
-    stop("The certificate '", substr(certificate, 1, 10), "...' is not ",
-    "correctly formed. Specify the certificate as either an ASCII armored string, ",
-    "beginning with -----BEGIN CERTIFICATE----, or a valid path to a file ",
-    "containing the certificate.")
+    stop(
+      "The certificate '",
+      substr(certificate, 1, 10),
+      "...' is not ",
+      "correctly formed. Specify the certificate as either an ASCII armored string, ",
+      "beginning with -----BEGIN CERTIFICATE----, or a valid path to a file ",
+      "containing the certificate."
+    )
   }
 }

--- a/R/client-cloud.R
+++ b/R/client-cloud.R
@@ -39,10 +39,18 @@ cloudClient <- function(service, authInfo) {
     ) {
       path <- paste0("/accounts/", accountId, "/usage/", usageType, "/")
       query <- list()
-      if (!is.null(applicationId)) query$application <- applicationId
-      if (!is.null(from)) query$from <- from
-      if (!is.null(until)) query$until <- until
-      if (!is.null(interval)) query$interval <- interval
+      if (!is.null(applicationId)) {
+        query$application <- applicationId
+      }
+      if (!is.null(from)) {
+        query$from <- from
+      }
+      if (!is.null(until)) {
+        query$until <- until
+      }
+      if (!is.null(interval)) {
+        query$interval <- interval
+      }
       GET(service, authInfo, path, queryString(query))
     },
 
@@ -167,9 +175,15 @@ cloudClient <- function(service, authInfo) {
         }),
         collapse = "&"
       )
-      if (!is.null(from)) query$from <- from
-      if (!is.null(until)) query$until <- until
-      if (!is.null(interval)) query$interval <- interval
+      if (!is.null(from)) {
+        query$from <- from
+      }
+      if (!is.null(until)) {
+        query$until <- until
+      }
+      if (!is.null(interval)) {
+        query$interval <- interval
+      }
       GET(service, authInfo, path, paste(m, queryString(query), sep = "&"))
     },
 
@@ -192,8 +206,11 @@ cloudClient <- function(service, authInfo) {
       json$name <- name
       json$application_type <- if (
         appMode %in% c("rmd-static", "quarto-static", "static")
-      )
-        "static" else "connect"
+      ) {
+        "static"
+      } else {
+        "connect"
+      }
       if (appMode %in% c("rmd-static", "quarto-static")) {
         json$render_by <- "server"
       }
@@ -303,8 +320,11 @@ cloudClient <- function(service, authInfo) {
 
       path <- paste0("/applications/", application$application_id, "/deploy")
       json <- list()
-      if (length(bundleId) > 0 && nzchar(bundleId))
-        json$bundle <- as.numeric(bundleId) else json$rebuild <- FALSE
+      if (length(bundleId) > 0 && nzchar(bundleId)) {
+        json$bundle <- as.numeric(bundleId)
+      } else {
+        json$rebuild <- FALSE
+      }
       POST_JSON(service, authInfo, path, json)
     },
 
@@ -327,9 +347,12 @@ cloudClient <- function(service, authInfo) {
       path <- paste0("/applications/", applicationId, "/authorization/users")
       json <- list()
       json$email <- email
-      if (!is.null(invite_email)) json$invite_email <- invite_email
-      if (!is.null(invite_email_message))
+      if (!is.null(invite_email)) {
+        json$invite_email <- invite_email
+      }
+      if (!is.null(invite_email_message)) {
         json$invite_email_message <- invite_email_message
+      }
       POST_JSON(service, authInfo, path, json)
     },
 

--- a/R/client-cloud.R
+++ b/R/client-cloud.R
@@ -11,9 +11,8 @@ getCurrentProjectId <- function(service, authInfo) {
 
 cloudClient <- function(service, authInfo) {
   list(
-
     status = function() {
-      GET(service, authInfo,  "/internal/status")
+      GET(service, authInfo, "/internal/status")
     },
 
     service = function() {
@@ -30,18 +29,20 @@ cloudClient <- function(service, authInfo) {
       listRequest(service, authInfo, path, query, "accounts")
     },
 
-    getAccountUsage = function(accountId, usageType = "hours", applicationId = NULL,
-                               from = NULL, until = NULL, interval = NULL) {
+    getAccountUsage = function(
+      accountId,
+      usageType = "hours",
+      applicationId = NULL,
+      from = NULL,
+      until = NULL,
+      interval = NULL
+    ) {
       path <- paste0("/accounts/", accountId, "/usage/", usageType, "/")
       query <- list()
-      if (!is.null(applicationId))
-        query$application <- applicationId
-      if (!is.null(from))
-        query$from <- from
-      if (!is.null(until))
-        query$until <- until
-      if (!is.null(interval))
-        query$interval <- interval
+      if (!is.null(applicationId)) query$application <- applicationId
+      if (!is.null(from)) query$from <- from
+      if (!is.null(until)) query$until <- until
+      if (!is.null(interval)) query$interval <- interval
       GET(service, authInfo, path, queryString(query))
     },
 
@@ -57,7 +58,12 @@ cloudClient <- function(service, authInfo) {
       POST_JSON(service, authInfo, path, json)
     },
 
-    createBundle = function(application, content_type, content_length, checksum) {
+    createBundle = function(
+      application,
+      content_type,
+      content_length,
+      checksum
+    ) {
       json <- list()
       json$application <- application
       json$content_type <- content_type
@@ -68,10 +74,13 @@ cloudClient <- function(service, authInfo) {
 
     listApplications = function(accountId, filters = list()) {
       path <- "/applications/"
-      query <- paste(filterQuery(
-        c("account_id", "type", names(filters)),
-        c(accountId, "connect", unname(filters))
-      ), collapse = "&")
+      query <- paste(
+        filterQuery(
+          c("account_id", "type", names(filters)),
+          c(accountId, "connect", unname(filters))
+        ),
+        collapse = "&"
+      )
       listRequest(service, authInfo, path, query, "applications")
     },
 
@@ -142,16 +151,25 @@ cloudClient <- function(service, authInfo) {
       application
     },
 
-    getApplicationMetrics = function(applicationId, series, metrics, from = NULL, until = NULL, interval = NULL) {
+    getApplicationMetrics = function(
+      applicationId,
+      series,
+      metrics,
+      from = NULL,
+      until = NULL,
+      interval = NULL
+    ) {
       path <- paste0("/applications/", applicationId, "/metrics/", series, "/")
       query <- list()
-      m <- paste(lapply(metrics, function(x) { paste("metric", urlEncode(x), sep = "=") }), collapse = "&")
-      if (!is.null(from))
-        query$from <- from
-      if (!is.null(until))
-        query$until <- until
-      if (!is.null(interval))
-        query$interval <- interval
+      m <- paste(
+        lapply(metrics, function(x) {
+          paste("metric", urlEncode(x), sep = "=")
+        }),
+        collapse = "&"
+      )
+      if (!is.null(from)) query$from <- from
+      if (!is.null(until)) query$until <- until
+      if (!is.null(interval)) query$interval <- interval
       GET(service, authInfo, path, paste(m, queryString(query), sep = "&"))
     },
 
@@ -161,10 +179,21 @@ cloudClient <- function(service, authInfo) {
       GET(service, authInfo, path, query)
     },
 
-    createApplication = function(name, title, template, accountId, appMode, contentCategory = NULL, spaceId = NULL) {
+    createApplication = function(
+      name,
+      title,
+      template,
+      accountId,
+      appMode,
+      contentCategory = NULL,
+      spaceId = NULL
+    ) {
       json <- list()
       json$name <- name
-      json$application_type <- if (appMode %in% c("rmd-static", "quarto-static", "static")) "static" else "connect"
+      json$application_type <- if (
+        appMode %in% c("rmd-static", "quarto-static", "static")
+      )
+        "static" else "connect"
       if (appMode %in% c("rmd-static", "quarto-static")) {
         json$render_by <- "server"
       }
@@ -201,20 +230,35 @@ cloudClient <- function(service, authInfo) {
       GET(service, authInfo, path)
     },
 
-    setApplicationProperty = function(applicationId, propertyName,
-                                      propertyValue, force = FALSE) {
-      path <- paste0("/applications/", applicationId, "/properties/",
-                    propertyName)
+    setApplicationProperty = function(
+      applicationId,
+      propertyName,
+      propertyValue,
+      force = FALSE
+    ) {
+      path <- paste0(
+        "/applications/",
+        applicationId,
+        "/properties/",
+        propertyName
+      )
       v <- list()
       v$value <- propertyValue
       query <- paste0("force=", if (force) "1" else "0")
       PUT_JSON(service, authInfo, path, v, query)
     },
 
-    unsetApplicationProperty = function(applicationId, propertyName,
-                                        force = FALSE) {
-      path <- paste0("/applications/", applicationId, "/properties/",
-                    propertyName)
+    unsetApplicationProperty = function(
+      applicationId,
+      propertyName,
+      force = FALSE
+    ) {
+      path <- paste0(
+        "/applications/",
+        applicationId,
+        "/properties/",
+        propertyName
+      )
       query <- paste0("force=", if (force) "1" else "0")
       DELETE(service, authInfo, path, query)
     },
@@ -231,28 +275,36 @@ cloudClient <- function(service, authInfo) {
     },
 
     createRevision = function(application, contentCategory) {
-        path <- paste0("/outputs/", application$id, "/revisions")
-        json <- list(content_category = contentCategory)
-        revision <- POST_JSON(service, authInfo, path, json)
-        revision$application_id
+      path <- paste0("/outputs/", application$id, "/revisions")
+      json <- list(content_category = contentCategory)
+      revision <- POST_JSON(service, authInfo, path, json)
+      revision$application_id
     },
 
     deployApplication = function(application, bundleId = NULL, spaceId = NULL) {
       currentProjectId <- getCurrentProjectId(service, authInfo)
       if (!is.null(currentProjectId)) {
-        PATCH_JSON(service, authInfo, paste0("/outputs/", application$id), list(project = currentProjectId))
+        PATCH_JSON(
+          service,
+          authInfo,
+          paste0("/outputs/", application$id),
+          list(project = currentProjectId)
+        )
       }
 
       if (!is.null(spaceId)) {
-        PATCH_JSON(service, authInfo, paste0("/outputs/", application$id), list(space = spaceId))
+        PATCH_JSON(
+          service,
+          authInfo,
+          paste0("/outputs/", application$id),
+          list(space = spaceId)
+        )
       }
 
       path <- paste0("/applications/", application$application_id, "/deploy")
       json <- list()
       if (length(bundleId) > 0 && nzchar(bundleId))
-        json$bundle <- as.numeric(bundleId)
-      else
-        json$rebuild <- FALSE
+        json$bundle <- as.numeric(bundleId) else json$rebuild <- FALSE
       POST_JSON(service, authInfo, path, json)
     },
 
@@ -266,27 +318,38 @@ cloudClient <- function(service, authInfo) {
       POST(service, authInfo, path)
     },
 
-    inviteApplicationUser = function(applicationId, email,
-                                     invite_email = NULL, invite_email_message = NULL) {
+    inviteApplicationUser = function(
+      applicationId,
+      email,
+      invite_email = NULL,
+      invite_email_message = NULL
+    ) {
       path <- paste0("/applications/", applicationId, "/authorization/users")
       json <- list()
       json$email <- email
-      if (!is.null(invite_email))
-        json$invite_email <- invite_email
+      if (!is.null(invite_email)) json$invite_email <- invite_email
       if (!is.null(invite_email_message))
         json$invite_email_message <- invite_email_message
       POST_JSON(service, authInfo, path, json)
     },
 
     addApplicationUser = function(applicationId, userId) {
-      path <- paste0("/applications/", applicationId, "/authorization/users/",
-                    userId)
+      path <- paste0(
+        "/applications/",
+        applicationId,
+        "/authorization/users/",
+        userId
+      )
       PUT(service, authInfo, path, NULL)
     },
 
     removeApplicationUser = function(applicationId, userId) {
-      path <- paste0("/applications/", applicationId, "/authorization/users/",
-                    userId)
+      path <- paste0(
+        "/applications/",
+        applicationId,
+        "/authorization/users/",
+        userId
+      )
       DELETE(service, authInfo, path)
     },
 
@@ -332,7 +395,6 @@ cloudClient <- function(service, authInfo) {
     },
 
     waitForTask = function(taskId, quiet = FALSE) {
-
       if (!quiet) {
         cat("Waiting for task: ", taskId, "\n", sep = "")
       }
@@ -341,7 +403,6 @@ cloudClient <- function(service, authInfo) {
 
       lastStatus <- NULL
       while (TRUE) {
-
         # check status
         status <- GET(service, authInfo, path)
 

--- a/R/client-connect.R
+++ b/R/client-connect.R
@@ -8,7 +8,6 @@ stripConnectTimestamps <- function(messages) {
 
 connectClient <- function(service, authInfo) {
   list(
-
     service = function() {
       "connect"
     },
@@ -47,18 +46,28 @@ connectClient <- function(service, authInfo) {
         filters <- vector()
       }
       path <- "/applications"
-      query <- paste(filterQuery(
-        c("account_id", names(filters)),
-        c(accountId, unname(filters))
-      ), collapse = "&")
+      query <- paste(
+        filterQuery(
+          c("account_id", names(filters)),
+          c(accountId, unname(filters))
+        ),
+        collapse = "&"
+      )
       listApplicationsRequest(service, authInfo, path, query, "applications")
     },
 
-    createApplication = function(name, title, template, accountId, appMode, contentCategory = NULL, spaceId = NULL) {
+    createApplication = function(
+      name,
+      title,
+      template,
+      accountId,
+      appMode,
+      contentCategory = NULL,
+      spaceId = NULL
+    ) {
       # add name; inject title if specified
       details <- list(name = name)
-      if (!is.null(title) && nzchar(title))
-        details$title <- title
+      if (!is.null(title) && nzchar(title)) details$title <- title
 
       # RSC doesn't currently use the template or account ID
       # parameters; they exist for compatibility with lucid.
@@ -94,8 +103,16 @@ connectClient <- function(service, authInfo) {
     },
 
     configureApplication = function(applicationId) {
-      GET(service, authInfo, paste(
-        "/applications/", applicationId, "/config", sep = ""))
+      GET(
+        service,
+        authInfo,
+        paste(
+          "/applications/",
+          applicationId,
+          "/config",
+          sep = ""
+        )
+      )
     },
 
     getApplication = function(applicationId, deploymentRecordVersion) {
@@ -107,9 +124,13 @@ connectClient <- function(service, authInfo) {
       wait <- 1
       while (TRUE) {
         path <- paste0(
-          "/v1/tasks/", taskId,
-          "?first=", first,
-          "&wait=", wait)
+          "/v1/tasks/",
+          taskId,
+          "?first=",
+          first,
+          "&wait=",
+          wait
+        )
         response <- GET(service, authInfo, path)
 
         if (length(response$output) > 0) {
@@ -171,25 +192,40 @@ userRecord <- function(email, username, first_name, last_name, password) {
 
 prettyPasteFields <- function(message, fields) {
   header <- paste(message, ":\n- ", sep = "")
-  body <- paste(strwrap(paste(shQuote(fields), collapse = ", ")),
-                collapse = "\n")
+  body <- paste(
+    strwrap(paste(shQuote(fields), collapse = ", ")),
+    collapse = "\n"
+  )
   paste(header, body, sep = "")
 }
 
 validateUserRecord <- function(record) {
-  requiredFields <- c("email", "username", "first_name", "last_name", "password")
+  requiredFields <- c(
+    "email",
+    "username",
+    "first_name",
+    "last_name",
+    "password"
+  )
   missingFields <- setdiff(requiredFields, names(record))
   extraFields <- setdiff(names(record), requiredFields)
 
   ## Construct error message if necessary
   msg <- NULL
   if (length(missingFields)) {
-    msg <- prettyPasteFields("The following required fields are missing",
-                             missingFields)
+    msg <- prettyPasteFields(
+      "The following required fields are missing",
+      missingFields
+    )
   }
   if (length(extraFields)) {
-    msg <- paste(msg, prettyPasteFields("The following extraneous fields were found",
-                                        extraFields))
+    msg <- paste(
+      msg,
+      prettyPasteFields(
+        "The following extraneous fields were found",
+        extraFields
+      )
+    )
   }
 
   if (!is.null(msg)) {
@@ -199,7 +235,6 @@ validateUserRecord <- function(record) {
 }
 
 getSnowflakeAuthToken <- function(url, snowflakeConnectionName) {
-
   parsedURL <- parseHttpUrl(url)
   ingressURL <- parsedURL$host
 

--- a/R/client-connect.R
+++ b/R/client-connect.R
@@ -67,7 +67,9 @@ connectClient <- function(service, authInfo) {
     ) {
       # add name; inject title if specified
       details <- list(name = name)
-      if (!is.null(title) && nzchar(title)) details$title <- title
+      if (!is.null(title) && nzchar(title)) {
+        details$title <- title
+      }
 
       # RSC doesn't currently use the template or account ID
       # parameters; they exist for compatibility with lucid.

--- a/R/client-shinyapps.R
+++ b/R/client-shinyapps.R
@@ -35,10 +35,18 @@ shinyAppsClient <- function(service, authInfo) {
         sep = ""
       )
       query <- list()
-      if (!is.null(applicationId)) query$application <- applicationId
-      if (!is.null(from)) query$from <- from
-      if (!is.null(until)) query$until <- until
-      if (!is.null(interval)) query$interval <- interval
+      if (!is.null(applicationId)) {
+        query$application <- applicationId
+      }
+      if (!is.null(from)) {
+        query$from <- from
+      }
+      if (!is.null(until)) {
+        query$until <- until
+      }
+      if (!is.null(interval)) {
+        query$interval <- interval
+      }
       GET(service, authInfo, path, queryString(query))
     },
 
@@ -110,9 +118,15 @@ shinyAppsClient <- function(service, authInfo) {
         }),
         collapse = "&"
       )
-      if (!is.null(from)) query$from <- from
-      if (!is.null(until)) query$until <- until
-      if (!is.null(interval)) query$interval <- interval
+      if (!is.null(from)) {
+        query$from <- from
+      }
+      if (!is.null(until)) {
+        query$until <- until
+      }
+      if (!is.null(interval)) {
+        query$interval <- interval
+      }
       GET(service, authInfo, path, paste(m, queryString(query), sep = "&"))
     },
 
@@ -198,8 +212,11 @@ shinyAppsClient <- function(service, authInfo) {
     deployApplication = function(application, bundleId = NULL, spaceId = NULL) {
       path <- paste("/applications/", application$id, "/deploy", sep = "")
       json <- list()
-      if (length(bundleId) > 0 && nzchar(bundleId))
-        json$bundle <- as.numeric(bundleId) else json$rebuild <- FALSE
+      if (length(bundleId) > 0 && nzchar(bundleId)) {
+        json$bundle <- as.numeric(bundleId)
+      } else {
+        json$rebuild <- FALSE
+      }
       POST_JSON(service, authInfo, path, json)
     },
 
@@ -227,9 +244,12 @@ shinyAppsClient <- function(service, authInfo) {
       )
       json <- list()
       json$email <- email
-      if (!is.null(invite_email)) json$invite_email <- invite_email
-      if (!is.null(invite_email_message))
+      if (!is.null(invite_email)) {
+        json$invite_email <- invite_email
+      }
+      if (!is.null(invite_email_message)) {
         json$invite_email_message <- invite_email_message
+      }
       POST_JSON(service, authInfo, path, json)
     },
 

--- a/R/client-shinyapps.R
+++ b/R/client-shinyapps.R
@@ -1,8 +1,7 @@
 shinyAppsClient <- function(service, authInfo) {
   list(
-
     status = function() {
-      GET(service, authInfo,  "/internal/status")
+      GET(service, authInfo, "/internal/status")
     },
 
     service = function() {
@@ -19,18 +18,27 @@ shinyAppsClient <- function(service, authInfo) {
       listRequest(service, authInfo, path, query, "accounts")
     },
 
-    getAccountUsage = function(accountId, usageType = "hours", applicationId = NULL,
-                               from = NULL, until = NULL, interval = NULL) {
-      path <- paste("/accounts/", accountId, "/usage/", usageType, "/", sep = "")
+    getAccountUsage = function(
+      accountId,
+      usageType = "hours",
+      applicationId = NULL,
+      from = NULL,
+      until = NULL,
+      interval = NULL
+    ) {
+      path <- paste(
+        "/accounts/",
+        accountId,
+        "/usage/",
+        usageType,
+        "/",
+        sep = ""
+      )
       query <- list()
-      if (!is.null(applicationId))
-        query$application <- applicationId
-      if (!is.null(from))
-        query$from <- from
-      if (!is.null(until))
-        query$until <- until
-      if (!is.null(interval))
-        query$interval <- interval
+      if (!is.null(applicationId)) query$application <- applicationId
+      if (!is.null(from)) query$from <- from
+      if (!is.null(until)) query$until <- until
+      if (!is.null(interval)) query$interval <- interval
       GET(service, authInfo, path, queryString(query))
     },
 
@@ -46,7 +54,12 @@ shinyAppsClient <- function(service, authInfo) {
       POST_JSON(service, authInfo, path, json)
     },
 
-    createBundle = function(application, content_type, content_length, checksum) {
+    createBundle = function(
+      application,
+      content_type,
+      content_length,
+      checksum
+    ) {
       json <- list()
       json$application <- application
       json$content_type <- content_type
@@ -55,12 +68,15 @@ shinyAppsClient <- function(service, authInfo) {
       POST_JSON(service, authInfo, "/bundles", json)
     },
 
-   listApplications = function(accountId, filters = list()) {
+    listApplications = function(accountId, filters = list()) {
       path <- "/applications/"
-      query <- paste(filterQuery(
-        c("account_id", "type", names(filters)),
-        c(accountId, "shiny", unname(filters))
-      ), collapse = "&")
+      query <- paste(
+        filterQuery(
+          c("account_id", "type", names(filters)),
+          c(accountId, "shiny", unname(filters))
+        ),
+        collapse = "&"
+      )
       listRequest(service, authInfo, path, query, "applications")
     },
 
@@ -71,16 +87,32 @@ shinyAppsClient <- function(service, authInfo) {
       application
     },
 
-    getApplicationMetrics = function(applicationId, series, metrics, from = NULL, until = NULL, interval = NULL) {
-      path <- paste("/applications/", applicationId, "/metrics/", series, "/", sep = "")
+    getApplicationMetrics = function(
+      applicationId,
+      series,
+      metrics,
+      from = NULL,
+      until = NULL,
+      interval = NULL
+    ) {
+      path <- paste(
+        "/applications/",
+        applicationId,
+        "/metrics/",
+        series,
+        "/",
+        sep = ""
+      )
       query <- list()
-      m <- paste(lapply(metrics, function(x) { paste("metric", urlEncode(x), sep = "=") }), collapse = "&")
-      if (!is.null(from))
-        query$from <- from
-      if (!is.null(until))
-        query$until <- until
-      if (!is.null(interval))
-        query$interval <- interval
+      m <- paste(
+        lapply(metrics, function(x) {
+          paste("metric", urlEncode(x), sep = "=")
+        }),
+        collapse = "&"
+      )
+      if (!is.null(from)) query$from <- from
+      if (!is.null(until)) query$until <- until
+      if (!is.null(interval)) query$interval <- interval
       GET(service, authInfo, path, paste(m, queryString(query), sep = "&"))
     },
 
@@ -90,7 +122,15 @@ shinyAppsClient <- function(service, authInfo) {
       GET(service, authInfo, path, query)
     },
 
-    createApplication = function(name, title, template, accountId, appMode, contentCategory = NULL, spaceId = NULL) {
+    createApplication = function(
+      name,
+      title,
+      template,
+      accountId,
+      appMode,
+      contentCategory = NULL,
+      spaceId = NULL
+    ) {
       json <- list()
       json$name <- name
       # the title field is only used on connect
@@ -109,20 +149,37 @@ shinyAppsClient <- function(service, authInfo) {
       GET(service, authInfo, path)
     },
 
-    setApplicationProperty = function(applicationId, propertyName,
-                                      propertyValue, force = FALSE) {
-      path <- paste("/applications/", applicationId, "/properties/",
-                    propertyName, sep = "")
+    setApplicationProperty = function(
+      applicationId,
+      propertyName,
+      propertyValue,
+      force = FALSE
+    ) {
+      path <- paste(
+        "/applications/",
+        applicationId,
+        "/properties/",
+        propertyName,
+        sep = ""
+      )
       v <- list()
       v$value <- propertyValue
       query <- paste("force=", if (force) "1" else "0", sep = "")
       PUT_JSON(service, authInfo, path, v, query)
     },
 
-    unsetApplicationProperty = function(applicationId, propertyName,
-                                        force = FALSE) {
-      path <- paste("/applications/", applicationId, "/properties/",
-                    propertyName, sep = "")
+    unsetApplicationProperty = function(
+      applicationId,
+      propertyName,
+      force = FALSE
+    ) {
+      path <- paste(
+        "/applications/",
+        applicationId,
+        "/properties/",
+        propertyName,
+        sep = ""
+      )
       query <- paste("force=", if (force) "1" else "0", sep = "")
       DELETE(service, authInfo, path, query)
     },
@@ -142,9 +199,7 @@ shinyAppsClient <- function(service, authInfo) {
       path <- paste("/applications/", application$id, "/deploy", sep = "")
       json <- list()
       if (length(bundleId) > 0 && nzchar(bundleId))
-        json$bundle <- as.numeric(bundleId)
-      else
-        json$rebuild <- FALSE
+        json$bundle <- as.numeric(bundleId) else json$rebuild <- FALSE
       POST_JSON(service, authInfo, path, json)
     },
 
@@ -158,46 +213,70 @@ shinyAppsClient <- function(service, authInfo) {
       POST(service, authInfo, path)
     },
 
-    inviteApplicationUser = function(applicationId, email,
-                                     invite_email = NULL, invite_email_message = NULL) {
-      path <- paste("/applications/", applicationId, "/authorization/users",
-                    sep = "")
+    inviteApplicationUser = function(
+      applicationId,
+      email,
+      invite_email = NULL,
+      invite_email_message = NULL
+    ) {
+      path <- paste(
+        "/applications/",
+        applicationId,
+        "/authorization/users",
+        sep = ""
+      )
       json <- list()
       json$email <- email
-      if (!is.null(invite_email))
-        json$invite_email <- invite_email
+      if (!is.null(invite_email)) json$invite_email <- invite_email
       if (!is.null(invite_email_message))
         json$invite_email_message <- invite_email_message
       POST_JSON(service, authInfo, path, json)
     },
 
     addApplicationUser = function(applicationId, userId) {
-      path <- paste("/applications/", applicationId, "/authorization/users/",
-                    userId, sep = "")
+      path <- paste(
+        "/applications/",
+        applicationId,
+        "/authorization/users/",
+        userId,
+        sep = ""
+      )
       PUT(service, authInfo, path, NULL)
     },
 
     removeApplicationUser = function(applicationId, userId) {
-      path <- paste("/applications/", applicationId, "/authorization/users/",
-                    userId, sep = "")
+      path <- paste(
+        "/applications/",
+        applicationId,
+        "/authorization/users/",
+        userId,
+        sep = ""
+      )
       DELETE(service, authInfo, path, NULL)
     },
 
     listApplicationAuthorization = function(applicationId) {
-      path <- paste("/applications/", applicationId, "/authorization",
-                    sep = "")
+      path <- paste("/applications/", applicationId, "/authorization", sep = "")
       listRequest(service, authInfo, path, NULL, "authorization")
     },
 
     listApplicationUsers = function(applicationId) {
-      path <- paste("/applications/", applicationId, "/authorization/users",
-                    sep = "")
+      path <- paste(
+        "/applications/",
+        applicationId,
+        "/authorization/users",
+        sep = ""
+      )
       listRequest(service, authInfo, path, NULL, "users")
     },
 
     listApplicationGroups = function(applicationId) {
-      path <- paste("/applications/", applicationId, "/authorization/groups",
-                    sep = "")
+      path <- paste(
+        "/applications/",
+        applicationId,
+        "/authorization/groups",
+        sep = ""
+      )
       listRequest(service, authInfo, path, NULL, "groups")
     },
 
@@ -235,7 +314,6 @@ shinyAppsClient <- function(service, authInfo) {
     },
 
     waitForTask = function(taskId, quiet = FALSE) {
-
       if (!quiet) {
         cat("Waiting for task: ", taskId, "\n", sep = "")
       }
@@ -244,7 +322,6 @@ shinyAppsClient <- function(service, authInfo) {
 
       lastStatus <- NULL
       while (TRUE) {
-
         # check status
         status <- GET(service, authInfo, path)
 

--- a/R/client.R
+++ b/R/client.R
@@ -8,7 +8,10 @@ clientForAccount <- function(account) {
   } else if (isPositCloudServer(account$server)) {
     cloudClient(serverUrl, account)
   } else if (isSPCSServer(account$server)) {
-    account$snowflakeToken <- getSnowflakeAuthToken(serverInfo$url, account$snowflakeConnectionName)
+    account$snowflakeToken <- getSnowflakeAuthToken(
+      serverInfo$url,
+      account$snowflakeConnectionName
+    )
     connectClient(serverUrl, account)
   } else {
     connectClient(serverUrl, account)
@@ -17,9 +20,15 @@ clientForAccount <- function(account) {
 
 # Appropriate when the list API includes "count" and "total" fields in the response JSON and the API
 # supports pagination with the query arguments count=PAGE_SIZE&offset=STARTING_POINT.
-listRequest <- function(service, authInfo, path, query, listName, page = 100,
-                       max = NULL) {
-
+listRequest <- function(
+  service,
+  authInfo,
+  path,
+  query,
+  listName,
+  page = 100,
+  max = NULL
+) {
   # accumulate multiple pages of results
   offset <- 0
   results <- list()
@@ -41,8 +50,7 @@ listRequest <- function(service, authInfo, path, query, listName, page = 100,
     }
 
     # exit if we've got them all
-    if (length(results) >= response$total || length(results) >= max)
-      break
+    if (length(results) >= response$total || length(results) >= max) break
   }
 
   return(results)
@@ -50,9 +58,15 @@ listRequest <- function(service, authInfo, path, query, listName, page = 100,
 
 # /__api__/applications response with { applications: [], count: M, total: N, continuation: "CONTINUATION" }
 # To paginate, use the query arguments cont=CONTINUATION&start=START&count=MAX
-listApplicationsRequest <- function(service, authInfo, path, query, listName, page = 100,
-                       max = NULL) {
-
+listApplicationsRequest <- function(
+  service,
+  authInfo,
+  path,
+  query,
+  listName,
+  page = 100,
+  max = NULL
+) {
   # accumulate multiple pages of results
   start <- 0
   cont <- ""
@@ -60,11 +74,16 @@ listApplicationsRequest <- function(service, authInfo, path, query, listName, pa
 
   repeat {
     # add query params
-    queryWithList <- paste(query,
-                           "&count=", page,
-                           "&start=", start,
-                           "&cont=", cont,
-                           sep = "")
+    queryWithList <- paste(
+      query,
+      "&count=",
+      page,
+      "&start=",
+      start,
+      "&cont=",
+      cont,
+      sep = ""
+    )
 
     # make request and append the results
     response <- GET(service, authInfo, path, queryWithList)
@@ -80,8 +99,7 @@ listApplicationsRequest <- function(service, authInfo, path, query, listName, pa
     }
 
     # exit if we've got them all
-    if (length(results) >= response$total || length(results) >= max)
-      break
+    if (length(results) >= response$total || length(results) >= max) break
   }
 
   return(results)
@@ -101,10 +119,12 @@ isContentType <- function(x, contentType) {
   grepl(contentType, x, fixed = TRUE)
 }
 
-uploadCloudBundle <- function(client,
-                              application_id,
-                              bundlePath,
-                              verbose = FALSE) {
+uploadCloudBundle <- function(
+  client,
+  application_id,
+  bundlePath,
+  verbose = FALSE
+) {
   # Step 1. Create presigned URL and register pending bundle.
   bundleSize <- file.info(bundlePath)$size
   bundle <- client$createBundle(
@@ -130,15 +150,14 @@ uploadCloudBundle <- function(client,
 }
 
 uploadBundle <- function(bundle, bundleSize, bundlePath) {
-
   presigned_service <- parseHttpUrl(bundle$presigned_url)
 
   headers <- list()
-  headers$`Content-Type` <-  "application/x-tar"
-  headers$`Content-Length` <-  bundleSize
+  headers$`Content-Type` <- "application/x-tar"
+  headers$`Content-Length` <- bundleSize
 
   # AWS requires a base64 encoded hash
-  headers$`Content-MD5` <-  bundle$presigned_checksum
+  headers$`Content-MD5` <- bundle$presigned_checksum
 
   # AWS seems very sensitive to additional headers (likely becauseit was not included and signed
   # for when the presigned link was created). So the lower level library is used here.

--- a/R/client.R
+++ b/R/client.R
@@ -50,7 +50,9 @@ listRequest <- function(
     }
 
     # exit if we've got them all
-    if (length(results) >= response$total || length(results) >= max) break
+    if (length(results) >= response$total || length(results) >= max) {
+      break
+    }
   }
 
   return(results)
@@ -99,7 +101,9 @@ listApplicationsRequest <- function(
     }
 
     # exit if we've got them all
-    if (length(results) >= response$total || length(results) >= max) break
+    if (length(results) >= response$total || length(results) >= max) {
+      break
+    }
   }
 
   return(results)

--- a/R/config.R
+++ b/R/config.R
@@ -46,16 +46,17 @@ applicationConfigDir <- function() {
     # In older versions of R, use an implementation derived from R_user_dir
     home <- Sys.getenv("HOME", unset = normalizePath("~"))
     path <-
-      if (nzchar(p <- Sys.getenv("R_USER_CONFIG_DIR"))) p else if (
-        nzchar(p <- Sys.getenv("XDG_CONFIG_HOME"))
-      )
-        p else if (.Platform$OS.type == "windows")
-        file.path(Sys.getenv("APPDATA"), "R", "config") else if (
-        Sys.info()["sysname"] == "Darwin"
-      )
-        file.path(home, "Library", "Preferences", "org.R-project.R") else
+      if (nzchar(p <- Sys.getenv("R_USER_CONFIG_DIR"))) {
+        p
+      } else if (nzchar(p <- Sys.getenv("XDG_CONFIG_HOME"))) {
+        p
+      } else if (.Platform$OS.type == "windows") {
+        file.path(Sys.getenv("APPDATA"), "R", "config")
+      } else if (Sys.info()["sysname"] == "Darwin") {
+        file.path(home, "Library", "Preferences", "org.R-project.R")
+      } else {
         file.path(home, ".config")
-
+      }
     file.path(path, "R", "rsconnect")
   }
 }

--- a/R/config.R
+++ b/R/config.R
@@ -37,7 +37,6 @@ rsconnectConfigDir <- function(subDir = NULL) {
 #'
 #' @keywords internal
 applicationConfigDir <- function() {
-
   if (exists("R_user_dir", envir = asNamespace("tools"))) {
     # In newer versions of R (>=4.0), we can ask R itself where configuration should be stored.
     # Load from the namespace to avoid check warnings with old R.
@@ -47,15 +46,14 @@ applicationConfigDir <- function() {
     # In older versions of R, use an implementation derived from R_user_dir
     home <- Sys.getenv("HOME", unset = normalizePath("~"))
     path <-
-      if (nzchar(p <- Sys.getenv("R_USER_CONFIG_DIR")))
-        p
-      else if (nzchar(p <- Sys.getenv("XDG_CONFIG_HOME")))
-        p
-      else if (.Platform$OS.type == "windows")
-        file.path(Sys.getenv("APPDATA"), "R", "config")
-      else if (Sys.info()["sysname"] == "Darwin")
-        file.path(home, "Library", "Preferences", "org.R-project.R")
-      else
+      if (nzchar(p <- Sys.getenv("R_USER_CONFIG_DIR"))) p else if (
+        nzchar(p <- Sys.getenv("XDG_CONFIG_HOME"))
+      )
+        p else if (.Platform$OS.type == "windows")
+        file.path(Sys.getenv("APPDATA"), "R", "config") else if (
+        Sys.info()["sysname"] == "Darwin"
+      )
+        file.path(home, "Library", "Preferences", "org.R-project.R") else
         file.path(home, ".config")
 
     file.path(path, "R", "rsconnect")
@@ -96,7 +94,12 @@ accountConfigFiles <- function(server = NULL) {
     path <- file.path(path, server)
   }
 
-  list.files(path, pattern = glob2rx("*.dcf"), recursive = TRUE, full.names = TRUE)
+  list.files(
+    path,
+    pattern = glob2rx("*.dcf"),
+    recursive = TRUE,
+    full.names = TRUE
+  )
 }
 
 
@@ -113,7 +116,12 @@ deploymentHistoryPath <- function(new = FALSE) {
 # stored
 deploymentConfigDir <- function(recordPath) {
   if (isDocumentPath(recordPath)) {
-    file.path(dirname(recordPath), "rsconnect", "documents", basename(recordPath))
+    file.path(
+      dirname(recordPath),
+      "rsconnect",
+      "documents",
+      basename(recordPath)
+    )
   } else {
     file.path(recordPath, "rsconnect")
   }

--- a/R/configMigrate.R
+++ b/R/configMigrate.R
@@ -11,7 +11,6 @@ migrateConfig <- function(configDir) {
 
   # We have no configuration directory but we do have an old one; migrate it.
   if (dirExists(oldConfigDir)) {
-
     # Create the parent folder if necessary
     dirCreate(dirname(configDir))
 
@@ -35,7 +34,6 @@ migrateConfig <- function(configDir) {
 #'
 #' @keywords internal
 oldApplicationConfigDir <- function(appName) {
-
   # get the home directory from the operating system (in case
   # the user has redefined the meaning of ~) but fault back
   # to ~ if there is no HOME variable defined
@@ -51,10 +49,8 @@ oldApplicationConfigDir <- function(appName) {
     # no R specific config dir; determine application config dir (platform specific)
     sysName <- Sys.info()[["sysname"]]
     if (identical(sysName, "Windows"))
-      configDir <- Sys.getenv("APPDATA")
-    else if (identical(sysName, "Darwin"))
-      configDir <- file.path(homeDir, "Library/Application Support")
-    else
+      configDir <- Sys.getenv("APPDATA") else if (identical(sysName, "Darwin"))
+      configDir <- file.path(homeDir, "Library/Application Support") else
       configDir <- Sys.getenv("XDG_CONFIG_HOME", file.path(homeDir, ".config"))
 
     # append the application name
@@ -80,12 +76,17 @@ migrateDeploymentsConfig <- function(appPath) {
   }
 
   migrateDir <- file.path(migrateRoot, "rsconnect")
-  for (shinyappsFile in list.files(shinyappsDir, glob2rx("*.dcf"),
-                                   recursive = TRUE)) {
+  for (shinyappsFile in list.files(
+    shinyappsDir,
+    glob2rx("*.dcf"),
+    recursive = TRUE
+  )) {
     # read deployment record
     shinyappsDCF <- file.path(shinyappsDir, shinyappsFile)
-    deployment <- as.data.frame(read.dcf(shinyappsDCF),
-                                stringsAsFactors = FALSE)
+    deployment <- as.data.frame(
+      read.dcf(shinyappsDCF),
+      stringsAsFactors = FALSE
+    )
     deployment$server <- "shinyapps.io"
 
     # write the new record
@@ -98,9 +99,6 @@ migrateDeploymentsConfig <- function(appPath) {
   }
 
   # remove shinyapps dir if it's completely empty
-  remainingFiles <- list.files(shinyappsDir,
-                               recursive = TRUE,
-                               all.files = TRUE)
-  if (length(remainingFiles) == 0)
-    unlink(shinyappsDir, recursive = TRUE)
+  remainingFiles <- list.files(shinyappsDir, recursive = TRUE, all.files = TRUE)
+  if (length(remainingFiles) == 0) unlink(shinyappsDir, recursive = TRUE)
 }

--- a/R/configMigrate.R
+++ b/R/configMigrate.R
@@ -48,10 +48,13 @@ oldApplicationConfigDir <- function(appName) {
   } else {
     # no R specific config dir; determine application config dir (platform specific)
     sysName <- Sys.info()[["sysname"]]
-    if (identical(sysName, "Windows"))
-      configDir <- Sys.getenv("APPDATA") else if (identical(sysName, "Darwin"))
-      configDir <- file.path(homeDir, "Library/Application Support") else
+    if (identical(sysName, "Windows")) {
+      configDir <- Sys.getenv("APPDATA")
+    } else if (identical(sysName, "Darwin")) {
+      configDir <- file.path(homeDir, "Library/Application Support")
+    } else {
       configDir <- Sys.getenv("XDG_CONFIG_HOME", file.path(homeDir, ".config"))
+    }
 
     # append the application name
     configDir <- file.path(configDir, "R", appName)
@@ -67,7 +70,11 @@ migrateDeploymentsConfig <- function(appPath) {
   # calculate migration dir--all shinyapps deployment records go into the root
   # folder since it wasn't possible to deploy individual docs using the
   # shinyapps package
-  migrateRoot <- if (isDocumentPath(appPath)) dirname(appPath) else appPath
+  migrateRoot <- if (isDocumentPath(appPath)) {
+    dirname(appPath)
+  } else {
+    appPath
+  }
 
   # migrate shinyapps package created records if necessary
   shinyappsDir <- file.path(migrateRoot, "shinyapps")
@@ -100,5 +107,7 @@ migrateDeploymentsConfig <- function(appPath) {
 
   # remove shinyapps dir if it's completely empty
   remainingFiles <- list.files(shinyappsDir, recursive = TRUE, all.files = TRUE)
-  if (length(remainingFiles) == 0) unlink(shinyappsDir, recursive = TRUE)
+  if (length(remainingFiles) == 0) {
+    unlink(shinyappsDir, recursive = TRUE)
+  }
 }

--- a/R/configureApp.R
+++ b/R/configureApp.R
@@ -20,15 +20,20 @@
 #' @seealso [applications()], [deployApp()]
 #' @note This function works only for ShinyApps servers.
 #' @export
-configureApp <- function(appName, appDir = getwd(), account = NULL, server = NULL,
-                         redeploy = TRUE, size = NULL,
-                         instances = NULL, logLevel = c("normal", "quiet", "verbose")) {
-
+configureApp <- function(
+  appName,
+  appDir = getwd(),
+  account = NULL,
+  server = NULL,
+  redeploy = TRUE,
+  size = NULL,
+  instances = NULL,
+  logLevel = c("normal", "quiet", "verbose")
+) {
   accountDetails <- accountInfo(account, server)
   checkShinyappsServer(accountDetails$server)
 
-  if (is.null(appName))
-    appName <- basename(appDir)
+  if (is.null(appName)) appName <- basename(appDir)
   application <- resolveApplication(accountDetails, appName)
 
   displayStatus <- displayStatus(identical(logLevel, "quiet"))
@@ -38,10 +43,10 @@ configureApp <- function(appName, appDir = getwd(), account = NULL, server = NUL
 
   # get a list of properties to set
   properties <- list()
-  if (! is.null(size)) {
+  if (!is.null(size)) {
     properties[["application.instances.template"]] <- size
   }
-  if (! is.null(instances)) {
+  if (!is.null(instances)) {
     properties[["application.instances.count"]] <- instances
   }
 
@@ -53,20 +58,34 @@ configureApp <- function(appName, appDir = getwd(), account = NULL, server = NUL
 
     # dispatch to the appropriate client implementation
     if (is.function(client$configureApplication))
-      client$configureApplication(application$id, propertyName, propertyValue)
-    else if (is.function(client$setApplicationProperty))
-      client$setApplicationProperty(application$id, propertyName, propertyValue)
-    else
-      stop("Server ", accountDetails$server, " has no appropriate configuration method.")
+      client$configureApplication(
+        application$id,
+        propertyName,
+        propertyValue
+      ) else if (is.function(client$setApplicationProperty))
+      client$setApplicationProperty(
+        application$id,
+        propertyName,
+        propertyValue
+      ) else
+      stop(
+        "Server ",
+        accountDetails$server,
+        " has no appropriate configuration method."
+      )
   }
 
   # redeploy application if requested
   if (redeploy) {
     if (length(properties) > 0) {
-      deployApp(appDir = appDir, appName = appName, account = account, logLevel = logLevel, upload = rebuildRequired)
-    }
-    else
-    {
+      deployApp(
+        appDir = appDir,
+        appName = appName,
+        account = account,
+        logLevel = logLevel,
+        upload = rebuildRequired
+      )
+    } else {
       displayStatus("No configuration changes to deploy")
     }
   }
@@ -97,9 +116,15 @@ configureApp <- function(appName, appDir = getwd(), account = NULL, server = NUL
 #'
 #' }
 #' @export
-setProperty <- function(propertyName, propertyValue, appPath = getwd(),
-                        appName = NULL, account = NULL, server = NULL, force = FALSE) {
-
+setProperty <- function(
+  propertyName,
+  propertyValue,
+  appPath = getwd(),
+  appName = NULL,
+  account = NULL,
+  server = NULL,
+  force = FALSE
+) {
   deployment <- findDeployment(
     appPath = appPath,
     appName = appName,
@@ -112,10 +137,12 @@ setProperty <- function(propertyName, propertyValue, appPath = getwd(),
   client <- clientForAccount(accountDetails)
   application <- getAppByName(client, accountDetails, deployment$name)
 
-  invisible(client$setApplicationProperty(application$id,
-                                         propertyName,
-                                         propertyValue,
-                                         force))
+  invisible(client$setApplicationProperty(
+    application$id,
+    propertyName,
+    propertyValue,
+    force
+  ))
 }
 
 #' Unset Application property
@@ -136,9 +163,14 @@ setProperty <- function(propertyName, propertyValue, appPath = getwd(),
 #'
 #' }
 #' @export
-unsetProperty <- function(propertyName, appPath = getwd(), appName = NULL,
-                          account = NULL, server = NULL, force = FALSE) {
-
+unsetProperty <- function(
+  propertyName,
+  appPath = getwd(),
+  appName = NULL,
+  account = NULL,
+  server = NULL,
+  force = FALSE
+) {
   deployment <- findDeployment(
     appPath = appPath,
     appName = appName,
@@ -151,9 +183,11 @@ unsetProperty <- function(propertyName, appPath = getwd(), appName = NULL,
   client <- clientForAccount(accountDetails)
   application <- getAppByName(client, accountInfo, deployment$name)
 
-  invisible(client$unsetApplicationProperty(application$id,
-                                           propertyName,
-                                           force))
+  invisible(client$unsetApplicationProperty(
+    application$id,
+    propertyName,
+    force
+  ))
 }
 
 
@@ -169,8 +203,12 @@ unsetProperty <- function(propertyName, appPath = getwd(), appName = NULL,
 #' @note This function works only for ShinyApps servers.
 #'
 #' @export
-showProperties <- function(appPath = getwd(), appName = NULL, account = NULL, server = NULL) {
-
+showProperties <- function(
+  appPath = getwd(),
+  appName = NULL,
+  account = NULL,
+  server = NULL
+) {
   deployment <- findDeployment(
     appPath = appPath,
     appName = appName,

--- a/R/configureApp.R
+++ b/R/configureApp.R
@@ -33,7 +33,9 @@ configureApp <- function(
   accountDetails <- accountInfo(account, server)
   checkShinyappsServer(accountDetails$server)
 
-  if (is.null(appName)) appName <- basename(appDir)
+  if (is.null(appName)) {
+    appName <- basename(appDir)
+  }
   application <- resolveApplication(accountDetails, appName)
 
   displayStatus <- displayStatus(identical(logLevel, "quiet"))

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -206,39 +206,38 @@
 #' @seealso [applications()], [terminateApp()], and [restartApp()]
 #' @family Deployment functions
 #' @export
-deployApp <- function(appDir = getwd(),
-                      appFiles = NULL,
-                      appFileManifest = NULL,
-                      appPrimaryDoc = NULL,
-                      appSourceDoc = NULL,
-                      appName = NULL,
-                      appTitle = NULL,
-                      envVars = NULL,
-                      appId = NULL,
-                      appMode = NULL,
-                      contentCategory = NULL,
-                      account = NULL,
-                      server = NULL,
-                      upload = TRUE,
-                      recordDir = NULL,
-                      launch.browser = getOption("rsconnect.launch.browser",
-                                                 is_interactive()),
-                      on.failure = NULL,
-                      logLevel = c("normal", "quiet", "verbose"),
-                      lint = TRUE,
-                      metadata = list(),
-                      forceUpdate = NULL,
-                      python = NULL,
-                      forceGeneratePythonEnvironment = FALSE,
-                      quarto = NA,
-                      appVisibility = NULL,
-                      image = NULL,
-                      envManagement = NULL,
-                      envManagementR = NULL,
-                      envManagementPy = NULL,
-                      space = NULL
-                      ) {
-
+deployApp <- function(
+  appDir = getwd(),
+  appFiles = NULL,
+  appFileManifest = NULL,
+  appPrimaryDoc = NULL,
+  appSourceDoc = NULL,
+  appName = NULL,
+  appTitle = NULL,
+  envVars = NULL,
+  appId = NULL,
+  appMode = NULL,
+  contentCategory = NULL,
+  account = NULL,
+  server = NULL,
+  upload = TRUE,
+  recordDir = NULL,
+  launch.browser = getOption("rsconnect.launch.browser", is_interactive()),
+  on.failure = NULL,
+  logLevel = c("normal", "quiet", "verbose"),
+  lint = TRUE,
+  metadata = list(),
+  forceUpdate = NULL,
+  python = NULL,
+  forceGeneratePythonEnvironment = FALSE,
+  quarto = NA,
+  appVisibility = NULL,
+  image = NULL,
+  envManagement = NULL,
+  envManagementR = NULL,
+  envManagementPy = NULL,
+  space = NULL
+) {
   check_string(appDir)
   if (isStaticFile(appDir) && !dirExists(appDir)) {
     lifecycle::deprecate_warn(
@@ -330,7 +329,9 @@ deployApp <- function(appDir = getwd(),
     cli::cli_rule("Preparing for deployment")
   }
 
-  forceUpdate <- forceUpdate %||% getOption("rsconnect.force.update.apps") %||% fromIDE()
+  forceUpdate <- forceUpdate %||%
+    getOption("rsconnect.force.update.apps") %||%
+    fromIDE()
 
   # determine the target deployment record and deploying account
   recordPath <- findRecordPath(appDir, recordDir, appPrimaryDoc)
@@ -349,18 +350,26 @@ deployApp <- function(appDir = getwd(),
 
   if (is.null(deployment$appId)) {
     dest <- accountLabel(accountDetails$name, accountDetails$server)
-    taskComplete(quiet, "Deploying {.val {deployment$name}} using {.val {dest}}")
+    taskComplete(
+      quiet,
+      "Deploying {.val {deployment$name}} using {.val {dest}}"
+    )
   } else {
     dest <- accountLabel(accountDetails$name, accountDetails$server)
-    taskComplete(quiet, "Re-deploying {.val {deployment$name}} using {.val {dest}}")
+    taskComplete(
+      quiet,
+      "Re-deploying {.val {deployment$name}} using {.val {dest}}"
+    )
   }
 
   # Run checks prior to first saveDeployment() to avoid errors that will always
   # prevent a successful upload from generating a partial deployment
   if (!isCloudServer(accountDetails$server) && identical(upload, FALSE)) {
     # it is not possible to deploy to Connect without uploading
-    stop("Posit Connect does not support deploying without uploading. ",
-         "Specify upload=TRUE to upload and re-deploy your application.")
+    stop(
+      "Posit Connect does not support deploying without uploading. ",
+      "Specify upload=TRUE to upload and re-deploy your application."
+    )
   }
   if (!isConnectServer(accountDetails$server) && length(envVars) > 1) {
     cli::cli_abort("{.arg envVars} only supported for Posit Connect servers")
@@ -398,21 +407,38 @@ deployApp <- function(appDir = getwd(),
     )
     taskComplete(quiet, "Created application with id {.val {application$id}}")
   } else {
-    taskStart(quiet, "Looking up application with id {.val {deployment$appId}}...")
+    taskStart(
+      quiet,
+      "Looking up application with id {.val {deployment$appId}}..."
+    )
     application <- tryCatch(
       {
-        application <- client$getApplication(deployment$appId, deployment$version)
+        application <- client$getApplication(
+          deployment$appId,
+          deployment$version
+        )
         taskComplete(quiet, "Found application {.url {application$url}}")
 
         if (identical(application$type, "static")) {
-          application$application_id <- client$createRevision(application, contentCategory)
+          application$application_id <- client$createRevision(
+            application,
+            contentCategory
+          )
         }
 
         application
       },
       rsconnect_http_404 = function(err) {
-        application <- applicationDeleted(client, deployment, recordPath, appMetadata)
-        taskComplete(quiet, "Created application with id {.val {application$id}}")
+        application <- applicationDeleted(
+          client,
+          deployment,
+          recordPath,
+          appMetadata
+        )
+        taskComplete(
+          quiet,
+          "Created application with id {.val {application$id}}"
+        )
         application
       }
     )
@@ -425,7 +451,9 @@ deployApp <- function(appDir = getwd(),
   )
 
   # Change _visibility_ & set env vars before uploading contents
-  if (needsVisibilityChange(accountDetails$server, application, appVisibility)) {
+  if (
+    needsVisibilityChange(accountDetails$server, application, appVisibility)
+  ) {
     taskStart(quiet, "Setting visibility to {appVisibility}...")
     client$setApplicationProperty(
       application$id,
@@ -464,7 +492,11 @@ deployApp <- function(appDir = getwd(),
     # create, and upload the bundle
     taskStart(quiet, "Uploading bundle...")
     if (isCloudServer(accountDetails$server)) {
-      bundle <- uploadCloudBundle(client, application$application_id, bundlePath)
+      bundle <- uploadCloudBundle(
+        client,
+        application$application_id,
+        bundlePath
+      )
     } else {
       bundle <- client$uploadApplication(application$id, bundlePath)
     }
@@ -500,14 +532,22 @@ deployApp <- function(appDir = getwd(),
   deploymentSucceeded <- is.null(response$code) || response$code == 0
   if (!quiet) {
     if (deploymentSucceeded) {
-      cli::cli_alert_success("Successfully deployed to {.url {application$url}}")
+      cli::cli_alert_success(
+        "Successfully deployed to {.url {application$url}}"
+      )
     } else {
       cli::cli_alert_danger("Deployment failed with error: {response$error}")
     }
   }
 
   if (!quiet)
-    openURL(client, application, launch.browser, on.failure, deploymentSucceeded)
+    openURL(
+      client,
+      application,
+      launch.browser,
+      on.failure,
+      deploymentSucceeded
+    )
 
   # invoke post-deploy hook if we have one
   if (deploymentSucceeded) {
@@ -528,9 +568,7 @@ taskComplete <- function(quiet, message, .envir = caller_env()) {
   cli::cli_alert_success(message, .envir = .envir)
 }
 
-findRecordPath <- function(appDir,
-                           recordDir = NULL,
-                           appPrimaryDoc = NULL) {
+findRecordPath <- function(appDir, recordDir = NULL, appPrimaryDoc = NULL) {
   if (!is.null(recordDir)) {
     recordDir
   } else if (!is.null(appPrimaryDoc)) {
@@ -614,17 +652,19 @@ applicationDeleted <- function(client, deployment, recordPath, appMetadata) {
 # deployApp() instead of being exposed to the user. Returns the path to the
 # bundle directory, whereas writeManifest() returns nothing and deletes the
 # bundle directory after writing the manifest.
-bundleApp <- function(appName,
-                      appDir,
-                      appFiles,
-                      appMetadata,
-                      verbose = FALSE,
-                      quiet = FALSE,
-                      pythonConfig = NULL,
-                      image = NULL,
-                      envManagement = NULL,
-                      envManagementR = NULL,
-                      envManagementPy = NULL) {
+bundleApp <- function(
+  appName,
+  appDir,
+  appFiles,
+  appMetadata,
+  verbose = FALSE,
+  quiet = FALSE,
+  pythonConfig = NULL,
+  image = NULL,
+  envManagement = NULL,
+  envManagementR = NULL,
+  envManagementPy = NULL
+) {
   logger <- verboseLogger(verbose)
 
   # get application users (for non-document deployments)
@@ -636,10 +676,10 @@ bundleApp <- function(appName,
   # copy files to bundle dir to stage
   logger("Bundling app dir")
   bundleDir <- bundleAppDir(
-      appDir = appDir,
-      appFiles = appFiles,
-      appPrimaryDoc = appMetadata$appPrimaryDoc,
-      appMode = appMetadata$appMode
+    appDir = appDir,
+    appFiles = appFiles,
+    appPrimaryDoc = appMetadata$appPrimaryDoc,
+    appMode = appMetadata$appMode
   )
   defer(unlink(bundleDir, recursive = TRUE))
 
@@ -673,13 +713,18 @@ validURL <- function(url) {
   !(is.null(url) || url == "")
 }
 
-openURL <- function(client, application, launch.browser, on.failure, deploymentSucceeded) {
-
+openURL <- function(
+  client,
+  application,
+  launch.browser,
+  on.failure,
+  deploymentSucceeded
+) {
   # function to browse to a URL using user-supplied browser (config or final)
   showURL <- function(url) {
-    if (isTRUE(launch.browser))
-      utils::browseURL(url)
-    else if (is.function(launch.browser))
+    if (isTRUE(launch.browser)) utils::browseURL(url) else if (
+      is.function(launch.browser)
+    )
       launch.browser(url)
   }
 
@@ -706,7 +751,7 @@ openURL <- function(client, application, launch.browser, on.failure, deploymentS
   } else if (is.function(on.failure)) {
     on.failure(NULL)
   }
-    # or open no url if things failed
+  # or open no url if things failed
 }
 
 runStartupScripts <- function(appDir, quiet = FALSE, verbose = FALSE) {

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -722,10 +722,11 @@ openURL <- function(
 ) {
   # function to browse to a URL using user-supplied browser (config or final)
   showURL <- function(url) {
-    if (isTRUE(launch.browser)) utils::browseURL(url) else if (
-      is.function(launch.browser)
-    )
+    if (isTRUE(launch.browser)) {
+      utils::browseURL(url)
+    } else if (is.function(launch.browser)) {
       launch.browser(url)
+    }
   }
 
   # Check to see if we should open config url or app url

--- a/R/deployDoc.R
+++ b/R/deployDoc.R
@@ -36,10 +36,12 @@ deployDoc <- function(doc, ..., logLevel = c("normal", "quiet", "verbose")) {
   )
 }
 
-standardizeSingleDocDeployment <- function(path,
-                                           quiet = FALSE,
-                                           error_call = caller_env(),
-                                           error_arg = caller_arg(path)) {
+standardizeSingleDocDeployment <- function(
+  path,
+  quiet = FALSE,
+  error_call = caller_env(),
+  error_arg = caller_arg(path)
+) {
   check_installed(
     "rmarkdown",
     version = "0.5.2",

--- a/R/deploySite.R
+++ b/R/deploySite.R
@@ -24,20 +24,21 @@
 #'   `deploySite()`.
 #' @family Deployment functions
 #' @export
-deploySite <- function(siteDir = getwd(),
-                       siteName = NULL,
-                       siteTitle = NULL,
-                       account = NULL,
-                       server = NULL,
-                       render = c("none", "local", "server"),
-                       launch.browser = getOption("rsconnect.launch.browser", interactive()),
-                       logLevel = c("normal", "quiet", "verbose"),
-                       lint = FALSE,
-                       metadata = list(),
-                       python = NULL,
-                       recordDir = NULL,
-                       ...) {
-
+deploySite <- function(
+  siteDir = getwd(),
+  siteName = NULL,
+  siteTitle = NULL,
+  account = NULL,
+  server = NULL,
+  render = c("none", "local", "server"),
+  launch.browser = getOption("rsconnect.launch.browser", interactive()),
+  logLevel = c("normal", "quiet", "verbose"),
+  lint = FALSE,
+  metadata = list(),
+  python = NULL,
+  recordDir = NULL,
+  ...
+) {
   check_directory(siteDir)
   isQuarto <- file.exists(file.path(siteDir, "_quarto.yml")) ||
     file.exists(file.path(siteDir, "_quarto.yaml"))
@@ -67,7 +68,7 @@ deploySite <- function(siteDir = getwd(),
     # We're deploying an entire directory, so we don't really need to set
     # a path here, but we don't want to break existing deployments so
     # we leave the existing behaviour for RMarkdown
-    if (!isQuarto)  {
+    if (!isQuarto) {
       name <- if (file.exists("index.Rmd")) "index.Rmd" else "index.md"
       recordDir <- file.path(siteDir, name)
     } else {
@@ -102,7 +103,8 @@ quartoSite <- function(path, quiet = FALSE, error_call = caller_env()) {
   config <- quarto::quarto_inspect(path)$config
 
   list(
-    render = function() quarto::quarto_render(path, quiet = quiet, as_job = FALSE),
+    render = function()
+      quarto::quarto_render(path, quiet = quiet, as_job = FALSE),
     name = basename(normalizePath(path)),
     title = config$website$title %||% config$book$title %||% config$title,
     # non-site projects build in current directory

--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -41,7 +41,6 @@ findDeploymentTarget <- function(
   forceUpdate = FALSE,
   error_call = caller_env()
 ) {
-
   if (!is.null(appId)) {
     return(findDeploymentTargetByAppId(
       recordPath = recordPath,
@@ -79,9 +78,16 @@ findDeploymentTarget <- function(
     serverFilter = server
   )
   if (nrow(allDeployments) > 0) {
-    deployment <- disambiguateDeployments(allDeployments, error_call = error_call)
+    deployment <- disambiguateDeployments(
+      allDeployments,
+      error_call = error_call
+    )
     deployment <- updateDeployment(deployment, appTitle, envVars)
-    accountDetails <- findAccountInfo(deployment$account, deployment$server, error_call = error_call)
+    accountDetails <- findAccountInfo(
+      deployment$account,
+      deployment$server,
+      error_call = error_call
+    )
     return(list(
       accountDetails = accountDetails,
       deployment = deployment
@@ -91,7 +97,12 @@ findDeploymentTarget <- function(
   # Otherwise, identify a target account (given just one available or prompted
   # by the user), generate a name, and locate the deployment.
   accountDetails <- findAccountInfo(account, server, error_call = error_call)
-  appName <- generateAppName(appTitle, recordPath, accountDetails$name, unique = FALSE)
+  appName <- generateAppName(
+    appTitle,
+    recordPath,
+    accountDetails$name,
+    unique = FALSE
+  )
   return(findDeploymentTargetByAppName(
     recordPath = recordPath,
     appName = appName,
@@ -125,7 +136,6 @@ findDeploymentTargetByAppId <- function(
   server = NULL,
   error_call = caller_env()
 ) {
-
   # We must have a target account+server in order to use the appId.
   # The selected account may not be the original creator of the content.
   accountDetails <- findAccountInfo(account, server, error_call = error_call)
@@ -159,7 +169,11 @@ findDeploymentTargetByAppId <- function(
   }
 
   # No local deployment record. Get it from the server.
-  application <- getApplication(accountDetails$name, accountDetails$server, appId)
+  application <- getApplication(
+    accountDetails$name,
+    accountDetails$server,
+    appId
+  )
 
   # Note: The account+server of this deployment record may
   # not correspond to the original content creator.
@@ -189,7 +203,6 @@ findDeploymentTargetByAppName <- function(
   forceUpdate = FALSE,
   error_call = caller_env()
 ) {
-
   appDeployments <- deployments(
     appPath = recordPath,
     nameFilter = appName,
@@ -202,7 +215,11 @@ findDeploymentTargetByAppName <- function(
   if (nrow(appDeployments) == 1) {
     deployment <- appDeployments[1, ]
     deployment <- updateDeployment(deployment, appTitle, envVars)
-    accountDetails <- findAccountInfo(deployment$account, deployment$server, error_call = error_call)
+    accountDetails <- findAccountInfo(
+      deployment$account,
+      deployment$server,
+      error_call = error_call
+    )
     return(list(
       accountDetails = accountDetails,
       deployment = deployment
@@ -212,9 +229,16 @@ findDeploymentTargetByAppName <- function(
   # When the appName identifies multiple records, we may not have had an
   # account+server constraint. Ask the user to choose.
   if (nrow(appDeployments) > 1) {
-    deployment <- disambiguateDeployments(appDeployments, error_call = error_call)
+    deployment <- disambiguateDeployments(
+      appDeployments,
+      error_call = error_call
+    )
     deployment <- updateDeployment(deployment, appTitle, envVars)
-    accountDetails <- findAccountInfo(deployment$account, deployment$server, error_call = error_call)
+    accountDetails <- findAccountInfo(
+      deployment$account,
+      deployment$server,
+      error_call = error_call
+    )
     return(list(
       accountDetails = accountDetails,
       deployment = deployment
@@ -233,8 +257,18 @@ findDeploymentTargetByAppName <- function(
     )
     if (!is.null(application)) {
       uniqueName <- findUnique(appName, application$name)
-      if (shouldUpdateApp(application, uniqueName, forceUpdate, error_call = error_call)) {
-        deployment <- createDeploymentFromApplication(application, accountDetails)
+      if (
+        shouldUpdateApp(
+          application,
+          uniqueName,
+          forceUpdate,
+          error_call = error_call
+        )
+      ) {
+        deployment <- createDeploymentFromApplication(
+          application,
+          accountDetails
+        )
         deployment <- updateDeployment(deployment, appTitle, envVars)
         return(list(
           accountDetails = accountDetails,
@@ -262,14 +296,16 @@ findDeploymentTargetByAppName <- function(
   ))
 }
 
-createDeployment <- function(appName,
-                             appTitle,
-                             appId,
-                             envVars,
-                             username,
-                             account,
-                             server,
-                             version = deploymentRecordVersion) {
+createDeployment <- function(
+  appName,
+  appTitle,
+  appId,
+  envVars,
+  username,
+  account,
+  server,
+  version = deploymentRecordVersion
+) {
   # Consider merging this object with the object returned by
   # deploymentRecord().
   #
@@ -315,10 +351,12 @@ updateDeployment <- function(previous, appTitle = NULL, envVars = NULL) {
   )
 }
 
-shouldUpdateApp <- function(application,
-                            uniqueName,
-                            forceUpdate = FALSE,
-                            error_call = caller_env()) {
+shouldUpdateApp <- function(
+  application,
+  uniqueName,
+  forceUpdate = FALSE,
+  error_call = caller_env()
+) {
   if (forceUpdate) {
     return(TRUE)
   }
@@ -341,7 +379,15 @@ shouldUpdateApp <- function(application,
     i = "Supply a unique `appName` to deploy a new application."
   )
 
-  cli_menu(message, prompt, choices, not_interactive, quit = 3, error_call = error_call) == 1
+  cli_menu(
+    message,
+    prompt,
+    choices,
+    not_interactive,
+    quit = 3,
+    error_call = error_call
+  ) ==
+    1
 }
 
 

--- a/R/deployments-find.R
+++ b/R/deployments-find.R
@@ -43,15 +43,11 @@ disambiguateDeployments <- function(appDeployments, error_call = caller_env()) {
     return(appDeployments[1, ])
   }
 
-  apps <- paste0(
+  apps <- sprintf(
+    "%s (%s): {.url %s}",
     appDeployments$name,
-    " ",
-    "(",
     accountLabel(appDeployments$account, appDeployments$server),
-    "): ",
-    "{.url ",
-    appDeployments$url,
-    "}"
+    appDeployments$url
   )
   not_interactive <- c(
     "Please use {.arg appName}, {.arg server} or {.arg account} to disambiguate.",

--- a/R/deployments-find.R
+++ b/R/deployments-find.R
@@ -1,8 +1,10 @@
-findDeployment <- function(appPath = getwd(),
-                           appName = NULL,
-                           server = NULL,
-                           account = NULL,
-                           error_call = caller_env()) {
+findDeployment <- function(
+  appPath = getwd(),
+  appName = NULL,
+  server = NULL,
+  account = NULL,
+  error_call = caller_env()
+) {
   deps <- deployments(
     appPath,
     nameFilter = appName,
@@ -17,7 +19,12 @@ findDeployment <- function(appPath = getwd(),
     # Infers account when not provided...
     accountDetails <- accountInfo(account, server)
     if (is.null(appName)) {
-      appName <- generateAppName(NULL, appPath, account = accountDetails$name, unique = FALSE)
+      appName <- generateAppName(
+        NULL,
+        appPath,
+        account = accountDetails$name,
+        unique = FALSE
+      )
     }
     list(
       name = appName,
@@ -37,9 +44,14 @@ disambiguateDeployments <- function(appDeployments, error_call = caller_env()) {
   }
 
   apps <- paste0(
-    appDeployments$name, " ",
-    "(", accountLabel(appDeployments$account, appDeployments$server), "): ",
-    "{.url ", appDeployments$url, "}"
+    appDeployments$name,
+    " ",
+    "(",
+    accountLabel(appDeployments$account, appDeployments$server),
+    "): ",
+    "{.url ",
+    appDeployments$url,
+    "}"
   )
   not_interactive <- c(
     "Please use {.arg appName}, {.arg server} or {.arg account} to disambiguate.",

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -36,12 +36,13 @@
 #' @seealso [applications()] to get a list of deployments from the
 #'   server, and [deployApp()] to create a new deployment.
 #' @export
-deployments <- function(appPath = ".",
-                        nameFilter = NULL,
-                        accountFilter = NULL,
-                        serverFilter = NULL,
-                        excludeOrphaned = TRUE) {
-
+deployments <- function(
+  appPath = ".",
+  nameFilter = NULL,
+  accountFilter = NULL,
+  serverFilter = NULL,
+  excludeOrphaned = TRUE
+) {
   migrateDeploymentsConfig(appPath)
   paths <- deploymentConfigFiles(appPath)
 
@@ -64,9 +65,14 @@ deployments <- function(appPath = ".",
   }
   if (excludeOrphaned) {
     activeAccounts <- accounts()
-    activeAccountServers <- paste0(activeAccounts$server, "@", activeAccounts$name)
+    activeAccountServers <- paste0(
+      activeAccounts$server,
+      "@",
+      activeAccounts$name
+    )
     accountServer <- paste0(deployments$server, "@", deployments$account)
-    okServer <- isRPubs(deployments$server) | accountServer %in% activeAccountServers
+    okServer <- isRPubs(deployments$server) |
+      accountServer %in% activeAccountServers
     ok <- ok & okServer
   }
 
@@ -79,8 +85,17 @@ deployments <- function(appPath = ".",
 }
 
 deploymentFields <- c(
-  "name", "title", "username", "account", "server", "hostUrl", "appId",
-  "bundleId", "url", "envVars", "version"
+  "name",
+  "title",
+  "username",
+  "account",
+  "server",
+  "hostUrl",
+  "appId",
+  "bundleId",
+  "url",
+  "envVars",
+  "version"
 )
 
 deploymentRecordVersion <- 1L
@@ -89,13 +104,15 @@ deploymentRecordVersion <- 1L
 # not correspond to an existing on-disk deployment record). Created by
 # deploymentRecord() or by findDeploymentTarget(), and possibly loaded from
 # disk.
-saveDeployment <- function(recordDir,
-                           deployment,
-                           application,
-                           bundleId = NULL,
-                           hostUrl = serverInfo(deployment$server)$url,
-                           metadata = list(),
-                           addToHistory = TRUE) {
+saveDeployment <- function(
+  recordDir,
+  deployment,
+  application,
+  bundleId = NULL,
+  hostUrl = serverInfo(deployment$server)$url,
+  metadata = list(),
+  addToHistory = TRUE
+) {
   deployment <- deploymentRecord(
     name = deployment$name,
     title = deployment$title,
@@ -110,7 +127,12 @@ saveDeployment <- function(recordDir,
     url = application$url,
     metadata = metadata
   )
-  path <- deploymentConfigFile(recordDir, deployment$name, deployment$account, deployment$server)
+  path <- deploymentConfigFile(
+    recordDir,
+    deployment$name,
+    deployment$account,
+    deployment$server
+  )
   writeDeploymentRecord(deployment, path)
 
   # also save to global history
@@ -121,19 +143,20 @@ saveDeployment <- function(recordDir,
   invisible(path)
 }
 
-deploymentRecord <- function(name,
-                             title,
-                             username,
-                             account,
-                             server,
-                             envVars = NULL,
-                             hostUrl = NULL,
-                             appId = NULL,
-                             bundleId = NULL,
-                             url = NULL,
-                             version = deploymentRecordVersion,
-                             metadata = list()) {
-
+deploymentRecord <- function(
+  name,
+  title,
+  username,
+  account,
+  server,
+  envVars = NULL,
+  hostUrl = NULL,
+  appId = NULL,
+  bundleId = NULL,
+  url = NULL,
+  version = deploymentRecordVersion,
+  metadata = list()
+) {
   check_character(envVars, allow_null = TRUE)
 
   standard <- list(
@@ -206,16 +229,26 @@ addToDeploymentHistory <- function(appPath, deploymentRecord) {
 #'   specified deployment is forgotten.
 #'
 #' @export
-forgetDeployment <- function(appPath = getwd(), name = NULL,
-                             account = NULL, server = NULL,
-                             dryRun = FALSE, force = !interactive()) {
+forgetDeployment <- function(
+  appPath = getwd(),
+  name = NULL,
+  account = NULL,
+  server = NULL,
+  dryRun = FALSE,
+  force = !interactive()
+) {
   if (is.null(name) && is.null(account) && is.null(server)) {
     dcfDir <- deploymentConfigDir(appPath)
-    if (dryRun)
-      message("Would remove the directory ", dcfDir)
-    else if (file.exists(dcfDir)) {
+    if (dryRun) message("Would remove the directory ", dcfDir) else if (
+      file.exists(dcfDir)
+    ) {
       if (!force) {
-        prompt <- paste("Forget all deployment records for ", appPath, "? [Y/n] ", sep = "")
+        prompt <- paste(
+          "Forget all deployment records for ",
+          appPath,
+          "? [Y/n] ",
+          sep = ""
+        )
         input <- readline(prompt)
         if (nzchar(input) && !identical(input, "y") && !identical(input, "Y"))
           stop("No deployment records removed.", call. = FALSE)
@@ -226,25 +259,42 @@ forgetDeployment <- function(appPath = getwd(), name = NULL,
     }
   } else {
     if (is.null(name) || is.null(account) || is.null(server)) {
-      stop("Invalid argument. ",
-           "Supply the name, account, and server of the deployment record to delete. ",
-           "Supply NULL for all three to delete all deployment records.")
+      stop(
+        "Invalid argument. ",
+        "Supply the name, account, and server of the deployment record to delete. ",
+        "Supply NULL for all three to delete all deployment records."
+      )
     }
     dcf <- deploymentConfigFile(appPath, name, account, server)
-    if (dryRun)
-      message("Would remove the file ", dcf)
-    else if (file.exists(dcf)) {
+    if (dryRun) message("Would remove the file ", dcf) else if (
+      file.exists(dcf)
+    ) {
       if (!force) {
-        prompt <- paste("Forget deployment of ", appPath, " to '", name, "' on ",
-                        server, "? [Y/n] ", sep = "")
+        prompt <- paste(
+          "Forget deployment of ",
+          appPath,
+          " to '",
+          name,
+          "' on ",
+          server,
+          "? [Y/n] ",
+          sep = ""
+        )
         input <- readline(prompt)
         if (nzchar(input) && !identical(input, "y") && !identical(input, "Y"))
           stop("Cancelled. No deployment records removed.", call. = FALSE)
       }
       unlink(dcf)
     } else {
-      message("No deployment of ", appPath, " to '", name, "' on ", server,
-              " found.")
+      message(
+        "No deployment of ",
+        appPath,
+        " to '",
+        name,
+        "' on ",
+        server,
+        " found."
+      )
     }
   }
 

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -239,9 +239,9 @@ forgetDeployment <- function(
 ) {
   if (is.null(name) && is.null(account) && is.null(server)) {
     dcfDir <- deploymentConfigDir(appPath)
-    if (dryRun) message("Would remove the directory ", dcfDir) else if (
-      file.exists(dcfDir)
-    ) {
+    if (dryRun) {
+      message("Would remove the directory ", dcfDir)
+    } else if (file.exists(dcfDir)) {
       if (!force) {
         prompt <- paste(
           "Forget all deployment records for ",
@@ -250,8 +250,9 @@ forgetDeployment <- function(
           sep = ""
         )
         input <- readline(prompt)
-        if (nzchar(input) && !identical(input, "y") && !identical(input, "Y"))
+        if (nzchar(input) && !identical(input, "y") && !identical(input, "Y")) {
           stop("No deployment records removed.", call. = FALSE)
+        }
       }
       unlink(dcfDir, recursive = TRUE)
     } else {
@@ -266,9 +267,9 @@ forgetDeployment <- function(
       )
     }
     dcf <- deploymentConfigFile(appPath, name, account, server)
-    if (dryRun) message("Would remove the file ", dcf) else if (
-      file.exists(dcf)
-    ) {
+    if (dryRun) {
+      message("Would remove the file ", dcf)
+    } else if (file.exists(dcf)) {
       if (!force) {
         prompt <- paste(
           "Forget deployment of ",
@@ -281,8 +282,9 @@ forgetDeployment <- function(
           sep = ""
         )
         input <- readline(prompt)
-        if (nzchar(input) && !identical(input, "y") && !identical(input, "Y"))
+        if (nzchar(input) && !identical(input, "y") && !identical(input, "Y")) {
           stop("Cancelled. No deployment records removed.", call. = FALSE)
+        }
       }
       unlink(dcf)
     } else {

--- a/R/envvars.R
+++ b/R/envvars.R
@@ -49,7 +49,9 @@ updateAccountEnvVars <- function(envVars, server = NULL, account = NULL) {
   )
   uses_vars <- vapply(apps$envVars, function(x) any(envVars %in% x), logical(1))
   if (!any(uses_vars)) {
-    cli::cli_abort("No applications use environment variable{?s} {.arg {envVars}}")
+    cli::cli_abort(
+      "No applications use environment variable{?s} {.arg {envVars}}"
+    )
   }
 
   guids <- apps$guid[uses_vars]

--- a/R/http-curl.R
+++ b/R/http-curl.R
@@ -16,7 +16,9 @@ httpCurl <- function(
   if (!is.null(contentFile) && is.null(contentType))
     stop("You must specify a contentType for the specified file")
 
-  if (!is.null(contentFile)) fileLength <- file.info(contentFile)$size
+  if (!is.null(contentFile)) {
+    fileLength <- file.info(contentFile)$size
+  }
 
   headers <- appendCookieHeaders(
     list(protocol = protocol, host = host, port = port, path = path),
@@ -39,9 +41,13 @@ httpCurl <- function(
 
   command <- paste("curl", "-i", "-X", method)
 
-  if (httpVerbose()) command <- paste(command, "-v")
+  if (httpVerbose()) {
+    command <- paste(command, "-v")
+  }
 
-  if (!is.null(timeout)) command <- paste(command, "--connect-timeout", timeout)
+  if (!is.null(timeout)) {
+    command <- paste(command, "--connect-timeout", timeout)
+  }
 
   if (!is.null(contentFile)) {
     command <- paste(
@@ -56,7 +62,9 @@ httpCurl <- function(
   }
 
   # add prefix to port if necessary
-  if (nzchar(port)) port <- paste(":", port, sep = "")
+  if (nzchar(port)) {
+    port <- paste(":", port, sep = "")
+  }
 
   if (!isTRUE(getOption("rsconnect.check.certificate", TRUE))) {
     # suppressed certificate check

--- a/R/http-curl.R
+++ b/R/http-curl.R
@@ -1,77 +1,84 @@
 # HTTP transport using the curl command-line utility. Useful on systems that have a working curl but
 # not necessarily a working curl library, such as Windows 10.
 
-httpCurl <- function(protocol,
-                     host,
-                     port,
-                     method,
-                     path,
-                     headers,
-                     contentType = NULL,
-                     contentFile = NULL,
-                     certificate = NULL,
-                     timeout = NULL) {
-
+httpCurl <- function(
+  protocol,
+  host,
+  port,
+  method,
+  path,
+  headers,
+  contentType = NULL,
+  contentFile = NULL,
+  certificate = NULL,
+  timeout = NULL
+) {
   if (!is.null(contentFile) && is.null(contentType))
     stop("You must specify a contentType for the specified file")
 
-  if (!is.null(contentFile))
-    fileLength <- file.info(contentFile)$size
+  if (!is.null(contentFile)) fileLength <- file.info(contentFile)$size
 
   headers <- appendCookieHeaders(
-    list(protocol = protocol, host = host, port = port, path = path), headers)
+    list(protocol = protocol, host = host, port = port, path = path),
+    headers
+  )
   extraHeaders <- character()
-  for (header in names(headers))
-  {
-    if (!identical(header, "Content-Type") && !identical(header, "Content-Length")) {
+  for (header in names(headers)) {
+    if (
+      !identical(header, "Content-Type") && !identical(header, "Content-Length")
+    ) {
       extraHeaders <- paste(extraHeaders, "--header")
-      extraHeaders <- paste(extraHeaders,
-                            paste('"', header, ": ", headers[[header]], '"', sep = ""))
+      extraHeaders <- paste(
+        extraHeaders,
+        paste('"', header, ": ", headers[[header]], '"', sep = "")
+      )
     }
   }
 
   outputFile <- tempfile()
 
-  command <- paste("curl",
-                   "-i",
-                   "-X",
-                   method)
+  command <- paste("curl", "-i", "-X", method)
 
-  if (httpVerbose())
-    command <- paste(command, "-v")
+  if (httpVerbose()) command <- paste(command, "-v")
 
-  if (!is.null(timeout))
-    command <- paste(command, "--connect-timeout", timeout)
+  if (!is.null(timeout)) command <- paste(command, "--connect-timeout", timeout)
 
   if (!is.null(contentFile)) {
-    command <- paste(command,
-                     "-T",
-                     shQuote(contentFile),
-                     "--header", paste('"', "Content-Type: ", contentType, '"', sep = ""),
-                     "--header", paste('"', "Content-Length: ", fileLength, '"', sep = ""))
+    command <- paste(
+      command,
+      "-T",
+      shQuote(contentFile),
+      "--header",
+      paste('"', "Content-Type: ", contentType, '"', sep = ""),
+      "--header",
+      paste('"', "Content-Length: ", fileLength, '"', sep = "")
+    )
   }
 
   # add prefix to port if necessary
-  if (nzchar(port))
-    port <- paste(":", port, sep = "")
+  if (nzchar(port)) port <- paste(":", port, sep = "")
 
   if (!isTRUE(getOption("rsconnect.check.certificate", TRUE))) {
     # suppressed certificate check
     command <- paste(command, "--insecure")
   } else if (!is.null(certificate)) {
     # cert check not suppressed and we have a supplied cert
-    command <- paste(command,
-                     "--cacert", shQuote(certificate))
+    command <- paste(command, "--cacert", shQuote(certificate))
   }
 
-  command <- paste(command,
-                   extraHeaders,
-                   "--header", "Expect:",
-                   "--user-agent", userAgent(),
-                   "--silent",
-                   "--show-error",
-                   "-o", shQuote(outputFile),
-                   paste('"', protocol, "://", host, port, path, '"', sep = ""))
+  command <- paste(
+    command,
+    extraHeaders,
+    "--header",
+    "Expect:",
+    "--user-agent",
+    userAgent(),
+    "--silent",
+    "--show-error",
+    "-o",
+    shQuote(outputFile),
+    paste('"', protocol, "://", host, port, path, '"', sep = "")
+  )
 
   result <- NULL
   time <- system.time(gcFirst = FALSE, {
@@ -80,9 +87,11 @@ httpCurl <- function(protocol,
   httpTrace(method, path, time)
 
   # emit JSON trace if requested
-  if (!is.null(contentFile) && httpTraceJson() &&
-      identical(contentType, "application/json"))
-  {
+  if (
+    !is.null(contentFile) &&
+      httpTraceJson() &&
+      identical(contentType, "application/json")
+  ) {
     fileLength <- file.info(contentFile)$size
     fileContents <- readBin(contentFile, what = "raw", n = fileLength)
     cat(paste0("<< ", rawToChar(fileContents), "\n"))
@@ -91,13 +100,16 @@ httpCurl <- function(protocol,
   if (result == 0) {
     fileConn <- file(outputFile, "rb")
     defer(close(fileConn))
-    readHttpResponse(list(
+    readHttpResponse(
+      list(
         protocol = protocol,
-        host     = host,
-        port     = port,
-        method   = method,
-        path     = path),
-      fileConn)
+        host = host,
+        port = port,
+        method = method,
+        path = path
+      ),
+      fileConn
+    )
   } else {
     stop(paste("Curl request failed (curl error", result, "occurred)"))
   }

--- a/R/http-internal.R
+++ b/R/http-internal.R
@@ -14,11 +14,14 @@ httpInternal <- function(
   certificate = NULL,
   timeout = NULL
 ) {
-  if (!is.null(contentFile) && is.null(contentType))
+  if (!is.null(contentFile) && is.null(contentType)) {
     stop("You must specify a contentType for the specified file")
+  }
 
   # default port to 80 if necessary
-  if (!nzchar(port)) port <- "80"
+  if (!nzchar(port)) {
+    port <- "80"
+  }
 
   # read file in binary mode
   if (!is.null(contentFile)) {
@@ -52,7 +55,9 @@ httpInternal <- function(
   request <- c(request, "\r\n")
 
   # output request if in verbose mode
-  if (httpVerbose()) cat(request)
+  if (httpVerbose()) {
+    cat(request)
+  }
 
   # use timeout if supplied, default timeout if not (matches parameter behavior
   # for socketConnection)
@@ -90,11 +95,14 @@ httpInternal <- function(
   httpTrace(method, path, time)
 
   # print if in verbose mode
-  if (httpVerbose()) print(response)
+  if (httpVerbose()) {
+    print(response)
+  }
 
   # output JSON if requested
-  if (httpTraceJson() && identical(contentType, "application/json"))
+  if (httpTraceJson() && identical(contentType, "application/json")) {
     cat(paste0("<< ", rawToChar(fileContents), "\n"))
+  }
 
   # return it
   response

--- a/R/http-internal.R
+++ b/R/http-internal.R
@@ -2,23 +2,23 @@
 # last resort if other methods don't work since it can piggyback on IE proxy settings via R's own
 # internet configuration.
 
-httpInternal <- function(protocol,
-                         host,
-                         port,
-                         method,
-                         path,
-                         headers,
-                         contentType = NULL,
-                         contentFile = NULL,
-                         certificate = NULL,
-                         timeout = NULL) {
-
+httpInternal <- function(
+  protocol,
+  host,
+  port,
+  method,
+  path,
+  headers,
+  contentType = NULL,
+  contentFile = NULL,
+  certificate = NULL,
+  timeout = NULL
+) {
   if (!is.null(contentFile) && is.null(contentType))
     stop("You must specify a contentType for the specified file")
 
   # default port to 80 if necessary
-  if (!nzchar(port))
-    port <- "80"
+  if (!nzchar(port)) port <- "80"
 
   # read file in binary mode
   if (!is.null(contentFile)) {
@@ -33,27 +33,26 @@ httpInternal <- function(protocol,
   request <- c(request, "Host: ", host, "\r\n", sep = "")
   request <- c(request, "Accept: */*\r\n")
   if (!is.null(contentFile)) {
-    request <- c(request, paste("Content-Type: ",
-                                contentType,
-                                "\r\n",
-                                sep = ""))
-    request <- c(request, paste("Content-Length: ",
-                                fileLength,
-                                "\r\n",
-                                sep = ""))
+    request <- c(
+      request,
+      paste("Content-Type: ", contentType, "\r\n", sep = "")
+    )
+    request <- c(
+      request,
+      paste("Content-Length: ", fileLength, "\r\n", sep = "")
+    )
   }
   headers <- appendCookieHeaders(
-    list(protocol = protocol, host = host, port = port, path = path), headers)
-  for (name in names(headers))
-  {
-    request <- c(request,
-                 paste(name, ": ", headers[[name]], "\r\n", sep = ""))
+    list(protocol = protocol, host = host, port = port, path = path),
+    headers
+  )
+  for (name in names(headers)) {
+    request <- c(request, paste(name, ": ", headers[[name]], "\r\n", sep = ""))
   }
   request <- c(request, "\r\n")
 
   # output request if in verbose mode
-  if (httpVerbose())
-    cat(request)
+  if (httpVerbose()) cat(request)
 
   # use timeout if supplied, default timeout if not (matches parameter behavior
   # for socketConnection)
@@ -61,11 +60,13 @@ httpInternal <- function(protocol,
 
   # open socket connection
   time <- system.time(gcFirst = FALSE, {
-    conn <- socketConnection(host = host,
-                             port = as.integer(port),
-                             open = "w+b",
-                             blocking = TRUE,
-                             timeout = timeout)
+    conn <- socketConnection(
+      host = host,
+      port = as.integer(port),
+      open = "w+b",
+      blocking = TRUE,
+      timeout = timeout
+    )
     defer(close(conn))
 
     # write the request header and file payload
@@ -75,19 +76,21 @@ httpInternal <- function(protocol,
     }
 
     # read the response
-    response <- readHttpResponse(list(
+    response <- readHttpResponse(
+      list(
         protocol = protocol,
-        host     = host,
-        port     = port,
-        method   = method,
-        path     = path),
-      conn)
+        host = host,
+        port = port,
+        method = method,
+        path = path
+      ),
+      conn
+    )
   })
   httpTrace(method, path, time)
 
   # print if in verbose mode
-  if (httpVerbose())
-    print(response)
+  if (httpVerbose()) print(response)
 
   # output JSON if requested
   if (httpTraceJson() && identical(contentType, "application/json"))

--- a/R/http-libcurl.R
+++ b/R/http-libcurl.R
@@ -1,14 +1,15 @@
-httpLibCurl <- function(protocol,
-                        host,
-                        port,
-                        method,
-                        path,
-                        headers,
-                        contentType = NULL,
-                        contentFile = NULL,
-                        certificate = NULL,
-                        timeout = NULL) {
-
+httpLibCurl <- function(
+  protocol,
+  host,
+  port,
+  method,
+  path,
+  headers,
+  contentType = NULL,
+  contentFile = NULL,
+  certificate = NULL,
+  timeout = NULL
+) {
   request <- list(
     protocol = protocol,
     host = host,
@@ -83,7 +84,12 @@ httpLibCurl <- function(protocol,
   jsonTracingEnabled <- httpTraceJson() && contentType == "application/json"
   if (jsonTracingEnabled) {
     if (!is.null(contentFile)) {
-      cat(paste0("<< ", readLines(contentFile, warn = FALSE), "\n", collapse = ""))
+      cat(paste0(
+        "<< ",
+        readLines(contentFile, warn = FALSE),
+        "\n",
+        collapse = ""
+      ))
     }
     lines <- strsplit(contentValue, "\n")[[1]]
     cat(paste0(">> ", lines, "\n", collapse = ""))
@@ -98,9 +104,7 @@ httpLibCurl <- function(protocol,
   )
 }
 
-createCurlHandle <- function(method,
-                             timeout = NULL,
-                             certificate = NULL) {
+createCurlHandle <- function(method, timeout = NULL, certificate = NULL) {
   # create curl handle
   handle <- curl::new_handle()
 

--- a/R/http-rcurl.R
+++ b/R/http-rcurl.R
@@ -2,23 +2,23 @@
 # was the default transport for many years). In a future release of rsconnect, the RCurl transport
 # will be removed entirely, and the "rcurl" option will be interpreted as "libcurl".
 
-httpRCurl <- function(protocol,
-                      host,
-                      port,
-                      method,
-                      path,
-                      headers,
-                      contentType = NULL,
-                      contentFile = NULL,
-                      certificate = NULL,
-                      timeout = NULL) {
-
+httpRCurl <- function(
+  protocol,
+  host,
+  port,
+  method,
+  path,
+  headers,
+  contentType = NULL,
+  contentFile = NULL,
+  certificate = NULL,
+  timeout = NULL
+) {
   if (!is.null(contentFile) && is.null(contentType))
     stop("You must specify a contentType for the specified file")
 
   # add prefix to port if necessary
-  if (!is.null(port) && nzchar(port))
-    port <- paste(":", port, sep = "")
+  if (!is.null(port) && nzchar(port)) port <- paste(":", port, sep = "")
 
   # build url
   url <- paste(protocol, "://", host, port, path, sep = "")
@@ -46,8 +46,7 @@ httpRCurl <- function(protocol,
     options$ssl.verifypeer <- TRUE
 
     # apply certificate information if present
-    if (!is.null(certificate))
-      options$cainfo <- certificate
+    if (!is.null(certificate)) options$cainfo <- certificate
   } else {
     # don't verify peer (less secure but tolerant to self-signed cert issues)
     options$ssl.verifypeer <- FALSE
@@ -67,52 +66,61 @@ httpRCurl <- function(protocol,
   }
 
   # verbose if requested
-  if (httpVerbose())
-    options$verbose <- TRUE
+  if (httpVerbose()) options$verbose <- TRUE
 
   # add extra headers
   headers <- appendCookieHeaders(
-    list(protocol = protocol, host = host, port = port, path = path), headers)
+    list(protocol = protocol, host = host, port = port, path = path),
+    headers
+  )
   extraHeaders <- as.character(headers)
   names(extraHeaders) <- names(headers)
   options$httpheader <- extraHeaders
 
   # make the request
-  time <- system.time(gcFirst = FALSE, tryCatch({
-    if (!is.null(contentFile)) {
-      RCurl::curlPerform(url = url,
-                         .opts = options,
-                         customrequest = method,
-                         readfunction = fileContents,
-                         infilesize = fileLength,
-                         writefunction = textGatherer$update,
-                         upload = TRUE)
-    } else if (method == "DELETE") {
-      RCurl::curlPerform(url = url,
-                         .opts = options,
-                         customrequest = method)
-
-    } else {
-      if (identical(method, "GET")) {
-        RCurl::getURL(url,
-                      .opts = options,
-                      write = textGatherer)
-      } else {
-        RCurl::curlPerform(url = url,
-                           .opts = options,
-                           customrequest = method,
-                           writefunction = textGatherer$update)
+  time <- system.time(
+    gcFirst = FALSE,
+    tryCatch(
+      {
+        if (!is.null(contentFile)) {
+          RCurl::curlPerform(
+            url = url,
+            .opts = options,
+            customrequest = method,
+            readfunction = fileContents,
+            infilesize = fileLength,
+            writefunction = textGatherer$update,
+            upload = TRUE
+          )
+        } else if (method == "DELETE") {
+          RCurl::curlPerform(url = url, .opts = options, customrequest = method)
+        } else {
+          if (identical(method, "GET")) {
+            RCurl::getURL(url, .opts = options, write = textGatherer)
+          } else {
+            RCurl::curlPerform(
+              url = url,
+              .opts = options,
+              customrequest = method,
+              writefunction = textGatherer$update
+            )
+          }
+        }
+      },
+      error = function(e, ...) {
+        # ignore errors resulting from timeout or user abort
+        if (
+          identical(e$message, "Callback aborted") ||
+            identical(
+              e$message,
+              "transfer closed with outstanding read data remaining"
+            )
+        )
+          return(NULL) # bubble remaining errors through
+        else stop(e)
       }
-    }},
-    error = function(e, ...) {
-      # ignore errors resulting from timeout or user abort
-      if (identical(e$message, "Callback aborted") ||
-          identical(e$message, "transfer closed with outstanding read data remaining"))
-        return(NULL)
-      # bubble remaining errors through
-      else
-        stop(e)
-    }))
+    )
+  )
   httpTrace(method, path, time)
 
   # get list of HTTP response headers
@@ -121,8 +129,8 @@ httpRCurl <- function(protocol,
   # deduce status. we do this *before* lowercase conversion, as it is possible
   # for both "Status" and "status" headers to exist
   status <- 200
-  statuses <- headers[names(headers) == "status"]   # find status header
-  statuses <- statuses[grepl("^\\d+$", statuses)]   # ensure fully numeric
+  statuses <- headers[names(headers) == "status"] # find status header
+  statuses <- statuses[grepl("^\\d+$", statuses)] # ensure fully numeric
   if (length(statuses) > 0) {
     # we found a numeric status header
     status <- as.integer(statuses[[1]])
@@ -132,9 +140,7 @@ httpRCurl <- function(protocol,
   # by default but they're typically capitalized in HTTP/1
   names(headers) <- tolower(names(headers))
 
-  if ("location" %in% names(headers))
-    location <- headers[["location"]]
-  else
+  if ("location" %in% names(headers)) location <- headers[["location"]] else
     location <- NULL
 
   # presume a plain text response unless specified otherwise
@@ -145,13 +151,19 @@ httpRCurl <- function(protocol,
   }
 
   # emit JSON trace if requested
-  if (!is.null(contentFile) && httpTraceJson() &&
-      identical(contentType, "application/json"))
+  if (
+    !is.null(contentFile) &&
+      httpTraceJson() &&
+      identical(contentType, "application/json")
+  )
     cat(paste0("<< ", rawToChar(fileContents), "\n"))
 
   # Parse cookies from header; bear in mind that there may be multiple headers
   cookieHeaders <- headers[names(headers) == "set-cookie"]
-  storeCookies(list(protocol = protocol, host = host, port = port, path = path), cookieHeaders)
+  storeCookies(
+    list(protocol = protocol, host = host, port = port, path = path),
+    cookieHeaders
+  )
 
   contentValue <- textGatherer$value()
 
@@ -159,13 +171,17 @@ httpRCurl <- function(protocol,
   if (httpTraceJson() && identical(contentType, "application/json"))
     cat(paste0(">> ", contentValue, "\n"))
 
-  list(req = list(protocol = protocol,
-                  host     = host,
-                  port     = port,
-                  method   = method,
-                  path     = path),
-       status = status,
-       location = location,
-       contentType = contentType,
-       content = contentValue)
+  list(
+    req = list(
+      protocol = protocol,
+      host = host,
+      port = port,
+      method = method,
+      path = path
+    ),
+    status = status,
+    location = location,
+    contentType = contentType,
+    content = contentValue
+  )
 }

--- a/R/http-rcurl.R
+++ b/R/http-rcurl.R
@@ -46,7 +46,9 @@ httpRCurl <- function(
     options$ssl.verifypeer <- TRUE
 
     # apply certificate information if present
-    if (!is.null(certificate)) options$cainfo <- certificate
+    if (!is.null(certificate)) {
+      options$cainfo <- certificate
+    }
   } else {
     # don't verify peer (less secure but tolerant to self-signed cert issues)
     options$ssl.verifypeer <- FALSE
@@ -66,7 +68,9 @@ httpRCurl <- function(
   }
 
   # verbose if requested
-  if (httpVerbose()) options$verbose <- TRUE
+  if (httpVerbose()) {
+    options$verbose <- TRUE
+  }
 
   # add extra headers
   headers <- appendCookieHeaders(
@@ -115,9 +119,11 @@ httpRCurl <- function(
               e$message,
               "transfer closed with outstanding read data remaining"
             )
-        )
-          return(NULL) # bubble remaining errors through
-        else stop(e)
+        ) {
+          return(NULL)
+        } else {
+          stop(e) # bubble remaining errors through
+        }
       }
     )
   )
@@ -140,8 +146,11 @@ httpRCurl <- function(
   # by default but they're typically capitalized in HTTP/1
   names(headers) <- tolower(names(headers))
 
-  if ("location" %in% names(headers)) location <- headers[["location"]] else
+  if ("location" %in% names(headers)) {
+    location <- headers[["location"]]
+  } else {
     location <- NULL
+  }
 
   # presume a plain text response unless specified otherwise
   contentType <- if ("content-type" %in% names(headers)) {
@@ -155,8 +164,9 @@ httpRCurl <- function(
     !is.null(contentFile) &&
       httpTraceJson() &&
       identical(contentType, "application/json")
-  )
+  ) {
     cat(paste0("<< ", rawToChar(fileContents), "\n"))
+  }
 
   # Parse cookies from header; bear in mind that there may be multiple headers
   cookieHeaders <- headers[names(headers) == "set-cookie"]
@@ -168,8 +178,9 @@ httpRCurl <- function(
   contentValue <- textGatherer$value()
 
   # emit JSON trace if requested
-  if (httpTraceJson() && identical(contentType, "application/json"))
+  if (httpTraceJson() && identical(contentType, "application/json")) {
     cat(paste0(">> ", contentValue, "\n"))
+  }
 
   list(
     req = list(

--- a/R/http.R
+++ b/R/http.R
@@ -1,4 +1,3 @@
-
 #' @param authInfo Typically an object created by `accountInfo()` augmented
 #'   with the `certificate` from the corresponding `serverInfo()`.
 #'
@@ -8,16 +7,17 @@
 #'   * `apiKey`: set in `connectApiUser()`
 #'
 #' @noRd
-httpRequest <- function(service,
-                        authInfo,
-                        method,
-                        path,
-                        query,
-                        headers = list(),
-                        timeout = NULL,
-                        rawResponse = FALSE,
-                        error_call = caller_env()) {
-
+httpRequest <- function(
+  service,
+  authInfo,
+  method,
+  path,
+  query,
+  headers = list(),
+  timeout = NULL,
+  rawResponse = FALSE,
+  error_call = caller_env()
+) {
   storeCookies(service, httpCookies())
   path <- buildPath(service$path, path, query)
   headers <- c(headers, authHeaders(authInfo, method, path), httpHeaders())
@@ -50,20 +50,26 @@ httpRequest <- function(service,
     )
   }
 
-  handleResponse(httpResponse, rawResponse = rawResponse, error_call = error_call)
+  handleResponse(
+    httpResponse,
+    rawResponse = rawResponse,
+    error_call = error_call
+  )
 }
 
-httpRequestWithBody <- function(service,
-                                authInfo,
-                                method,
-                                path,
-                                query = NULL,
-                                contentType = NULL,
-                                file = NULL,
-                                content = NULL,
-                                headers = list(),
-                                rawResponse = FALSE,
-                                error_call = caller_env()) {
+httpRequestWithBody <- function(
+  service,
+  authInfo,
+  method,
+  path,
+  query = NULL,
+  contentType = NULL,
+  file = NULL,
+  content = NULL,
+  headers = list(),
+  rawResponse = FALSE,
+  error_call = caller_env()
+) {
   if ((is.null(file) && is.null(content))) {
     stop("You must specify either the file or content parameter.")
   }
@@ -114,7 +120,11 @@ httpRequestWithBody <- function(service,
     httpResponse
   }
 
-  handleResponse(httpResponse, rawResponse = rawResponse, error_call = error_call)
+  handleResponse(
+    httpResponse,
+    rawResponse = rawResponse,
+    error_call = error_call
+  )
 }
 
 isRedirect <- function(status) {
@@ -130,10 +140,13 @@ redirectService <- function(service, location) {
   }
 }
 
-handleResponse <- function(response, rawResponse = FALSE, error_call = caller_env()) {
+handleResponse <- function(
+  response,
+  rawResponse = FALSE,
+  error_call = caller_env()
+) {
   url <- buildHttpUrl(response$req)
   reportError <- function(msg) {
-
     cli::cli_abort(
       c("<{url}> failed with HTTP status {response$status}", msg),
       class = c(paste0("rsconnect_http_", response$status), "rsconnect_http"),
@@ -196,62 +209,95 @@ handleResponse <- function(response, rawResponse = FALSE, error_call = caller_en
 
 # Wrappers for HTTP methods -----------------------------------------------
 
-GET <- function(service,
-                authInfo,
-                path,
-                query = NULL,
-                headers = list(),
-                timeout = NULL,
-                rawResponse = FALSE) {
-  httpRequest(service, authInfo, "GET", path, query, headers, timeout, rawResponse)
+GET <- function(
+  service,
+  authInfo,
+  path,
+  query = NULL,
+  headers = list(),
+  timeout = NULL,
+  rawResponse = FALSE
+) {
+  httpRequest(
+    service,
+    authInfo,
+    "GET",
+    path,
+    query,
+    headers,
+    timeout,
+    rawResponse
+  )
 }
 
-DELETE <- function(service,
-                   authInfo,
-                   path,
-                   query = NULL,
-                   headers = list(),
-                   rawResponse = FALSE) {
-  httpRequest(service, authInfo, "DELETE", path, query, headers, rawResponse = rawResponse)
+DELETE <- function(
+  service,
+  authInfo,
+  path,
+  query = NULL,
+  headers = list(),
+  rawResponse = FALSE
+) {
+  httpRequest(
+    service,
+    authInfo,
+    "DELETE",
+    path,
+    query,
+    headers,
+    rawResponse = rawResponse
+  )
 }
 
-POST <- function(service,
-                 authInfo,
-                 path,
-                 query = NULL,
-                 contentType = NULL,
-                 file = NULL,
-                 content = NULL,
-                 headers = list(),
-                 rawResponse = FALSE) {
+POST <- function(
+  service,
+  authInfo,
+  path,
+  query = NULL,
+  contentType = NULL,
+  file = NULL,
+  content = NULL,
+  headers = list(),
+  rawResponse = FALSE
+) {
   # check if the request needs a body
   if ((is.null(file) && is.null(content))) {
     # no file or content, don't include a body with the request
-    httpRequest(service, authInfo, "POST", path, query, headers, rawResponse = rawResponse)
+    httpRequest(
+      service,
+      authInfo,
+      "POST",
+      path,
+      query,
+      headers,
+      rawResponse = rawResponse
+    )
   } else {
     # include the request's data in the body
     httpRequestWithBody(
-    service = service,
-    authInfo = authInfo,
-    method = "POST",
-    path = path,
-    query = query,
-    contentType = contentType,
-    file = file,
-    content = content,
-    headers = headers,
-    rawResponse = rawResponse
+      service = service,
+      authInfo = authInfo,
+      method = "POST",
+      path = path,
+      query = query,
+      contentType = contentType,
+      file = file,
+      content = content,
+      headers = headers,
+      rawResponse = rawResponse
     )
   }
 }
 
-POST_JSON <- function(service,
-                      authInfo,
-                      path,
-                      json,
-                      query = NULL,
-                      headers = list(),
-                      rawResponse = FALSE) {
+POST_JSON <- function(
+  service,
+  authInfo,
+  path,
+  json,
+  query = NULL,
+  headers = list(),
+  rawResponse = FALSE
+) {
   POST(
     service = service,
     authInfo = authInfo,
@@ -264,15 +310,17 @@ POST_JSON <- function(service,
   )
 }
 
-PUT <- function(service,
-                authInfo,
-                path,
-                query = NULL,
-                contentType = NULL,
-                file = NULL,
-                content = NULL,
-                headers = list(),
-                rawResponse = FALSE) {
+PUT <- function(
+  service,
+  authInfo,
+  path,
+  query = NULL,
+  contentType = NULL,
+  file = NULL,
+  content = NULL,
+  headers = list(),
+  rawResponse = FALSE
+) {
   httpRequestWithBody(
     service = service,
     authInfo = authInfo,
@@ -287,13 +335,15 @@ PUT <- function(service,
   )
 }
 
-PUT_JSON <- function(service,
-                     authInfo,
-                     path,
-                     json,
-                     query = NULL,
-                     headers = list(),
-                     rawResponse = FALSE) {
+PUT_JSON <- function(
+  service,
+  authInfo,
+  path,
+  json,
+  query = NULL,
+  headers = list(),
+  rawResponse = FALSE
+) {
   PUT(
     service = service,
     authInfo = authInfo,
@@ -306,15 +356,17 @@ PUT_JSON <- function(service,
   )
 }
 
-PATCH <- function(service,
-                  authInfo,
-                  path,
-                  query = NULL,
-                  contentType = NULL,
-                  file = NULL,
-                  content = NULL,
-                  headers = list(),
-                  rawResponse = FALSE) {
+PATCH <- function(
+  service,
+  authInfo,
+  path,
+  query = NULL,
+  contentType = NULL,
+  file = NULL,
+  content = NULL,
+  headers = list(),
+  rawResponse = FALSE
+) {
   httpRequestWithBody(
     service = service,
     authInfo = authInfo,
@@ -329,13 +381,15 @@ PATCH <- function(service,
   )
 }
 
-PATCH_JSON <- function(service,
-                       authInfo,
-                       path,
-                       json,
-                       query = NULL,
-                       headers = list(),
-                       rawResponse = FALSE) {
+PATCH_JSON <- function(
+  service,
+  authInfo,
+  path,
+  json,
+  query = NULL,
+  headers = list(),
+  rawResponse = FALSE
+) {
   PATCH(
     service = service,
     authInfo = authInfo,
@@ -360,7 +414,13 @@ httpTraceJson <- function() {
 
 httpTrace <- function(method, path, time) {
   if (getOption("rsconnect.http.trace", FALSE)) {
-    cat(method, " ", path, " ", as.integer(time[["elapsed"]] * 1000), "ms\n",
+    cat(
+      method,
+      " ",
+      path,
+      " ",
+      as.integer(time[["elapsed"]] * 1000),
+      "ms\n",
       sep = ""
     )
   }
@@ -400,7 +460,8 @@ httpFunction <- function() {
     httpType
   } else {
     stop(paste(
-      "Invalid http option specified:", httpType,
+      "Invalid http option specified:",
+      httpType,
       ". Valid values are libcurl, rcurl, curl, and internal"
     ))
   }
@@ -485,7 +546,7 @@ authHeaders <- function(authInfo, method, path, file = NULL) {
   } else if (!is.null(authInfo$snowflakeToken)) {
     # snowflakeauth returns a list of named header values
     authInfo$snowflakeToken
-  } else{
+  } else {
     # The value doesn't actually matter here, but the header needs to be set.
     list(`X-Auth-Token` = "anonymous-access")
   }
@@ -548,7 +609,12 @@ signRequestPrivateKey <- function(private_key, canonicalRequest) {
 
   # use sha1 digest and then sign. digest and PKI avoid using system openssl which
   # can be problematic in strict FIPS environments
-  digested <- digest::digest(charToRaw(canonicalRequest), "sha1", serialize = FALSE, raw = TRUE)
+  digested <- digest::digest(
+    charToRaw(canonicalRequest),
+    "sha1",
+    serialize = FALSE,
+    raw = TRUE
+  )
   rawsig <- PKI::PKI.sign(key = pki_key, digest = digested)
   openssl::base64_encode(rawsig)
 }
@@ -633,7 +699,8 @@ readHttpResponse <- function(request, conn) {
   } else {
     # we know the content length, so read exactly that many bytes
     content <- rawToChar(readBin(
-      con = conn, what = "raw",
+      con = conn,
+      what = "raw",
       n = contentLength
     ))
   }

--- a/R/ide.R
+++ b/R/ide.R
@@ -21,7 +21,11 @@ findAndRegisterLocalServer <- function(url) {
   findServerByUrl <- function(url) {
     allServers <- rsconnect::servers(local = TRUE)
     match <- allServers[allServers$url == url, , drop = FALSE]
-    if (nrow(match) == 0) NULL else as.character(match[1, "name"])
+    if (nrow(match) == 0) {
+      NULL
+    } else {
+      as.character(match[1, "name"])
+    }
   }
 
   # if there are no local servers with the given URL, add one and return its

--- a/R/ide.R
+++ b/R/ide.R
@@ -5,7 +5,7 @@
 validateServerUrl <- function(url, certificate = NULL) {
   res <- validateConnectUrl(url, certificate)
 
-  if (res$valid)  {
+  if (res$valid) {
     name <- findAndRegisterLocalServer(res$url)
     c(list(valid = TRUE, url = res$url, name = name), res$response)
   } else {
@@ -21,10 +21,7 @@ findAndRegisterLocalServer <- function(url) {
   findServerByUrl <- function(url) {
     allServers <- rsconnect::servers(local = TRUE)
     match <- allServers[allServers$url == url, , drop = FALSE]
-    if (nrow(match) == 0)
-      NULL
-    else
-      as.character(match[1, "name"])
+    if (nrow(match) == 0) NULL else as.character(match[1, "name"])
   }
 
   # if there are no local servers with the given URL, add one and return its
@@ -45,7 +42,13 @@ findAndRegisterLocalServer <- function(url) {
   }
 }
 
-registerUserToken <- function(serverName, accountName, userId, token, privateKey) {
+registerUserToken <- function(
+  serverName,
+  accountName,
+  userId,
+  token,
+  privateKey
+) {
   registerAccount(
     serverName = serverName,
     accountName = accountName,
@@ -73,11 +76,13 @@ showRstudioSourceMarkers <- function(basePath, lint) {
     })
   })
 
-  rstudioapi::callFun("sourceMarkers",
-                      name = "Publish Content Issues",
-                      markers = markers,
-                      basePath = basePath,
-                      autoSelect = "first")
+  rstudioapi::callFun(
+    "sourceMarkers",
+    name = "Publish Content Issues",
+    markers = markers,
+    basePath = basePath,
+    autoSelect = "first"
+  )
 }
 
 # getAppById() -----------------------------------------------------------------
@@ -112,11 +117,12 @@ getAppById <- function(id, account, server, hostUrl) {
 # -------------------------------------------------------------------------
 
 # passthrough function for compatibility with old IDE versions
-getUserFromRawToken <- function(serverUrl,
-                                token,
-                                privateKey,
-                                serverCertificate = NULL) {
-
+getUserFromRawToken <- function(
+  serverUrl,
+  token,
+  privateKey,
+  serverCertificate = NULL
+) {
   # Look up server name from url
   servers <- servers()
   matches <- servers$url == serverUrl

--- a/R/imports.R
+++ b/R/imports.R
@@ -1,5 +1,3 @@
-
-
 #' @importFrom stats na.omit setNames
 #' @importFrom utils available.packages installed.packages contrib.url getFromNamespace glob2rx packageVersion packageDescription read.csv
 NULL

--- a/R/lint.R
+++ b/R/lint.R
@@ -21,14 +21,16 @@ lint <- function(project, files = NULL, appPrimaryDoc = NULL) {
   linters <- mget(objects(.__LINTERS__.), envir = .__LINTERS__.)
 
   # Identify all files that will be read in by one or more linters
-  projectFilesToLint <- Reduce(union, lapply(linters, function(linter) {
-    getLinterApplicableFiles(linter, files)
-  }))
+  projectFilesToLint <- Reduce(
+    union,
+    lapply(linters, function(linter) {
+      getLinterApplicableFiles(linter, files)
+    })
+  )
 
   # Read in the files
   encoding <- activeEncoding(project)
   projectContent <- lapply(projectFilesToLint, function(file) {
-
     # force native encoding (disable any potential internal conversion)
     old <- options(encoding = "native.enc")
     defer(options(old))
@@ -36,7 +38,6 @@ lint <- function(project, files = NULL, appPrimaryDoc = NULL) {
     # read content with requested encoding
     # TODO: may consider converting from native encoding to UTF-8 if appropriate
     readLines(file, encoding = encoding, warn = FALSE)
-
   })
 
   names(projectContent) <- projectFilesToLint
@@ -55,11 +56,13 @@ lint <- function(project, files = NULL, appPrimaryDoc = NULL) {
       file <- applicableFiles[[j]]
       tryCatch(
         expr = {
-          lintIndices[[j]] <- applyLinter(linter,
-                                          projectContent[[file]],
-                                          project = project,
-                                          path = file,
-                                          files = files)
+          lintIndices[[j]] <- applyLinter(
+            linter,
+            projectContent[[file]],
+            project = project,
+            path = file,
+            files = files
+          )
         },
         error = function(e) {
           message("Failed to lint file '", file, "'")
@@ -91,13 +94,15 @@ lint <- function(project, files = NULL, appPrimaryDoc = NULL) {
       message = lintMessages,
       suggestion = linter$suggestion
     )
-
   }
 
   ## Get all of the linted files, and transform the results into a by-file format
-  lintedFiles <- Reduce(union, lapply(lintResults, function(x) {
-    names(x$indices)
-  }))
+  lintedFiles <- Reduce(
+    union,
+    lapply(lintResults, function(x) {
+      names(x$indices)
+    })
+  )
 
   lintFields <- c("indices", "message")
   fileResults <- lapply(lintedFiles, function(file) {
@@ -122,9 +127,12 @@ lint <- function(project, files = NULL, appPrimaryDoc = NULL) {
 lintHeader <- function(file) {
   dashSep <- paste(rep("-", nchar(file)), collapse = "")
   header <- paste0(
-    dashSep, "\n",
-    file, "\n",
-    dashSep, "\n"
+    dashSep,
+    "\n",
+    file,
+    "\n",
+    dashSep,
+    "\n"
   )
   cat(paste(header, collapse = "\n"))
 }
@@ -173,14 +181,17 @@ showLintResults <- function(appDir, lintResults) {
   if (interactive()) {
     # if enabled, show warnings in friendly marker tab in addition to
     # printing to console
-    if (getOption("rsconnect.rstudio_source_markers", TRUE) &&
-        rstudioapi::hasFun("sourceMarkers"))
-    {
+    if (
+      getOption("rsconnect.rstudio_source_markers", TRUE) &&
+        rstudioapi::hasFun("sourceMarkers")
+    ) {
       showRstudioSourceMarkers(appDir, lintResults)
     }
   }
 
-  message("The following potential problems were identified in the project files:\n")
+  message(
+    "The following potential problems were identified in the project files:\n"
+  )
   print(lintResults)
 
   if (interactive()) {
@@ -194,8 +205,10 @@ showLintResults <- function(appDir, lintResults) {
     #   "\tdeployApp(lint = FALSE)\n\n",
     #   "to disable linting."
     # )
-    message("If your code fails to run post-deployment, ",
-            "please double-check these messages.")
+    message(
+      "If your code fails to run post-deployment, ",
+      "please double-check these messages."
+    )
 
     invisible()
   }
@@ -210,15 +223,17 @@ showLintResults <- function(appDir, lintResults) {
 #' @param content The content of the file that was linted.
 #' @param lines The line numbers from `content` that contain lint.
 makeLinterMessage <- function(header, content, lines) {
-
   lint <- attr(lines, "lint")
 
   c(
     paste0(header, ":"),
-    paste(lines, ": ",
-          content[lines],
-          if (!is.null(lint)) paste("    ", lint, sep = ""),
-          sep = ""),
+    paste(
+      lines,
+      ": ",
+      content[lines],
+      if (!is.null(lint)) paste("    ", lint, sep = ""),
+      sep = ""
+    ),
     "\n"
   )
 }
@@ -242,24 +257,19 @@ hasLint <- function(x) {
 }
 
 activeEncoding <- function(project = getwd()) {
-
   defaultEncoding <- getOption("encoding")
-  if (identical(defaultEncoding, "native.enc"))
-    defaultEncoding <- "unknown"
+  if (identical(defaultEncoding, "native.enc")) defaultEncoding <- "unknown"
 
   # attempt to locate .Rproj file
   files <- list.files(project, full.names = TRUE)
   rprojFile <- grep("\\.Rproj$", files, value = TRUE)
-  if (length(rprojFile) != 1)
-    return(defaultEncoding)
+  if (length(rprojFile) != 1) return(defaultEncoding)
 
   # read the file
   contents <- readLines(rprojFile, warn = FALSE, encoding = "UTF-8")
   encodingLine <- grep("^Encoding:", contents, value = TRUE)
-  if (length(encodingLine) != 1)
-    return(defaultEncoding)
+  if (length(encodingLine) != 1) return(defaultEncoding)
 
   # remove "Encoding:" prefix
   sub("^Encoding:\\s*", "", encodingLine)
-
 }

--- a/R/lint.R
+++ b/R/lint.R
@@ -258,17 +258,23 @@ hasLint <- function(x) {
 
 activeEncoding <- function(project = getwd()) {
   defaultEncoding <- getOption("encoding")
-  if (identical(defaultEncoding, "native.enc")) defaultEncoding <- "unknown"
+  if (identical(defaultEncoding, "native.enc")) {
+    defaultEncoding <- "unknown"
+  }
 
   # attempt to locate .Rproj file
   files <- list.files(project, full.names = TRUE)
   rprojFile <- grep("\\.Rproj$", files, value = TRUE)
-  if (length(rprojFile) != 1) return(defaultEncoding)
+  if (length(rprojFile) != 1) {
+    return(defaultEncoding)
+  }
 
   # read the file
   contents <- readLines(rprojFile, warn = FALSE, encoding = "UTF-8")
   encodingLine <- grep("^Encoding:", contents, value = TRUE)
-  if (length(encodingLine) != 1) return(defaultEncoding)
+  if (length(encodingLine) != 1) {
+    return(defaultEncoding)
+  }
 
   # remove "Encoding:" prefix
   sub("^Encoding:\\s*", "", encodingLine)

--- a/R/linters.R
+++ b/R/linters.R
@@ -64,186 +64,207 @@ isRCodeFile <- function(path) {
 }
 
 
-addLinter("absolute.paths", linter(
+addLinter(
+  "absolute.paths",
+  linter(
+    apply = function(content, ...) {
+      content <- stripComments(content)
+      which(hasAbsolutePaths(content))
+    },
 
-  apply = function(content, ...) {
-    content <- stripComments(content)
-    which(hasAbsolutePaths(content))
-  },
+    takes = isRCodeFile,
 
-  takes = isRCodeFile,
+    message = function(content, lines) {
+      makeLinterMessage(
+        "The following lines contain absolute paths",
+        content,
+        lines
+      )
+    },
 
-  message = function(content, lines) {
-    makeLinterMessage("The following lines contain absolute paths",
-                      content,
-                      lines)
-  },
+    suggestion = "Paths should be to files within the project directory."
+  )
+)
 
-  suggestion = "Paths should be to files within the project directory."
-))
+addLinter(
+  "filepath.capitalization",
+  linter(
+    apply = function(content, project, path, files) {
+      content <- stripComments(content)
 
-addLinter("filepath.capitalization", linter(
-
-  apply = function(content, project, path, files) {
-    content <- stripComments(content)
-
-    # Extract references between bounding (unescaped) quotes.
-    extractQuoted <- function(regex) {
-      matches <- gregexpr(regex, content, perl = TRUE)
-      results <- vector("list", length(content))
-      for (i in seq_along(matches)) {
-        x <- matches[[i]]
-        if (x[[1]] == -1L || length(x) %% 2 != 0) next
-        starts <- x[seq(1, length(x), by = 2)]
-        ends   <- x[seq(2, length(x), by = 2)]
-        results[[i]] <- character(length(starts))
-        for (j in seq_along(starts)) {
-          results[[i]][[j]] <- substring(content[i], starts[j] + 1, ends[j] - 1)
+      # Extract references between bounding (unescaped) quotes.
+      extractQuoted <- function(regex) {
+        matches <- gregexpr(regex, content, perl = TRUE)
+        results <- vector("list", length(content))
+        for (i in seq_along(matches)) {
+          x <- matches[[i]]
+          if (x[[1]] == -1L || length(x) %% 2 != 0) next
+          starts <- x[seq(1, length(x), by = 2)]
+          ends <- x[seq(2, length(x), by = 2)]
+          results[[i]] <- character(length(starts))
+          for (j in seq_along(starts)) {
+            results[[i]][[j]] <- substring(
+              content[i],
+              starts[j] + 1,
+              ends[j] - 1
+            )
+          }
         }
+        results
       }
-      results
-    }
 
-    # Extract targets from Markdown links.
-    extractLinked <- function() {
-      regex <- "\\]\\(.*?\\)"
-      matches <- gregexpr(regex, content, perl = TRUE)
-      results <- vector("list", length(content))
-      for (i in seq_along(matches)) {
-        x <- matches[[i]]
-        if (x[[1]] == -1L) next
-        results[[i]] <- character(length(x))
-        attr <- attributes(x)
-        for (j in seq_along(x)) {
-          raw <- x[[j]]
-          raw.length <- attr$match.length[[j]]
-          # skip past "](" and discard ")"
-          start <- as.integer(raw) + 2
-          end <- as.integer(raw) + raw.length - 2
-          results[[i]][[j]] <- substring(content[i], start, end)
+      # Extract targets from Markdown links.
+      extractLinked <- function() {
+        regex <- "\\]\\(.*?\\)"
+        matches <- gregexpr(regex, content, perl = TRUE)
+        results <- vector("list", length(content))
+        for (i in seq_along(matches)) {
+          x <- matches[[i]]
+          if (x[[1]] == -1L) next
+          results[[i]] <- character(length(x))
+          attr <- attributes(x)
+          for (j in seq_along(x)) {
+            raw <- x[[j]]
+            raw.length <- attr$match.length[[j]]
+            # skip past "](" and discard ")"
+            start <- as.integer(raw) + 2
+            end <- as.integer(raw) + raw.length - 2
+            results[[i]][[j]] <- substring(content[i], start, end)
+          }
         }
+        results
       }
-      results
-    }
 
-    # Inferred files within source documents; between matching quotes or in
-    # something that looks like a Markdown link.
-    inferredFiles <- list(
-      "single.quotes" = extractQuoted("(?!\\\\)\'"),
-      "double.quotes" = extractQuoted("(?!\\\\)\""),
-      "markdown.links" = extractLinked()
-    )
+      # Inferred files within source documents; between matching quotes or in
+      # something that looks like a Markdown link.
+      inferredFiles <- list(
+        "single.quotes" = extractQuoted("(?!\\\\)\'"),
+        "double.quotes" = extractQuoted("(?!\\\\)\""),
+        "markdown.links" = extractLinked()
+      )
 
-    ## Replace '\' with '/' in filepaths for consistency in comparisons
-    inferredFiles <- lapply(inferredFiles, function(x) {
-      lapply(x, function(xx) {
-        gsub("\\\\", "/", xx, perl = TRUE)
+      ## Replace '\' with '/' in filepaths for consistency in comparisons
+      inferredFiles <- lapply(inferredFiles, function(x) {
+        lapply(x, function(xx) {
+          gsub("\\\\", "/", xx, perl = TRUE)
+        })
       })
-    })
 
-    # Compare in case sensitive, case insensitive fashion
-    projectFiles <- files
-    projectFilesLower <- tolower(files)
+      # Compare in case sensitive, case insensitive fashion
+      projectFiles <- files
+      projectFilesLower <- tolower(files)
 
-    badLines <- lapply(inferredFiles, function(regex) {
-      lapply(regex, function(x) {
-
-        which(
-          # Only examine paths containing a slash to reduce false positives
-          grepl("/", x, fixed = TRUE) &
-          (tolower(x) %in% projectFilesLower) &
-            (!(x %in% projectFiles))
-        )
-
-      })
-    })
-
-    indices <- Reduce(union, lapply(badLines, function(x) {
-      which(sapply(x, length) > 0)
-    }))
-
-    if (!length(indices)) return(integer())
-
-    from <- lapply(inferredFiles, function(x) x[indices])
-    to <- lapply(from, function(x) {
-      lapply(x, function(xx) {
-        projectFiles[tolower(xx) == projectFilesLower]
-      })
-    })
-
-    messages <- lapply(seq_along(from), function(regex) {
-      lapply(seq_along(regex), function(i) {
-        if (length(from[[regex]][[i]]))
-          paste(collapse = ", ",
-                paste("[",
-                      sQuote(from[[regex]][[i]]),
-                      " -> ",
-                      sQuote(to[[regex]][[i]]),
-                      "]", sep = "")
+      badLines <- lapply(inferredFiles, function(regex) {
+        lapply(regex, function(x) {
+          which(
+            # Only examine paths containing a slash to reduce false positives
+            grepl("/", x, fixed = TRUE) &
+              (tolower(x) %in% projectFilesLower) &
+              (!(x %in% projectFiles))
           )
-        else
-          ""
+        })
       })
-    })
 
-    transposed <- transposeList(messages)
-    lint <- sapply(transposed, function(x) {
-      paste(x[x != ""], collapse = ", ")
-    })
+      indices <- Reduce(
+        union,
+        lapply(badLines, function(x) {
+          which(sapply(x, length) > 0)
+        })
+      )
 
-    indices <- as.numeric(indices)
-    attr(indices, "lint") <- lint
-    indices
+      if (!length(indices)) return(integer())
 
-  },
+      from <- lapply(inferredFiles, function(x) x[indices])
+      to <- lapply(from, function(x) {
+        lapply(x, function(xx) {
+          projectFiles[tolower(xx) == projectFilesLower]
+        })
+      })
 
-  takes = isRCodeFile,
+      messages <- lapply(seq_along(from), function(regex) {
+        lapply(seq_along(regex), function(i) {
+          if (length(from[[regex]][[i]]))
+            paste(
+              collapse = ", ",
+              paste(
+                "[",
+                sQuote(from[[regex]][[i]]),
+                " -> ",
+                sQuote(to[[regex]][[i]]),
+                "]",
+                sep = ""
+              )
+            ) else ""
+        })
+      })
 
-  message = function(content, lines) {
-    makeLinterMessage(
-      "The following lines contain paths to files not matching in case sensitivity",
-      content,
-      lines
-    )
-  },
+      transposed <- transposeList(messages)
+      lint <- sapply(transposed, function(x) {
+        paste(x[x != ""], collapse = ", ")
+      })
 
-  suggestion = "Filepaths are case-sensitive on deployment server."
+      indices <- as.numeric(indices)
+      attr(indices, "lint") <- lint
+      indices
+    },
 
-))
+    takes = isRCodeFile,
 
-addLinter("browser", linter(
-  apply = function(content, ...) {
-    content <- stripComments(content)
-    which(hasBrowserCalls(content))
-  },
+    message = function(content, lines) {
+      makeLinterMessage(
+        "The following lines contain paths to files not matching in case sensitivity",
+        content,
+        lines
+      )
+    },
 
-  takes = isRCodeFile,
+    suggestion = "Filepaths are case-sensitive on deployment server."
+  )
+)
 
-  message = function(content, lines) {
-    makeLinterMessage("The following lines contain the browser() debugging function",
-                      content,
-                      lines)
-  },
+addLinter(
+  "browser",
+  linter(
+    apply = function(content, ...) {
+      content <- stripComments(content)
+      which(hasBrowserCalls(content))
+    },
 
-  suggestion = "The browser() debugging function should be removed."
-))
+    takes = isRCodeFile,
 
-addLinter("browseURL", linter(
-  apply = function(content, ...) {
-    content <- stripComments(content)
-    which(hasBrowseURLCalls(content))
-  },
+    message = function(content, lines) {
+      makeLinterMessage(
+        "The following lines contain the browser() debugging function",
+        content,
+        lines
+      )
+    },
 
-  takes = isRCodeFile,
+    suggestion = "The browser() debugging function should be removed."
+  )
+)
 
-  message = function(content, lines) {
-    makeLinterMessage("The following lines contain calls to the browseURL function",
-                      content,
-                      lines)
-  },
+addLinter(
+  "browseURL",
+  linter(
+    apply = function(content, ...) {
+      content <- stripComments(content)
+      which(hasBrowseURLCalls(content))
+    },
 
-  suggestion = "Remove browseURL calls; browseURL does not work in deployed applications."
-))
+    takes = isRCodeFile,
+
+    message = function(content, lines) {
+      makeLinterMessage(
+        "The following lines contain calls to the browseURL function",
+        content,
+        lines
+      )
+    },
+
+    suggestion = "Remove browseURL calls; browseURL does not work in deployed applications."
+  )
+)
 
 
 stripComments <- function(content) {
@@ -263,16 +284,18 @@ hasBrowseURLCalls <- function(content) {
 }
 
 hasAbsolutePaths <- function(content) {
-
   regex <- c(
     "\\[(.*?)\\]\\(\\s*[a-zA-Z]:/[^\"\']", ## windows-style markdown references [Some image](C:/...)
     "\\[(.*?)\\]\\(\\s*/[^/]", ## unix-style markdown references [Some image](/Users/...)
     NULL ## so we don't worry about commas above
   )
 
-  regexResults <- as.logical(Reduce(`+`, lapply(regex, function(rex) {
-    grepl(rex, content, perl = TRUE)
-  })))
+  regexResults <- as.logical(Reduce(
+    `+`,
+    lapply(regex, function(rex) {
+      grepl(rex, content, perl = TRUE)
+    })
+  ))
 
   # Strip out all strings in the document, and check to see if any of them
   # resolve to absolute paths on the system.
@@ -292,21 +315,29 @@ hasAbsolutePaths <- function(content) {
 
   strings <- vector("list", length(extractedStrings[[1]]))
   for (i in seq_along(extractedStrings[[1]])) {
-    strings[[i]] <- unique(c(extractedStrings[[1]][[i]], extractedStrings[[2]][[i]]))
+    strings[[i]] <- unique(c(
+      extractedStrings[[1]][[i]],
+      extractedStrings[[2]][[i]]
+    ))
     strings[[i]] <- strings[[i]][nchar(strings[[i]]) >= 5]
   }
 
   lineHasAbsolutePath <- unlist(lapply(strings, function(x) {
     any(
       grepl("^/|^[a-zA-Z]:/|^~", x, perl = TRUE) &
-      file.exists(x) &
-      !dirExists(x) &
-      vapply(gregexpr("[~/]", x, perl = TRUE), USE.NAMES = FALSE, FUN.VALUE = numeric(1), length) >= 3
+        file.exists(x) &
+        !dirExists(x) &
+        vapply(
+          gregexpr("[~/]", x, perl = TRUE),
+          USE.NAMES = FALSE,
+          FUN.VALUE = numeric(1),
+          length
+        ) >=
+          3
     )
   }))
 
   as.logical(lineHasAbsolutePath + regexResults)
-
 }
 
 noMatch <- function(x) {
@@ -320,6 +351,8 @@ transposeList <- function(list) {
         as.matrix(
           as.data.frame(list, stringsAsFactors = FALSE)
         )
-      ), stringsAsFactors = FALSE)
+      ),
+      stringsAsFactors = FALSE
+    )
   ))
 }

--- a/R/linters.R
+++ b/R/linters.R
@@ -98,7 +98,9 @@ addLinter(
         results <- vector("list", length(content))
         for (i in seq_along(matches)) {
           x <- matches[[i]]
-          if (x[[1]] == -1L || length(x) %% 2 != 0) next
+          if (x[[1]] == -1L || length(x) %% 2 != 0) {
+            next
+          }
           starts <- x[seq(1, length(x), by = 2)]
           ends <- x[seq(2, length(x), by = 2)]
           results[[i]] <- character(length(starts))
@@ -120,7 +122,9 @@ addLinter(
         results <- vector("list", length(content))
         for (i in seq_along(matches)) {
           x <- matches[[i]]
-          if (x[[1]] == -1L) next
+          if (x[[1]] == -1L) {
+            next
+          }
           results[[i]] <- character(length(x))
           attr <- attributes(x)
           for (j in seq_along(x)) {
@@ -172,7 +176,9 @@ addLinter(
         })
       )
 
-      if (!length(indices)) return(integer())
+      if (!length(indices)) {
+        return(integer())
+      }
 
       from <- lapply(inferredFiles, function(x) x[indices])
       to <- lapply(from, function(x) {
@@ -183,7 +189,7 @@ addLinter(
 
       messages <- lapply(seq_along(from), function(regex) {
         lapply(seq_along(regex), function(i) {
-          if (length(from[[regex]][[i]]))
+          if (length(from[[regex]][[i]])) {
             paste(
               collapse = ", ",
               paste(
@@ -194,7 +200,10 @@ addLinter(
                 "]",
                 sep = ""
               )
-            ) else ""
+            )
+          } else {
+            ""
+          }
         })
       })
 
@@ -306,7 +315,9 @@ hasAbsolutePaths <- function(content) {
     matches <- gregexpr(regex, content, perl = TRUE)
     lapply(seq_along(matches), function(i) {
       match <- matches[[i]]
-      if (c(match[[1]]) == -1L) return(character())
+      if (c(match[[1]]) == -1L) {
+        return(character())
+      }
       starts <- as.integer(match) + 1
       ends <- starts + attr(match, "match.length") - 3
       substring(content[[i]], starts, ends)

--- a/R/purgeApp.R
+++ b/R/purgeApp.R
@@ -21,8 +21,7 @@
 #' @seealso [applications()], [deployApp()], and
 #'   [restartApp()]
 #' @export
-purgeApp <- function(appName, account = NULL, server = NULL,
-                     quiet = FALSE) {
+purgeApp <- function(appName, account = NULL, server = NULL, quiet = FALSE) {
   accountDetails <- accountInfo(account, server)
   checkShinyappsServer(accountDetails$server)
 

--- a/R/rpubs.R
+++ b/R/rpubs.R
@@ -39,29 +39,23 @@
 #'                             id = result$id)
 #' }
 #' @export
-rpubsUpload <- function(title,
-                        contentFile,
-                        originalDoc,
-                        id = NULL,
-                        properties = list()) {
-
+rpubsUpload <- function(
+  title,
+  contentFile,
+  originalDoc,
+  id = NULL,
+  properties = list()
+) {
   check_string(title, allow_empty = FALSE)
   check_file(contentFile)
-  if (!is.list(properties))
-    stop("properties paramater must be a named list")
+  if (!is.list(properties)) stop("properties paramater must be a named list")
 
   pathFromId <- function(id) {
     split <- strsplit(id, "^https?://[^/]+")[[1]]
-    if (length(split) == 2)
-      return(split[2])
-    else
-      return(NULL)
+    if (length(split) == 2) return(split[2]) else return(NULL)
   }
 
-  buildPackage <- function(title,
-                           contentFile,
-                           properties = list()) {
-
+  buildPackage <- function(title, contentFile, properties = list()) {
     # build package.json
     properties$title <- title
     packageJson <- toJSON(properties)
@@ -109,20 +103,22 @@ rpubsUpload <- function(title,
   }
 
   # send the request
-  result <- http(protocol = protocol,
-                 host = "api.rpubs.com",
-                 port = port,
-                 method = method,
-                 path = path,
-                 headers = headers,
-                 contentType = "application/x-compressed",
-                 contentFile = packageFile)
+  result <- http(
+    protocol = protocol,
+    host = "api.rpubs.com",
+    port = port,
+    method = method,
+    path = path,
+    headers = headers,
+    contentType = "application/x-compressed",
+    contentFile = packageFile
+  )
 
   # check for success
   succeeded <- FALSE
-  if (isUpdate && (result$status == 200))
-    succeeded <- TRUE
-  else if (result$status == 201)
+  if (isUpdate && (result$status == 200)) succeeded <- TRUE else if (
+    result$status == 201
+  )
     succeeded <- TRUE
 
   # mark content as UTF-8
@@ -137,24 +133,36 @@ rpubsUpload <- function(title,
 
     # we use the source doc as the key for the deployment record as long as
     # it's a recognized document path; otherwise we use the content file
-    recordSource <- ifelse(!is.null(originalDoc) && isDocumentPath(originalDoc),
-                           originalDoc, contentFile)
+    recordSource <- ifelse(
+      !is.null(originalDoc) && isDocumentPath(originalDoc),
+      originalDoc,
+      contentFile
+    )
 
     # use the title if given, and the filename name of the document if not
-    recordName <- ifelse(is.null(title) || nchar(title) == 0,
-                         basename(recordSource), title)
+    recordName <- ifelse(
+      is.null(title) || nchar(title) == 0,
+      basename(recordSource),
+      title
+    )
 
-    rpubsRec <- deploymentRecord(name = recordName,
-                                 title = "",
-                                 username = "",
-                                 account = "rpubs",
-                                 server = "rpubs.com",
-                                 hostUrl = "rpubs.com",
-                                 appId = id,
-                                 bundleId = id,
-                                 url = url)
-    rpubsRecFile <- deploymentConfigFile(recordSource, recordName, "rpubs",
-                                   "rpubs.com")
+    rpubsRec <- deploymentRecord(
+      name = recordName,
+      title = "",
+      username = "",
+      account = "rpubs",
+      server = "rpubs.com",
+      hostUrl = "rpubs.com",
+      appId = id,
+      bundleId = id,
+      url = url
+    )
+    rpubsRecFile <- deploymentConfigFile(
+      recordSource,
+      recordName,
+      "rpubs",
+      "rpubs.com"
+    )
     write.dcf(rpubsRec, rpubsRecFile, width = 4096)
 
     # record in global history
@@ -162,8 +170,7 @@ rpubsUpload <- function(title,
       addToDeploymentHistory(originalDoc, rpubsRec)
 
     # return the publish information
-    return(list(id = id,
-                 continueUrl = url))
+    return(list(id = id, continueUrl = url))
   } else {
     return(list(error = content))
   }

--- a/R/rpubs.R
+++ b/R/rpubs.R
@@ -48,11 +48,17 @@ rpubsUpload <- function(
 ) {
   check_string(title, allow_empty = FALSE)
   check_file(contentFile)
-  if (!is.list(properties)) stop("properties paramater must be a named list")
+  if (!is.list(properties)) {
+    stop("properties paramater must be a named list")
+  }
 
   pathFromId <- function(id) {
     split <- strsplit(id, "^https?://[^/]+")[[1]]
-    if (length(split) == 2) return(split[2]) else return(NULL)
+    if (length(split) == 2) {
+      return(split[2])
+    } else {
+      return(NULL)
+    }
   }
 
   buildPackage <- function(title, contentFile, properties = list()) {
@@ -116,10 +122,11 @@ rpubsUpload <- function(
 
   # check for success
   succeeded <- FALSE
-  if (isUpdate && (result$status == 200)) succeeded <- TRUE else if (
-    result$status == 201
-  )
+  if (isUpdate && (result$status == 200)) {
     succeeded <- TRUE
+  } else if (result$status == 201) {
+    succeeded <- TRUE
+  }
 
   # mark content as UTF-8
   content <- result$content
@@ -166,8 +173,9 @@ rpubsUpload <- function(
     write.dcf(rpubsRec, rpubsRecFile, width = 4096)
 
     # record in global history
-    if (!is.null(originalDoc) && nzchar(originalDoc))
+    if (!is.null(originalDoc) && nzchar(originalDoc)) {
       addToDeploymentHistory(originalDoc, rpubsRec)
+    }
 
     # return the publish information
     return(list(id = id, continueUrl = url))

--- a/R/secret.R
+++ b/R/secret.R
@@ -22,8 +22,7 @@ str.rsconnect_secret <- function(object, ...) {
 }
 
 #' @export
-as.data.frame.rsconnect_secret <- function(x,
-                                           ...) {
+as.data.frame.rsconnect_secret <- function(x, ...) {
   structure(
     list(x),
     row.names = .set_row_names(length(x)),

--- a/R/servers-deprec.R
+++ b/R/servers-deprec.R
@@ -10,17 +10,26 @@
 discoverServers <- function(quiet = FALSE) {
   lifecycle::deprecate_warn("1.0.0", "discoverServers()")
 
-  discovered <- getOption("rsconnect.local_servers", "http://localhost:3939/__api__")
+  discovered <- getOption(
+    "rsconnect.local_servers",
+    "http://localhost:3939/__api__"
+  )
 
   # get the URLs of the known servers, and silently add any that aren't yet
   # present
   existing <- servers()[, "url"]
   introduced <- setdiff(discovered, existing)
-  lapply(introduced, function(url) { addServer(url, quiet = TRUE) })
+  lapply(introduced, function(url) {
+    addServer(url, quiet = TRUE)
+  })
 
   if (!quiet && length(introduced) > 0) {
-    message("Discovered ", length(introduced),
-            (if (length(introduced) == 1) "server" else "servers"), ":")
+    message(
+      "Discovered ",
+      length(introduced),
+      (if (length(introduced) == 1) "server" else "servers"),
+      ":"
+    )
     lapply(introduced, message)
   } else if (!quiet) {
     message("No new servers found.")
@@ -38,7 +47,12 @@ discoverServers <- function(quiet = FALSE) {
 #' @export
 #' @inheritParams addServer
 #' @keywords internal
-addConnectServer <- function(url, name = NULL, certificate = NULL, quiet = FALSE) {
+addConnectServer <- function(
+  url,
+  name = NULL,
+  certificate = NULL,
+  quiet = FALSE
+) {
   lifecycle::deprecate_warn("1.0.0", "addConnectServer()", "addServer()")
   addServer(
     ensureConnectServerUrl(url),

--- a/R/servers.R
+++ b/R/servers.R
@@ -107,10 +107,7 @@ cloudServerInfo <- function(name, url) {
   )
 }
 
-findServer <- function(server = NULL,
-                       local = TRUE,
-                       error_call = caller_env()) {
-
+findServer <- function(server = NULL, local = TRUE, error_call = caller_env()) {
   if (!is.null(server)) {
     check_string(server, call = error_call)
 
@@ -175,7 +172,14 @@ findServer <- function(server = NULL,
 #' connectUser(server = "myserver")
 #' }
 #' @export
-addServer <- function(url, name = NULL, certificate = NULL, validate = TRUE, snowflakeConnectionName = NULL, quiet = FALSE) {
+addServer <- function(
+  url,
+  name = NULL,
+  certificate = NULL,
+  validate = TRUE,
+  snowflakeConnectionName = NULL,
+  quiet = FALSE
+) {
   check_string(url)
   check_name(name, allow_null = TRUE)
 
@@ -191,7 +195,7 @@ addServer <- function(url, name = NULL, certificate = NULL, validate = TRUE, sno
   registerServer(name, url, certificate)
 
   if (!quiet) {
-    message("Server '", name,  "' added successfully: ", url)
+    message("Server '", name, "' added successfully: ", url)
   }
 }
 
@@ -199,7 +203,11 @@ addServer <- function(url, name = NULL, certificate = NULL, validate = TRUE, sno
 # Validate a connect server URL by hitting a known configuration endpoint
 # The URL may be specified with or without the protocol and port; this function
 # will try both http and https and follow any redirects given by the server.
-validateConnectUrl <- function(url, certificate = NULL, snowflakeConnectionName = NULL) {
+validateConnectUrl <- function(
+  url,
+  certificate = NULL,
+  snowflakeConnectionName = NULL
+) {
   # Add protocol if missing, assuming https except for local installs
   if (!grepl("://", url, fixed = TRUE)) {
     if (grepl(":3939", url, fixed = TRUE)) {
@@ -216,13 +224,17 @@ validateConnectUrl <- function(url, certificate = NULL, snowflakeConnectionName 
     auth_info <- list(certificate = inferCertificateContents(certificate))
 
     if (!is.null(snowflakeConnectionName)) {
-      auth_info$snowflakeToken <- getSnowflakeAuthToken(url, snowflakeConnectionName)
+      auth_info$snowflakeToken <- getSnowflakeAuthToken(
+        url,
+        snowflakeConnectionName
+      )
     }
     GET(
       parseHttpUrl(url),
       auth_info,
       "/server_settings",
-      timeout = timeout, rawResponse = TRUE
+      timeout = timeout,
+      rawResponse = TRUE
     )
   }
   response <- NULL
@@ -252,13 +264,17 @@ ensureConnectServerUrl <- function(url) {
   url <- gsub("/$", "", url)
 
   # ensure 'url' ends with '/__api__'
-  if (!grepl("/__api__$", url))
-    url <- paste(url, "/__api__", sep = "")
+  if (!grepl("/__api__$", url)) url <- paste(url, "/__api__", sep = "")
 
   url
 }
 
-registerServer <- function(name, url, certificate = NULL, error_call = caller_env()) {
+registerServer <- function(
+  name,
+  url,
+  certificate = NULL,
+  error_call = caller_env()
+) {
   certificate <- inferCertificateContents(certificate)
 
   if (!identical(substr(url, 1, 5), "https") && !is.null(certificate)) {
@@ -295,8 +311,7 @@ addServerCertificate <- function(name, certificate, quiet = FALSE) {
   info <- serverInfo(name)
   registerServer(name, info$url, certificate)
 
-  if (!quiet)
-    message("Certificate added to server '", name, "'")
+  if (!quiet) message("Certificate added to server '", name, "'")
 
   invisible(NULL)
 }

--- a/R/servers.R
+++ b/R/servers.R
@@ -264,7 +264,9 @@ ensureConnectServerUrl <- function(url) {
   url <- gsub("/$", "", url)
 
   # ensure 'url' ends with '/__api__'
-  if (!grepl("/__api__$", url)) url <- paste(url, "/__api__", sep = "")
+  if (!grepl("/__api__$", url)) {
+    url <- paste(url, "/__api__", sep = "")
+  }
 
   url
 }
@@ -311,7 +313,9 @@ addServerCertificate <- function(name, certificate, quiet = FALSE) {
   info <- serverInfo(name)
   registerServer(name, info$url, certificate)
 
-  if (!quiet) message("Certificate added to server '", name, "'")
+  if (!quiet) {
+    message("Certificate added to server '", name, "'")
+  }
 
   invisible(NULL)
 }

--- a/R/tasks.R
+++ b/R/tasks.R
@@ -21,7 +21,6 @@
 #' @note This function works only with shinyapps.io and posit.cloud.
 #' @export
 tasks <- function(account = NULL, server = NULL) {
-
   # resolve account and create connect client
   accountDetails <- accountInfo(account, server)
   checkCloudServer(accountDetails$server)
@@ -61,7 +60,6 @@ tasks <- function(account = NULL, server = NULL) {
 #' @note This function works only with shinyapps.io and posit.cloud.
 #' @export
 taskLog <- function(taskId, account = NULL, server = NULL, output = NULL) {
-
   accountDetails <- accountInfo(account, server)
   checkCloudServer(accountDetails$server)
 
@@ -69,7 +67,7 @@ taskLog <- function(taskId, account = NULL, server = NULL, output = NULL) {
 
   if (identical(output, "stderr")) {
     conn <- stderr()
-  } else{
+  } else {
     conn <- ""
   }
 
@@ -77,12 +75,13 @@ taskLog <- function(taskId, account = NULL, server = NULL, output = NULL) {
   cat(client$getTaskLogs(taskId), file = conn)
 
   # get child tasks
-  tasks <- client$listTasks(accountDetails$accountId,
-                            filters = filterQuery("parent_id", taskId))
+  tasks <- client$listTasks(
+    accountDetails$accountId,
+    filters = filterQuery("parent_id", taskId)
+  )
 
   # get child task logs
   for (task in tasks) {
     taskLog(task["id"], account = account, server = server, output = output)
   }
-
 }

--- a/R/terminateApp.R
+++ b/R/terminateApp.R
@@ -21,8 +21,12 @@
 #' @seealso [applications()], [deployApp()], and
 #'   [restartApp()]
 #' @export
-terminateApp <- function(appName, account = NULL, server = NULL,
-                         quiet = FALSE) {
+terminateApp <- function(
+  appName,
+  account = NULL,
+  server = NULL,
+  quiet = FALSE
+) {
   accountDetails <- accountInfo(account, server)
   checkShinyappsServer(accountDetails$server)
 

--- a/R/title.R
+++ b/R/title.R
@@ -31,7 +31,12 @@
 #' }
 #' @export
 
-generateAppName <- function(appTitle, appPath = NULL, account = NULL, unique = TRUE) {
+generateAppName <- function(
+  appTitle,
+  appPath = NULL,
+  account = NULL,
+  unique = TRUE
+) {
   munge <- function(title) {
     # safe default if no title specified
     if (is.null(title)) {
@@ -73,8 +78,12 @@ generateAppName <- function(appTitle, appPath = NULL, account = NULL, unique = T
 
   # validate that we wound up with a valid name
   if (nchar(name) < 3) {
-    stop("The generated app name '", name, "' is invalid. Include at least 3 ",
-         "alphanumeric characters in the title.")
+    stop(
+      "The generated app name '",
+      name,
+      "' is invalid. Include at least 3 ",
+      "alphanumeric characters in the title."
+    )
   }
 
   # if we have an account and a directory, make the new app name unique to the
@@ -89,8 +98,8 @@ generateAppName <- function(appTitle, appPath = NULL, account = NULL, unique = T
 
       # keep incrementing the suffix until we find a unique name
       while (candidate %in% apps$name) {
-         suffix <- suffix + 1
-         candidate <- paste0(base, suffix)
+        suffix <- suffix + 1
+        candidate <- paste0(base, suffix)
       }
       name <- candidate
     }

--- a/R/usage.R
+++ b/R/usage.R
@@ -14,26 +14,34 @@
 #'   will be grouped. (Relative time delta e.g. "120s" or "1h" or "30d").
 #' @note This function only works for ShinyApps servers.
 #' @export
-showUsage <- function(appDir = getwd(), appName = NULL, account = NULL, server = NULL,
-                      usageType = "hours", from = NULL, until = NULL, interval = NULL) {
-
+showUsage <- function(
+  appDir = getwd(),
+  appName = NULL,
+  account = NULL,
+  server = NULL,
+  usageType = "hours",
+  from = NULL,
+  until = NULL,
+  interval = NULL
+) {
   accountDetails <- accountInfo(account, server)
   checkShinyappsServer(accountDetails$server)
 
   api <- clientForAccount(accountDetails)
 
   # resolve application
-  if (is.null(appName))
-    appName <- basename(appDir)
+  if (is.null(appName)) appName <- basename(appDir)
   application <- resolveApplication(accountDetails, appName)
 
   # get application usage
-  data <- api$getAccountUsage(accountDetails$accountId,
-                              usageType,
-                              application$id,
-                              from,
-                              until,
-                              interval)
+  data <- api$getAccountUsage(
+    accountDetails$accountId,
+    usageType,
+    application$id,
+    from,
+    until,
+    interval
+  )
 
   if (length(data$points) < 1) {
     stop("No data.", call. = FALSE)
@@ -47,7 +55,10 @@ showUsage <- function(appDir = getwd(), appName = NULL, account = NULL, server =
   })
 
   # convert to data frame
-  df <- data.frame(matrix(unlist(points), nrow = length(points), byrow = TRUE), stringsAsFactors = FALSE)
+  df <- data.frame(
+    matrix(unlist(points), nrow = length(points), byrow = TRUE),
+    stringsAsFactors = FALSE
+  )
   colnames(df) <- c("timestamp", usageType)
   return(df)
 }
@@ -71,31 +82,33 @@ showUsage <- function(appDir = getwd(), appName = NULL, account = NULL, server =
 #' @param interval Summarization interval. Data points at intervals less then this
 #'   will be grouped. (Relative time delta e.g. "120s" or "1h" or "30d").
 #' @export
-showMetrics <- function(metricSeries,
-                        metricNames,
-                        appDir = getwd(),
-                        appName = NULL,
-                        account = NULL,
-                        server = "shinyapps.io",
-                        from = NULL,
-                        until = NULL,
-                        interval = NULL) {
-
+showMetrics <- function(
+  metricSeries,
+  metricNames,
+  appDir = getwd(),
+  appName = NULL,
+  account = NULL,
+  server = "shinyapps.io",
+  from = NULL,
+  until = NULL,
+  interval = NULL
+) {
   accountDetails <- accountInfo(account, server)
   api <- clientForAccount(accountDetails)
 
   # resolve application
-  if (is.null(appName))
-    appName <- basename(appDir)
+  if (is.null(appName)) appName <- basename(appDir)
   application <- resolveApplication(accountDetails, appName)
 
   # get application usage
-  data <- api$getApplicationMetrics(application$id,
-                                    metricSeries,
-                                    metricNames,
-                                    from,
-                                    until,
-                                    interval)
+  data <- api$getApplicationMetrics(
+    application$id,
+    metricSeries,
+    metricNames,
+    from,
+    until,
+    interval
+  )
 
   if (length(data$points) < 1) {
     stop("No data.", call. = FALSE)
@@ -120,18 +133,26 @@ showMetrics <- function(metricSeries,
 #'   will be grouped. (Number of seconds or relative time delta e.g. "1h").
 #' @note This function only works for ShinyApps servers.
 #' @export
-accountUsage <- function(account = NULL, server = NULL, usageType = "hours",
-                         from = NULL, until = NULL, interval = NULL) {
+accountUsage <- function(
+  account = NULL,
+  server = NULL,
+  usageType = "hours",
+  from = NULL,
+  until = NULL,
+  interval = NULL
+) {
   accountDetails <- accountInfo(account, server)
   checkShinyappsServer(accountDetails$server)
 
   api <- clientForAccount(accountDetails)
 
   # get application usage
-  data <- api$getAccountUsage(accountDetails$accountId,
-                              usageType,
-                              NULL,
-                              from,
-                              until,
-                              interval)
+  data <- api$getAccountUsage(
+    accountDetails$accountId,
+    usageType,
+    NULL,
+    from,
+    until,
+    interval
+  )
 }

--- a/R/usage.R
+++ b/R/usage.R
@@ -30,7 +30,9 @@ showUsage <- function(
   api <- clientForAccount(accountDetails)
 
   # resolve application
-  if (is.null(appName)) appName <- basename(appDir)
+  if (is.null(appName)) {
+    appName <- basename(appDir)
+  }
   application <- resolveApplication(accountDetails, appName)
 
   # get application usage
@@ -97,7 +99,9 @@ showMetrics <- function(
   api <- clientForAccount(accountDetails)
 
   # resolve application
-  if (is.null(appName)) appName <- basename(appDir)
+  if (is.null(appName)) {
+    appName <- basename(appDir)
+  }
   application <- resolveApplication(accountDetails, appName)
 
   # get application usage

--- a/R/utils-cli.R
+++ b/R/utils-cli.R
@@ -8,13 +8,15 @@ simulate_user_input <- function(x, env = caller_env()) {
   )
 }
 
-cli_menu <- function(header,
-                     prompt,
-                     choices,
-                     not_interactive = choices,
-                     quit = integer(),
-                     .envir = caller_env(),
-                     error_call = caller_env()) {
+cli_menu <- function(
+  header,
+  prompt,
+  choices,
+  not_interactive = choices,
+  quit = integer(),
+  .envir = caller_env(),
+  error_call = caller_env()
+) {
   if (!is_interactive()) {
     cli::cli_abort(
       c(header, not_interactive),

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,7 +6,8 @@ verboseLogger <- function(verbose) {
       cat(paste0(timestamp, " ", ..., "\n"))
     }
   } else {
-    function(...) {}
+    function(...) {
+    }
   }
 }
 
@@ -31,8 +32,10 @@ displayStatus <- function(quiet) {
 }
 
 httpDiagnosticsEnabled <- function() {
-  return(getOption("rsconnect.http.trace", FALSE) ||
-    getOption("rsconnect.http.verbose", FALSE))
+  return(
+    getOption("rsconnect.http.trace", FALSE) ||
+      getOption("rsconnect.http.verbose", FALSE)
+  )
 }
 
 # Replacement for tools::file_path_sans_ext to work around an issue where
@@ -62,9 +65,11 @@ fileMD5 <- function(path, raw = FALSE) {
   }
 }
 
-check_file <- function(x,
-                       error_arg = caller_arg(x),
-                       error_call = caller_env()) {
+check_file <- function(
+  x,
+  error_arg = caller_arg(x),
+  error_call = caller_env()
+) {
   check_string(
     x,
     allow_empty = FALSE,
@@ -79,9 +84,11 @@ check_file <- function(x,
   }
 }
 
-check_directory <- function(x,
-                            error_arg = caller_arg(x),
-                            error_call = caller_env()) {
+check_directory <- function(
+  x,
+  error_arg = caller_arg(x),
+  error_call = caller_env()
+) {
   check_file(x, error_arg = error_arg, error_call = error_call)
   if (!dirExists(x)) {
     cli::cli_abort(
@@ -103,7 +110,6 @@ rbind_fill <- function(dfs, col_names = character()) {
     names(df) <- col_names
     return(as.data.frame(df))
   }
-
 
   all_names <- unique(unlist(lapply(dfs, names)))
   all_names <- union(col_names, all_names)
@@ -146,7 +152,8 @@ dirCreate <- function(paths) {
 }
 
 fromIDE <- function() {
-  !is.na(Sys.getenv("RSTUDIO", unset = NA)) && !identical(.Platform$GUI, "RStudio")
+  !is.na(Sys.getenv("RSTUDIO", unset = NA)) &&
+    !identical(.Platform$GUI, "RStudio")
 }
 
 toJSON <- function(x, ...) {
@@ -163,10 +170,8 @@ toJSON <- function(x, ...) {
 }
 
 truthy <- function(value, default = FALSE) {
-  if (!is.atomic(value) || length(value) != 1 || is.na(value))
-    default
-  else if (is.character(value))
-    value %in% c("TRUE", "True", "true", "T", "1")
-  else
-    as.logical(value)
+  if (!is.atomic(value) || length(value) != 1 || is.na(value)) default else if (
+    is.character(value)
+  )
+    value %in% c("TRUE", "True", "true", "T", "1") else as.logical(value)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -170,8 +170,11 @@ toJSON <- function(x, ...) {
 }
 
 truthy <- function(value, default = FALSE) {
-  if (!is.atomic(value) || length(value) != 1 || is.na(value)) default else if (
-    is.character(value)
-  )
-    value %in% c("TRUE", "True", "true", "T", "1") else as.logical(value)
+  if (!is.atomic(value) || length(value) != 1 || is.na(value)) {
+    default
+  } else if (is.character(value)) {
+    value %in% c("TRUE", "True", "true", "T", "1")
+  } else {
+    as.logical(value)
+  }
 }

--- a/R/writeManifest.R
+++ b/R/writeManifest.R
@@ -16,21 +16,23 @@
 #' @param verbose If `TRUE`, prints detailed progress messages.
 #' @param quiet If `FALSE`, prints progress messages.
 #' @export
-writeManifest <- function(appDir = getwd(),
-                          appFiles = NULL,
-                          appFileManifest = NULL,
-                          appPrimaryDoc = NULL,
-                          appMode = NULL,
-                          contentCategory = NULL,
-                          python = NULL,
-                          forceGeneratePythonEnvironment = FALSE,
-                          quarto = NA,
-                          image = NULL,
-                          envManagement = NULL,
-                          envManagementR = NULL,
-                          envManagementPy = NULL,
-                          verbose = FALSE,
-                          quiet = FALSE) {
+writeManifest <- function(
+  appDir = getwd(),
+  appFiles = NULL,
+  appFileManifest = NULL,
+  appPrimaryDoc = NULL,
+  appMode = NULL,
+  contentCategory = NULL,
+  python = NULL,
+  forceGeneratePythonEnvironment = FALSE,
+  quarto = NA,
+  image = NULL,
+  envManagement = NULL,
+  envManagementR = NULL,
+  envManagementPy = NULL,
+  verbose = FALSE,
+  quiet = FALSE
+) {
   appFiles <- listDeploymentFiles(
     appDir,
     appFiles = appFiles,

--- a/tests/testthat/_snaps/linters.md
+++ b/tests/testthat/_snaps/linters.md
@@ -13,10 +13,10 @@
       server.R
       --------
       The following lines contain absolute paths:
-      15:     otherFile <- read.table("~/.rsconnect-tests/local-file.txt")
+      12:     otherFile <- read.table("~/.rsconnect-tests/local-file.txt")
       
       The following lines contain paths to files not matching in case sensitivity:
-      31:     file <- read.csv("data/college.txt") ## bad    ['data/college.txt' -> 'data/College.txt']
+      28:     file <- read.csv("data/college.txt") ## bad    ['data/college.txt' -> 'data/College.txt']
       
       Paths should be to files within the project directory.
       Filepaths are case-sensitive on deployment server.

--- a/tests/testthat/helper-http.R
+++ b/tests/testthat/helper-http.R
@@ -40,7 +40,9 @@ service_settings_404 <- function() {
       json_app <- webfakes::new_app()
       json_app$use(webfakes::mw_json())
       json_app$get("/__api__/server_settings", function(req, res) {
-        res$set_status(404L)$send_json(list(error = jsonlite::unbox("not found")))
+        res$set_status(404L)$send_json(list(
+          error = jsonlite::unbox("not found")
+        ))
       })
       app <- webfakes::new_app_process(json_app)
     }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -7,17 +7,19 @@ showDcf <- function(df) {
 httpLastRequest <- list()
 
 # HTTP function which just saves the result for analysis
-httpTestRecorder <- function(protocol,
-                             host,
-                             port,
-                             method,
-                             path,
-                             headers,
-                             contentType = NULL,
-                             file = NULL,
-                             certificate = NULL,
-                             writer = NULL,
-                             timeout = NULL) {
+httpTestRecorder <- function(
+  protocol,
+  host,
+  port,
+  method,
+  path,
+  headers,
+  contentType = NULL,
+  file = NULL,
+  certificate = NULL,
+  writer = NULL,
+  timeout = NULL
+) {
   httpLastRequest <<- list(
     protocol = protocol,
     host = host,
@@ -89,12 +91,20 @@ local_shiny_bundle <- function(appName, appDir, appPrimaryDoc, python = NULL) {
 
 # Servers and accounts ----------------------------------------------------
 
-addTestAccount <- function(account = "ron", server = "example.com", userId = account) {
+addTestAccount <- function(
+  account = "ron",
+  server = "example.com",
+  userId = account
+) {
   registerAccount(server, account, userId, apiKey = "123")
   invisible()
 }
 
-addTestServer <- function(name = NULL, url = "https://example.com", certificate = NULL) {
+addTestServer <- function(
+  name = NULL,
+  url = "https://example.com",
+  certificate = NULL
+) {
   if (is.null(name)) {
     serverUrl <- parseHttpUrl(url)
     name <- serverUrl$host
@@ -107,18 +117,20 @@ addTestServer <- function(name = NULL, url = "https://example.com", certificate 
   )
   invisible()
 }
-addTestDeployment <- function(path,
-                              appName = "test",
-                              appTitle = "",
-                              appId = "123",
-                              account = "ron",
-                              envVars = NULL,
-                              username = account,
-                              server = "example.com",
-                              url = paste0("https://", server, "/", username, "/", appId),
-                              hostUrl = NULL,
-                              version = deploymentRecordVersion,
-                              metadata = list()) {
+addTestDeployment <- function(
+  path,
+  appName = "test",
+  appTitle = "",
+  appId = "123",
+  account = "ron",
+  envVars = NULL,
+  username = account,
+  server = "example.com",
+  url = paste0("https://", server, "/", username, "/", appId),
+  hostUrl = NULL,
+  version = deploymentRecordVersion,
+  metadata = list()
+) {
   saveDeployment(
     path,
     createDeployment(

--- a/tests/testthat/multibyte-characters/app.R
+++ b/tests/testthat/multibyte-characters/app.R
@@ -1,15 +1,16 @@
-
 # 定义用户界面
 fluidPage(
-
   # 标题
   titlePanel("麻麻再也不用担心我的Shiny应用不能显示中文了"),
 
   # 侧边栏布局
   sidebarLayout(
     sidebarPanel(
-      selectInput("dataset", "请选一个数据：",
-                  choices = c("岩石", "pressure", "cars")),
+      selectInput(
+        "dataset",
+        "请选一个数据：",
+        choices = c("岩石", "pressure", "cars")
+      ),
 
       uiOutput("rockvars"),
 

--- a/tests/testthat/shinyapp-appR/app.R
+++ b/tests/testthat/shinyapp-appR/app.R
@@ -6,7 +6,15 @@ server <- function(input, output) {
 ui <- fluidPage(
   sidebarLayout(
     sidebarPanel(
-      sliderInput("obs", "Number of observations:", min = 10, max = 500,
-                  value = 100)),
-    mainPanel(plotOutput("distPlot"))))
+      sliderInput(
+        "obs",
+        "Number of observations:",
+        min = 10,
+        max = 500,
+        value = 100
+      )
+    ),
+    mainPanel(plotOutput("distPlot"))
+  )
+)
 shinyApp(ui = ui, server = server)

--- a/tests/testthat/shinyapp-simple/server.R
+++ b/tests/testthat/shinyapp-simple/server.R
@@ -4,5 +4,7 @@ shinyServer(function(input, output) {
     dist <- rnorm(input$obs)
     hist(dist)
   })
-  output$obs <- renderText({paste(input$obs, "\n", input$obs)})
+  output$obs <- renderText({
+    paste(input$obs, "\n", input$obs)
+  })
 })

--- a/tests/testthat/shinyapp-simple/ui.R
+++ b/tests/testthat/shinyapp-simple/ui.R
@@ -2,10 +2,15 @@ library(shiny)
 shinyUI(pageWithSidebar(
   headerPanel("Hello, Shiny!"),
   sidebarPanel(
-    sliderInput("obs", "Number of observations:",
-                min = 1,
-                max = 1000,
-                value = 500)),
+    sliderInput(
+      "obs",
+      "Number of observations:",
+      min = 1,
+      max = 1000,
+      value = 500
+    )
+  ),
   mainPanel(
-    plotOutput("distPlot")))
-)
+    plotOutput("distPlot")
+  )
+))

--- a/tests/testthat/shinyapp-singleR/single.R
+++ b/tests/testthat/shinyapp-singleR/single.R
@@ -6,7 +6,15 @@ server <- function(input, output) {
 ui <- fluidPage(
   sidebarLayout(
     sidebarPanel(
-      sliderInput("obs", "Number of observations:", min = 10, max = 500,
-                  value = 100)),
-    mainPanel(plotOutput("distPlot"))))
+      sliderInput(
+        "obs",
+        "Number of observations:",
+        min = 10,
+        max = 500,
+        value = 100
+      )
+    ),
+    mainPanel(plotOutput("distPlot"))
+  )
+)
 shinyApp(ui = ui, server = server)

--- a/tests/testthat/shinyapp-with-absolute-paths/server.R
+++ b/tests/testthat/shinyapp-with-absolute-paths/server.R
@@ -1,4 +1,3 @@
-
 # This is the server logic for a Shiny web application.
 # You can find out more about building applications with Shiny here:
 #
@@ -8,9 +7,7 @@
 library(shiny)
 
 shinyServer(function(input, output) {
-
   output$distPlot <- renderPlot({
-
     # read a file on disk
     otherFile <- read.table("~/.rsconnect-tests/local-file.txt")
     anotherFile <- readLines("../../foo.bar")
@@ -18,7 +15,7 @@ shinyServer(function(input, output) {
     validWeblink <- "//www.google.com/"
 
     # generate bins based on input$bins from ui.R
-    x    <- faithful[, 2]
+    x <- faithful[, 2]
     bins <- seq(min(x), max(x), length.out = input$bins + 1)
 
     # don't warn on this line
@@ -33,7 +30,5 @@ shinyServer(function(input, output) {
 
     ## don't warn about absolute paths that could be URL query paths
     file <- paste("/applcations")
-
   })
-
 })

--- a/tests/testthat/shinyapp-with-absolute-paths/ui.R
+++ b/tests/testthat/shinyapp-with-absolute-paths/ui.R
@@ -1,4 +1,3 @@
-
 # This is the user-interface definition of a Shiny web application.
 # You can find out more about building applications with Shiny here:
 #
@@ -8,7 +7,6 @@
 library(shiny)
 
 shinyUI(fluidPage(
-
   # Application title
   titlePanel("Old Faithful Geyser Data"),
 
@@ -18,11 +16,7 @@ shinyUI(fluidPage(
   # Sidebar with a slider input for number of bins
   sidebarLayout(
     sidebarPanel(
-      sliderInput("bins",
-                  "Number of bins:",
-                  min = 1,
-                  max = 50,
-                  value = 30)
+      sliderInput("bins", "Number of bins:", min = 1, max = 50, value = 30)
     ),
 
     # Show a plot of the generated distribution

--- a/tests/testthat/shinyapp-with-browser/server.R
+++ b/tests/testthat/shinyapp-with-browser/server.R
@@ -8,5 +8,7 @@ shinyServer(function(input, output) {
     # stop to examine state
     browser()
   })
-  output$obs <- renderText({paste(input$obs, "\n", input$obs)})
+  output$obs <- renderText({
+    paste(input$obs, "\n", input$obs)
+  })
 })

--- a/tests/testthat/shinyapp-with-browser/ui.R
+++ b/tests/testthat/shinyapp-with-browser/ui.R
@@ -2,10 +2,15 @@ library(shiny)
 shinyUI(pageWithSidebar(
   headerPanel("Hello, Shiny!"),
   sidebarPanel(
-    sliderInput("obs", "Number of observations:",
-                min = 1,
-                max = 1000,
-                value = 500)),
+    sliderInput(
+      "obs",
+      "Number of observations:",
+      min = 1,
+      max = 1000,
+      value = 500
+    )
+  ),
   mainPanel(
-    plotOutput("distPlot")))
-)
+    plotOutput("distPlot")
+  )
+))

--- a/tests/testthat/test-appDependencies.R
+++ b/tests/testthat/test-appDependencies.R
@@ -50,13 +50,16 @@ test_that("appDependencies includes implicit deps when appMode forced", {
   expect_true("rmarkdown" %in% deps$Package)
 
   deps <- appDependencies(dir, appMode = "static")
-  expect_equal(deps, data.frame(
-    Package = character(),
-    Version = character(),
-    Source = character(),
-    Repository = character(),
-    stringsAsFactors = FALSE
-  ))
+  expect_equal(
+    deps,
+    data.frame(
+      Package = character(),
+      Version = character(),
+      Source = character(),
+      Repository = character(),
+      stringsAsFactors = FALSE
+    )
+  )
 })
 
 test_that("static project doesn't have deps", {
@@ -65,21 +68,26 @@ test_that("static project doesn't have deps", {
   path <- local_temp_app(list("index.html" = ""))
   deps <- appDependencies(path)
 
-  expect_equal(deps, data.frame(
-    Package = character(),
-    Version = character(),
-    Source = character(),
-    Repository = character(),
-    stringsAsFactors = FALSE
-  ))
+  expect_equal(
+    deps,
+    data.frame(
+      Package = character(),
+      Version = character(),
+      Source = character(),
+      Repository = character(),
+      stringsAsFactors = FALSE
+    )
+  )
 })
 
 test_that("infers correct packages for each source", {
   skip_on_cran()
 
-  simulateMetadata <- function(appMode,
-                               hasParameters = FALSE,
-                               documentsHavePython = FALSE) {
+  simulateMetadata <- function(
+    appMode,
+    hasParameters = FALSE,
+    documentsHavePython = FALSE
+  ) {
     list(
       appMode = appMode,
       hasParameters = hasParameters,
@@ -90,12 +98,18 @@ test_that("infers correct packages for each source", {
   # Simple regression test in preparation for refactoring
   expect_snapshot({
     inferRPackageDependencies(simulateMetadata("rmd-static"))
-    inferRPackageDependencies(simulateMetadata("rmd-static", hasParameters = TRUE))
+    inferRPackageDependencies(simulateMetadata(
+      "rmd-static",
+      hasParameters = TRUE
+    ))
     inferRPackageDependencies(simulateMetadata("quarto-static"))
     inferRPackageDependencies(simulateMetadata("quarto-shiny"))
     inferRPackageDependencies(simulateMetadata("rmd-shiny"))
     inferRPackageDependencies(simulateMetadata("shiny"))
     inferRPackageDependencies(simulateMetadata("api"))
-    inferRPackageDependencies(simulateMetadata("api", documentsHavePython = TRUE))
+    inferRPackageDependencies(simulateMetadata(
+      "api",
+      documentsHavePython = TRUE
+    ))
   })
 })

--- a/tests/testthat/test-appMetadata-quarto.R
+++ b/tests/testthat/test-appMetadata-quarto.R
@@ -1,4 +1,3 @@
-
 # quarto ------------------------------------------------------------------
 
 fakeQuartoMetadata <- function(version, engines) {
@@ -31,17 +30,23 @@ test_that("inferQuartoInfo correctly detects info when quarto is provided alone"
 })
 
 test_that("inferQuartoInfo prefers metadata over quarto inspect", {
-  metadata <- fakeQuartoMetadata(version = "99.9.9", engines = c("internal-combustion"))
+  metadata <- fakeQuartoMetadata(
+    version = "99.9.9",
+    engines = c("internal-combustion")
+  )
 
   quartoInfo <- inferQuartoInfo(
     appDir = test_path("quarto-website-r"),
     appPrimaryDoc = NULL,
     metadata = metadata
   )
-  expect_equal(quartoInfo, list(
-    version = "99.9.9",
-    engines = I("internal-combustion")
-  ))
+  expect_equal(
+    quartoInfo,
+    list(
+      version = "99.9.9",
+      engines = I("internal-combustion")
+    )
+  )
 })
 
 test_that("quartoInspect requires quarto", {
@@ -80,12 +85,15 @@ test_that("quartoInspect processes content within paths containing spaces", {
   parent <- withr::local_tempdir()
   dir <- file.path(parent, "space dir")
   dir.create(dir)
-  writeLines(c(
-    "---",
-    "title: space path",
-    "---",
-    "this is a document within a path having spaces."
-  ), file.path(dir, "index.qmd"))
+  writeLines(
+    c(
+      "---",
+      "title: space path",
+      "---",
+      "this is a document within a path having spaces."
+    ),
+    file.path(dir, "index.qmd")
+  )
   inspect <- quartoInspect(dir, "index.qmd")
   expect_equal(inspect$engines, c("markdown"))
 })
@@ -94,12 +102,14 @@ test_that("quartoInspect processes content with filenames containing spaces", {
   skip_on_cran()
   skip_if_no_quarto()
 
-  dir <- local_temp_app(list("space file.qmd" = c(
-    "---",
-    "title: space name",
-    "---",
-    "this is a document with a filename having spaces."
-  )))
+  dir <- local_temp_app(list(
+    "space file.qmd" = c(
+      "---",
+      "title: space name",
+      "---",
+      "this is a document with a filename having spaces."
+    )
+  ))
   inspect <- quartoInspect(dir, "space file.qmd")
   expect_equal(inspect$engines, c("markdown"))
 })
@@ -123,12 +133,14 @@ test_that("quartoInspect produces an error when a document cannot be inspected",
   # Suppress colors from Quarto errors.
   withr::local_envvar(NO_COLOR = "1")
 
-  dir <- local_temp_app(list("bad.qmd" = c(
-    "---",
-    "format: unsupported",
-    "---",
-    "this is a document using an unsupported format."
-  )))
+  dir <- local_temp_app(list(
+    "bad.qmd" = c(
+      "---",
+      "format: unsupported",
+      "---",
+      "this is a document using an unsupported format."
+    )
+  ))
   expect_snapshot(
     quartoInspect(dir, "bad.qmd"),
     error = TRUE,

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -8,7 +8,11 @@ test_that("quarto affects mode inference", {
   metadata <- appMetadata(dir, c("foo.Rmd"))
   expect_equal(metadata$appMode, "rmd-static")
 
-  metadata <- appMetadata(dir, c("foo.Rmd"), metadata = list(quarto_version = 1))
+  metadata <- appMetadata(
+    dir,
+    c("foo.Rmd"),
+    metadata = list(quarto_version = 1)
+  )
   expect_equal(metadata$appMode, "quarto-static")
 })
 
@@ -67,8 +71,8 @@ test_that("Shiny Quarto without an appropriate engine is an error", {
   skip_on_cran()
 
   dir <- local_temp_app(list(
-    "index.qmd" = c("---", "server: shiny", "---"))
-  )
+    "index.qmd" = c("---", "server: shiny", "---")
+  ))
   files <- list.files(dir)
   expect_snapshot(appMetadata(dir, files), error = TRUE)
 })
@@ -77,8 +81,8 @@ test_that("Shiny Quarto with the knitr engine is OK", {
   skip_on_cran()
 
   dir <- local_temp_app(list(
-    "index.qmd" = c("---", "server: shiny", "engine: knitr", "---"))
-  )
+    "index.qmd" = c("---", "server: shiny", "engine: knitr", "---")
+  ))
   files <- list.files(dir)
   metadata <- appMetadata(dir, files)
   expect_contains(metadata$quartoInfo$engines, "knitr")
@@ -88,8 +92,8 @@ test_that("Shiny Quarto with the jupyter engine is OK", {
   skip_on_cran()
 
   dir <- local_temp_app(list(
-    "index.qmd" = c("---", "server: shiny", "engine: jupyter", "---"))
-  )
+    "index.qmd" = c("---", "server: shiny", "engine: jupyter", "---")
+  ))
   files <- list.files(dir)
   metadata <- appMetadata(dir, files)
   expect_contains(metadata$quartoInfo$engines, "jupyter")
@@ -189,12 +193,18 @@ test_that("can infer mode for shiny rmd docs", {
   expect_equal(inferAppMode(dir, paths), "rmd-shiny")
 
   # can pair server.R with shiny runtime
-  dir <- local_temp_app(list("index.Rmd" = yaml_runtime("shiny"), "server.R" = ""))
+  dir <- local_temp_app(list(
+    "index.Rmd" = yaml_runtime("shiny"),
+    "server.R" = ""
+  ))
   paths <- list.files(dir)
   expect_equal(inferAppMode(dir, paths), "rmd-shiny")
 
   # Beats static rmarkdowns
-  dir <- local_temp_app(list("index.Rmd" = yaml_runtime("shiny"), "foo.Rmd" = ""))
+  dir <- local_temp_app(list(
+    "index.Rmd" = yaml_runtime("shiny"),
+    "foo.Rmd" = ""
+  ))
   paths <- list.files(dir)
   expect_equal(inferAppMode(dir, paths), "rmd-shiny")
 })
@@ -205,7 +215,8 @@ test_that("can infer mode for shiny qmd docs", {
       "---",
       paste0("runtime: ", runtime),
       paste0("engine: knitr"),
-      "---")
+      "---"
+    )
   }
 
   dir <- local_temp_app(list("index.Qmd" = yaml_runtime("shiny")))
@@ -270,11 +281,26 @@ test_that("otherwise fails back to first file with matching extensions", {
 })
 
 test_that("can use R, Rmd, and qmd files for Quarto modes", {
-  expect_equal(inferAppPrimaryDoc(NULL, c(".Rprofile", "foo.R"), "quarto-static"), "foo.R")
-  expect_equal(inferAppPrimaryDoc(NULL, c(".Rprofile", "foo.Rmd"), "quarto-static"), "foo.Rmd")
-  expect_equal(inferAppPrimaryDoc(NULL, c(".Rprofile", "foo.qmd"), "quarto-static"), "foo.qmd")
-  expect_equal(inferAppPrimaryDoc(NULL, c(".Rprofile", "foo.Rmd"), "quarto-shiny"), "foo.Rmd")
-  expect_equal(inferAppPrimaryDoc(NULL, c(".Rprofile", "foo.qmd"), "quarto-shiny"), "foo.qmd")
+  expect_equal(
+    inferAppPrimaryDoc(NULL, c(".Rprofile", "foo.R"), "quarto-static"),
+    "foo.R"
+  )
+  expect_equal(
+    inferAppPrimaryDoc(NULL, c(".Rprofile", "foo.Rmd"), "quarto-static"),
+    "foo.Rmd"
+  )
+  expect_equal(
+    inferAppPrimaryDoc(NULL, c(".Rprofile", "foo.qmd"), "quarto-static"),
+    "foo.qmd"
+  )
+  expect_equal(
+    inferAppPrimaryDoc(NULL, c(".Rprofile", "foo.Rmd"), "quarto-shiny"),
+    "foo.Rmd"
+  )
+  expect_equal(
+    inferAppPrimaryDoc(NULL, c(".Rprofile", "foo.qmd"), "quarto-shiny"),
+    "foo.qmd"
+  )
 })
 
 test_that("errors if no files with needed extension", {

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -91,7 +91,10 @@ test_that("Rmd with reticulate as a dependency includes python in the manifest",
   expect_equal(manifest$metadata$appmode, "rmd-static")
   expect_equal(manifest$metadata$primary_rmd, "index.Rmd")
   expect_true("reticulate" %in% names(manifest$packages))
-  expect_true(file.exists(file.path(bundleTempDir, manifest$python$package_manager$package_file)))
+  expect_true(file.exists(file.path(
+    bundleTempDir,
+    manifest$python$package_manager$package_file
+  )))
 })
 
 test_that("Rmd with reticulate as an inferred dependency includes reticulate and python in the manifest", {
@@ -110,7 +113,10 @@ test_that("Rmd with reticulate as an inferred dependency includes reticulate and
   expect_equal(manifest$metadata$appmode, "rmd-static")
   expect_equal(manifest$metadata$primary_rmd, "implicit.Rmd")
   expect_true("reticulate" %in% names(manifest$packages))
-  expect_true(file.exists(file.path(bundleTempDir, manifest$python$package_manager$package_file)))
+  expect_true(file.exists(file.path(
+    bundleTempDir,
+    manifest$python$package_manager$package_file
+  )))
 })
 
 test_that("Rmd without a python block doesn't include reticulate or python in the manifest", {
@@ -192,13 +198,15 @@ test_that(".Rprofile without renv/packrt left as is", {
 })
 
 test_that("removes renv/packrat activation", {
-  path <- withr::local_tempfile(lines = c(
-    "# Line 1",
-    'source("renv/activate.R")',
-    "# Line 3",
-    'source("packrat/init.R")',
-    "# Line 5"
-  ))
+  path <- withr::local_tempfile(
+    lines = c(
+      "# Line 1",
+      'source("renv/activate.R")',
+      "# Line 3",
+      'source("packrat/init.R")',
+      "# Line 5"
+    )
+  )
 
   expect_snapshot(
     {

--- a/tests/testthat/test-bundleFiles.R
+++ b/tests/testthat/test-bundleFiles.R
@@ -1,4 +1,3 @@
-
 # listDeploymentFiles ------------------------------------------------------
 
 test_that("can read all files from directory", {
@@ -35,7 +34,10 @@ test_that("can read selected files from manifest", {
     "manifest" = c("b.R", "c.R")
   ))
   expect_snapshot(
-    out <- listDeploymentFiles(dir, appFileManifest = file.path(dir, "manifest")),
+    out <- listDeploymentFiles(
+      dir,
+      appFileManifest = file.path(dir, "manifest")
+    ),
   )
   expect_equal(out, "b.R")
 
@@ -138,7 +140,9 @@ test_that("ignores Python virtual envs (non-Windows)", {
 
   names <- c(
     # well-known names ...
-    ".env", ".venv", "venv",
+    ".env",
+    ".venv",
+    "venv",
 
     # other names ...
     "test"
@@ -155,7 +159,9 @@ test_that("ignores Python virtual envs (Windows)", {
 
   names <- c(
     # well-known names ...
-    ".env", ".venv", "venv",
+    ".env",
+    ".venv",
+    "venv",
 
     # other names ...
     "test"
@@ -172,7 +178,9 @@ test_that("ignores Python virtual envs (Windows-GUI)", {
 
   names <- c(
     # well-known names ...
-    ".env", ".venv", "venv",
+    ".env",
+    ".venv",
+    "venv",
 
     # other names ...
     "test"
@@ -189,7 +197,9 @@ test_that("ignores Python virtual envs (Windows-debug)", {
 
   names <- c(
     # well-known names ...
-    ".env", ".venv", "venv",
+    ".env",
+    ".venv",
+    "venv",
 
     # other names ...
     "test"

--- a/tests/testthat/test-bundlePackage.R
+++ b/tests/testthat/test-bundlePackage.R
@@ -105,11 +105,14 @@ test_that("error if can't find source", {
   })
 
   app_dir <- withr::local_tempdir()
-  writeLines(con = file.path(app_dir, "index.Rmd"), c(
-    "```{r}",
-    "library(shiny)",
-    "```"
-  ))
+  writeLines(
+    con = file.path(app_dir, "index.Rmd"),
+    c(
+      "```{r}",
+      "library(shiny)",
+      "```"
+    )
+  )
 
   expect_snapshot(
     . <- bundlePackages(app_dir),
@@ -150,12 +153,18 @@ test_that("usePackrat prefers the environment variable over the option", {
 })
 
 test_that("package_record works", {
-  latin1Record <- package_record("latin1package", lib_dir = test_path("packages"))
+  latin1Record <- package_record(
+    "latin1package",
+    lib_dir = test_path("packages")
+  )
   expect_equal(latin1Record$Author, "Jens Fröhling")
 
   utf8Record <- package_record("utf8package", lib_dir = test_path("packages"))
   expect_equal(utf8Record$Author, "Jens Fröhling")
 
-  windows1251Record <- package_record("windows1251package", lib_dir = test_path("packages"))
+  windows1251Record <- package_record(
+    "windows1251package",
+    lib_dir = test_path("packages")
+  )
   expect_equal(windows1251Record$Author, "Сергей Брин")
 })

--- a/tests/testthat/test-bundlePackagePackrat.R
+++ b/tests/testthat/test-bundlePackagePackrat.R
@@ -13,12 +13,14 @@ test_that("manifest has correct data types", {
 })
 
 test_that("uninstalled packages error", {
-  app <- local_temp_app(list("index.Rmd" = c(
-    "```{r}",
-    "library(doesntexist1)",
-    "library(doesntexist2)",
-    "```"
-  )))
+  app <- local_temp_app(list(
+    "index.Rmd" = c(
+      "```{r}",
+      "library(doesntexist1)",
+      "library(doesntexist2)",
+      "```"
+    )
+  ))
   expect_snapshot(
     snapshotPackratDependencies(app),
     error = TRUE,
@@ -28,11 +30,13 @@ test_that("uninstalled packages error", {
 
 test_that("recommended packages are snapshotted", {
   skip_if_not_installed("MASS")
-  app <- local_temp_app(list("index.Rmd" = c(
-    "```{r}",
-    "library(MASS)",
-    "```"
-  )))
+  app <- local_temp_app(list(
+    "index.Rmd" = c(
+      "```{r}",
+      "library(MASS)",
+      "```"
+    )
+  ))
   deps <- snapshotPackratDependencies(app)
   expect_true("MASS" %in% deps$Package)
 })
@@ -40,25 +44,35 @@ test_that("recommended packages are snapshotted", {
 test_that("works with BioC packages", {
   skip_on_cran()
   skip_on_ci()
-  app <- local_temp_app(list("index.Rmd" = c(
-    "```{r}",
-    "library(Biobase)",
-    "```"
-  )))
-  withr::local_options(repos = c(
-    CRAN = "https://cran.rstudio.com",
-    BioC = "https://bioconductor.org/packages/release/bioc"
+  app <- local_temp_app(list(
+    "index.Rmd" = c(
+      "```{r}",
+      "library(Biobase)",
+      "```"
+    )
   ))
+  withr::local_options(
+    repos = c(
+      CRAN = "https://cran.rstudio.com",
+      BioC = "https://bioconductor.org/packages/release/bioc"
+    )
+  )
 
   deps <- snapshotPackratDependencies(app)
 
   Biobase <- deps[deps$Package == "Biobase", ]
   expect_equal(Biobase$Source, "Bioconductor")
-  expect_equal(Biobase$Repository, "https://bioconductor.org/packages/release/bioc")
+  expect_equal(
+    Biobase$Repository,
+    "https://bioconductor.org/packages/release/bioc"
+  )
 
   BiocGenerics <- deps[deps$Package == "BiocGenerics", ]
   expect_equal(BiocGenerics$Source, "Bioconductor")
-  expect_equal(BiocGenerics$Repository, "https://bioconductor.org/packages/release/bioc")
+  expect_equal(
+    BiocGenerics$Repository,
+    "https://bioconductor.org/packages/release/bioc"
+  )
 })
 
 # addPackratSnapshot() ----------------------------------------------------

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -21,11 +21,13 @@ test_that("recommended packages are snapshotted", {
   skip_if_not_installed("MASS")
 
   withr::local_options(renv.verbose = TRUE)
-  app <- local_temp_app(list("index.Rmd" = c(
-    "```{r}",
-    "library(MASS)",
-    "```"
-  )))
+  app <- local_temp_app(list(
+    "index.Rmd" = c(
+      "```{r}",
+      "library(MASS)",
+      "```"
+    )
+  ))
   deps <- snapshotRenvDependencies(app)
   expect_true("MASS" %in% deps$Package)
 })
@@ -44,22 +46,28 @@ test_that("works with BioC packages", {
   skip_on_cran()
   skip_on_ci()
 
-  app <- local_temp_app(list("index.R" = c(
-    "library(Biobase)"
-  )))
+  app <- local_temp_app(list(
+    "index.R" = c(
+      "library(Biobase)"
+    )
+  ))
   biocRepos <- BiocManager::repositories()
   withr::local_options(repos = biocRepos)
   expect_no_condition(
-    { deps <- snapshotRenvDependencies(app) },
+    {
+      deps <- snapshotRenvDependencies(app)
+    },
     class = "rsconnect_biocRepos"
   )
   Biobase <- deps[deps$Package == "Biobase", ]
   expect_equal(Biobase$Source, "Bioconductor")
   expect_equal(Biobase$Repository, biocRepos[["BioCsoft"]])
 
-  withr::local_options(repos = c(
-    CRAN = "https://cran.rstudio.com"
-  ))
+  withr::local_options(
+    repos = c(
+      CRAN = "https://cran.rstudio.com"
+    )
+  )
   expect_condition(
     deps <- snapshotRenvDependencies(app),
     class = "rsconnect_biocRepos"
@@ -181,7 +189,11 @@ test_that("has special handling for CRAN packages", {
 })
 
 test_that("packages installed from other repos get correctly named", {
-  pkg <- list(Package = "pkg", Source = "Repository", Repository = "https://test2.com")
+  pkg <- list(
+    Package = "pkg",
+    Source = "Repository",
+    Repository = "https://test2.com"
+  )
   packages <- as.matrix(data.frame(
     Package = "pkg",
     Version = "1.0.0",

--- a/tests/testthat/test-bundlePython.R
+++ b/tests/testthat/test-bundlePython.R
@@ -41,7 +41,10 @@ test_that("can infer env from existing directory", {
 
   env <- inferPythonEnv(test_path("test-reticulate-rmds"), pythonPathOrSkip())
   expect_named(env, c("version", "package_manager"))
-  expect_named(env$package_manager, c("name", "version", "package_file", "contents"))
+  expect_named(
+    env$package_manager,
+    c("name", "version", "package_file", "contents")
+  )
 })
 
 

--- a/tests/testthat/test-cert.R
+++ b/tests/testthat/test-cert.R
@@ -5,7 +5,9 @@ test_that("system and server cert stores are concatenated", {
   withr::local_options(rsconnect.ca.bundle = test_path("certs/store.crt"))
 
   # create and then read the temporary certificate file
-  concatenated <- createCertificateFile(readLines(test_path("certs/localhost.crt")))
+  concatenated <- createCertificateFile(readLines(test_path(
+    "certs/localhost.crt"
+  )))
   withr::defer(unlink(concatenated))
   store <- paste(readLines(concatenated), collapse = "\n")
 
@@ -31,10 +33,10 @@ test_that("certificates not used when making plain http connections", {
 
   GET(
     list(
-      protocol  = "http",
-      host      = "localhost:4567",
-      port      = "80",
-      path      = "apps"
+      protocol = "http",
+      host = "localhost:4567",
+      port = "80",
+      path = "apps"
     ),
     authInfo = list(certificate = test_path("certs/localhost.crt")),
     "apps"
@@ -48,10 +50,10 @@ test_that("certificates used when making https connections", {
 
   GET(
     list(
-      protocol  = "https",
-      host      = "localhost:4567",
-      port      = "443",
-      path      = "apps"
+      protocol = "https",
+      host = "localhost:4567",
+      port = "443",
+      path = "apps"
     ),
     authInfo = list(certificate = test_path("certs/localhost.crt")),
     "apps"

--- a/tests/testthat/test-client-cloud.R
+++ b/tests/testthat/test-client-cloud.R
@@ -38,17 +38,18 @@ mockServerFactory <- function(initialResponses) {
     mockServer$responses <- append(mockServer$responses, response)
   }
 
-  mockServer$impl <- function(protocol,
-                          host,
-                          port,
-                          method,
-                          path,
-                          headers,
-                          contentType = NULL,
-                          contentFile = NULL,
-                          certificate = NULL,
-                          timeout = NULL) {
-
+  mockServer$impl <- function(
+    protocol,
+    host,
+    port,
+    method,
+    path,
+    headers,
+    contentType = NULL,
+    contentFile = NULL,
+    certificate = NULL,
+    timeout = NULL
+  ) {
     methodAndPath <- paste(method, path)
 
     request <- list(
@@ -76,19 +77,25 @@ mockServerFactory <- function(initialResponses) {
 
         for (respProperty in names(responseSupplement)) {
           if (is.function(responseSupplement[[respProperty]])) {
-            responseSupplement[[respProperty]] <- responseSupplement[[respProperty]](
+            responseSupplement[[respProperty]] <- responseSupplement[[
+              respProperty
+            ]](
               methodAndPath,
               match,
               headers = headers,
               contentType = contentType,
-              contentFile = contentFile)
+              contentFile = contentFile
+            )
           }
 
           response[[respProperty]] <- responseSupplement[[respProperty]]
         }
 
         if (is.list(response$content)) {
-          response$content <- jsonlite::toJSON(response$content, auto_unbox = TRUE)
+          response$content <- jsonlite::toJSON(
+            response$content,
+            auto_unbox = TRUE
+          )
         }
 
         break
@@ -113,7 +120,9 @@ configureTestAccount <- function(server = "posit.cloud", name = NULL) {
   existingAccount <- NULL
   tryCatch(
     existingAccount <- accountInfo(name, server),
-    error = function(e) { existingAccount <- NULL }
+    error = function(e) {
+      existingAccount <- NULL
+    }
   )
 
   if (is.null(existingAccount)) {
@@ -161,7 +170,6 @@ test_that("Get application", {
             class = "rsconnect_http_404"
           )
         }
-
 
         list(
           "id" = application_id,
@@ -262,7 +270,10 @@ test_that("Create application", {
   mockServer <- mockServerFactory(list(
     "^POST /outputs" = list(
       content = function(methodAndPath, match, contentFile, ...) {
-        content <- jsonlite::fromJSON(readChar(contentFile, file.info(contentFile)$size))
+        content <- jsonlite::fromJSON(readChar(
+          contentFile,
+          file.info(contentFile)$size
+        ))
         expect_equal(content$application_type, "connect")
         list(
           "id" = 1,
@@ -281,7 +292,8 @@ test_that("Create application", {
           "id" = application_id,
           "content_id" = 1
         )
-      })
+      }
+    )
   ))
 
   withr::local_options(rsconnect.http = mockServer$impl)
@@ -293,7 +305,13 @@ test_that("Create application", {
   )
   client <- cloudClient(fakeService, NULL)
 
-  app <- client$createApplication("test app", "unused?", "unused?", "unused?", "shiny")
+  app <- client$createApplication(
+    "test app",
+    "unused?",
+    "unused?",
+    "unused?",
+    "shiny"
+  )
 
   expect_equal(app$id, 1)
   expect_equal(app$application_id, 2)
@@ -304,7 +322,10 @@ test_that("Create application with space id", {
   mockServer <- mockServerFactory(list(
     "^POST /outputs" = list(
       content = function(methodAndPath, match, contentFile, ...) {
-        content <- jsonlite::fromJSON(readChar(contentFile, file.info(contentFile)$size))
+        content <- jsonlite::fromJSON(readChar(
+          contentFile,
+          file.info(contentFile)$size
+        ))
         expect_equal(content$application_type, "connect")
         expect_equal(content$space, 333)
         list(
@@ -324,7 +345,8 @@ test_that("Create application with space id", {
           "id" = application_id,
           "content_id" = 1
         )
-      })
+      }
+    )
   ))
 
   withr::local_options(rsconnect.http = mockServer$impl)
@@ -336,7 +358,14 @@ test_that("Create application with space id", {
   )
   client <- cloudClient(fakeService, NULL)
 
-  app <- client$createApplication("test app", "unused?", "unused?", "unused?", "shiny", spaceId = 333)
+  app <- client$createApplication(
+    "test app",
+    "unused?",
+    "unused?",
+    "unused?",
+    "shiny",
+    spaceId = 333
+  )
 
   expect_equal(app$id, 1)
   expect_equal(app$application_id, 2)
@@ -347,7 +376,10 @@ test_that("Create static application", {
   mockServer <- mockServerFactory(list(
     "^POST /outputs" = list(
       content = function(methodAndPath, match, contentFile, ...) {
-        content <- jsonlite::fromJSON(readChar(contentFile, file.info(contentFile)$size))
+        content <- jsonlite::fromJSON(readChar(
+          contentFile,
+          file.info(contentFile)$size
+        ))
         expect_equal(content$application_type, "static")
         expect_equal(content$content_category, "document")
         list(
@@ -367,7 +399,8 @@ test_that("Create static application", {
           "id" = application_id,
           "content_id" = 1
         )
-      })
+      }
+    )
   ))
 
   withr::local_options(rsconnect.http = mockServer$impl)
@@ -379,7 +412,14 @@ test_that("Create static application", {
   )
   client <- cloudClient(fakeService, NULL)
 
-  app <- client$createApplication("test app", "unused?", "unused?", "unused?", "static", "document")
+  app <- client$createApplication(
+    "test app",
+    "unused?",
+    "unused?",
+    "unused?",
+    "static",
+    "document"
+  )
 
   expect_equal(app$id, 1)
   expect_equal(app$application_id, 2)
@@ -390,7 +430,10 @@ test_that("Create static server-side-rendered application", {
   mockServer <- mockServerFactory(list(
     "^POST /outputs" = list(
       content = function(methodAndPath, match, contentFile, ...) {
-        content <- jsonlite::fromJSON(readChar(contentFile, file.info(contentFile)$size))
+        content <- jsonlite::fromJSON(readChar(
+          contentFile,
+          file.info(contentFile)$size
+        ))
         expect_equal(content$application_type, "static")
         expect_equal(content$render_by, "server")
         expect_equal(content$content_category, "document")
@@ -411,7 +454,8 @@ test_that("Create static server-side-rendered application", {
           "id" = application_id,
           "content_id" = 1
         )
-      })
+      }
+    )
   ))
 
   withr::local_options(rsconnect.http = mockServer$impl)
@@ -423,7 +467,14 @@ test_that("Create static server-side-rendered application", {
   )
   client <- cloudClient(fakeService, NULL)
 
-  app <- client$createApplication("test app", "unused?", "unused?", "unused?", "quarto-static", "document")
+  app <- client$createApplication(
+    "test app",
+    "unused?",
+    "unused?",
+    "unused?",
+    "quarto-static",
+    "document"
+  )
 
   expect_equal(app$id, 1)
   expect_equal(app$application_id, 2)
@@ -446,7 +497,10 @@ test_that("deployApplication updates the parent project", {
     ),
     "^PATCH /outputs" = list(
       content = function(methodAndPath, match, contentFile, ...) {
-        content <- jsonlite::fromJSON(readChar(contentFile, file.info(contentFile)$size))
+        content <- jsonlite::fromJSON(readChar(
+          contentFile,
+          file.info(contentFile)$size
+        ))
         if (!is.null(content$project)) {
           expect_equal(content$project, 41)
         } else {
@@ -463,7 +517,10 @@ test_that("deployApplication updates the parent project", {
         application_id <- substr(methodAndPath, match[2], end)
         expect_equal(application_id, "101/")
 
-        content <- jsonlite::fromJSON(readChar(contentFile, file.info(contentFile)$size))
+        content <- jsonlite::fromJSON(readChar(
+          contentFile,
+          file.info(contentFile)$size
+        ))
         expect_equal(content$rebuild, FALSE)
         list(
           "id" = 101
@@ -493,7 +550,10 @@ test_that("Create static RMD application", {
   mockServer <- mockServerFactory(list(
     "^POST /outputs" = list(
       content = function(methodAndPath, match, contentFile, ...) {
-        content <- jsonlite::fromJSON(readChar(contentFile, file.info(contentFile)$size))
+        content <- jsonlite::fromJSON(readChar(
+          contentFile,
+          file.info(contentFile)$size
+        ))
         expect_equal(content$application_type, "static")
         expect_equal(content$render_by, "server")
         expect_equal(content$content_category, "document")
@@ -514,7 +574,8 @@ test_that("Create static RMD application", {
           "id" = application_id,
           "content_id" = 1
         )
-      })
+      }
+    )
   ))
 
   withr::local_options(rsconnect.http = mockServer$impl)
@@ -526,7 +587,14 @@ test_that("Create static RMD application", {
   )
   client <- cloudClient(fakeService, NULL)
 
-  app <- client$createApplication("test app", "unused?", "unused?", "1", "rmd-static", "document")
+  app <- client$createApplication(
+    "test app",
+    "unused?",
+    "unused?",
+    "1",
+    "rmd-static",
+    "document"
+  )
 
   expect_equal(app$id, 1)
   expect_equal(app$application_id, 2)
@@ -537,16 +605,19 @@ test_that("Create application with linked source project", {
   mockServer <- mockServerFactory(list(
     "^POST /outputs" = list(
       content = function(methodAndPAth, match, contentFile, ...) {
-        content <- jsonlite::fromJSON(readChar(contentFile, file.info(contentFile)$size))
+        content <- jsonlite::fromJSON(readChar(
+          contentFile,
+          file.info(contentFile)$size
+        ))
 
         expect_equal(content$project, 41)
         expect_equal(content$space, 99)
 
         list(
-        "id" = 1,
-        "source_id" = 2,
-        "url" = "http://fake-url.test.me/",
-        "state" = "active"
+          "id" = 1,
+          "source_id" = 2,
+          "url" = "http://fake-url.test.me/",
+          "state" = "active"
         )
       }
     ),
@@ -580,7 +651,13 @@ test_that("Create application with linked source project", {
   )
   client <- cloudClient(fakeService, NULL)
 
-  app <- client$createApplication("test app", "unused?", "unused?", "unused?", "static")
+  app <- client$createApplication(
+    "test app",
+    "unused?",
+    "unused?",
+    "unused?",
+    "static"
+  )
 
   expect_equal(app$id, 1)
   expect_equal(app$application_id, 2)
@@ -672,7 +749,10 @@ deployAppMockServerFactory <- function(expectedAppType, outputState) {
         p <- parent.env(e)
         p$actualCalls$outputCreated <- TRUE
 
-        content <- jsonlite::fromJSON(readChar(contentFile, file.info(contentFile)$size))
+        content <- jsonlite::fromJSON(readChar(
+          contentFile,
+          file.info(contentFile)$size
+        ))
 
         expect_equal(content$application_type, expectedAppType)
         expect_equal(content$name, "Desired name here")
@@ -699,7 +779,10 @@ deployAppMockServerFactory <- function(expectedAppType, outputState) {
         p <- parent.env(e)
         p$actualCalls$bundleReady <- TRUE
 
-        content <- jsonlite::fromJSON(readChar(contentFile, file.info(contentFile)$size))
+        content <- jsonlite::fromJSON(readChar(
+          contentFile,
+          file.info(contentFile)$size
+        ))
         expect_equal(content$status, "ready")
 
         list()
@@ -711,7 +794,10 @@ deployAppMockServerFactory <- function(expectedAppType, outputState) {
         p <- parent.env(e)
         p$actualCalls$bundleCreated <- TRUE
 
-        content <- jsonlite::fromJSON(readChar(contentFile, file.info(contentFile)$size))
+        content <- jsonlite::fromJSON(readChar(
+          contentFile,
+          file.info(contentFile)$size
+        ))
 
         list(
           id = 123,
@@ -805,7 +891,10 @@ test_that("deployApp() for shiny results in correct Cloud API calls", {
 
   withr::local_options(renv.verbose = TRUE)
 
-  mock <- deployAppMockServerFactory(expectedAppType = "connect", outputState = "active")
+  mock <- deployAppMockServerFactory(
+    expectedAppType = "connect",
+    outputState = "active"
+  )
   mockServer <- mock$server
 
   withr::local_options(rsconnect.http = mockServer$impl)
@@ -857,7 +946,9 @@ test_that("deployApp() for shiny results in correct Cloud API calls", {
   mock$reset_calls()
   forgetDeployment(appPath = sourcePath, force = TRUE)
 
-  extraLocalAccount <- configureTestAccount(name = "testthat-superfluous-account")
+  extraLocalAccount <- configureTestAccount(
+    name = "testthat-superfluous-account"
+  )
   withr::defer(removeAccount(extraLocalAccount))
 
   deployApp(
@@ -903,7 +994,10 @@ test_that("deployDoc() results in correct Cloud API calls", {
 
   local_temp_config()
 
-  mock <- deployAppMockServerFactory(expectedAppType = "static", outputState = "active")
+  mock <- deployAppMockServerFactory(
+    expectedAppType = "static",
+    outputState = "active"
+  )
   mockServer <- mock$server
 
   withr::local_options(rsconnect.http = mockServer$impl)

--- a/tests/testthat/test-client-connect.R
+++ b/tests/testthat/test-client-connect.R
@@ -53,7 +53,8 @@ test_that("waitForTask", {
         code = 0,
         error = "",
         last = 4
-      ), auto_unbox = TRUE
+      ),
+      auto_unbox = TRUE
     )
   })
   app <- webfakes::new_app_process(task_app)
@@ -92,7 +93,6 @@ findConnect <- function() {
 }
 
 test_that("Users API", {
-
   skip_on_cran()
   skip_on_os("windows")
   skip("connect user test skipped.")
@@ -132,9 +132,11 @@ test_that("Users API", {
   accountId <- response$id
   token <- generateToken()
 
-  tokenResponse <- connect$addToken(list(token = token$token,
-                                         public_key = token$public_key,
-                                         user_id = accountId))
+  tokenResponse <- connect$addToken(list(
+    token = token$token,
+    public_key = token$public_key,
+    user_id = accountId
+  ))
 
   Sys.sleep(1)
 
@@ -146,23 +148,26 @@ test_that("Users API", {
 
   # finally, create a fully authenticated client using the new token, and
   # keep trying to authenticate until we're successful
-  connect <- connectClient(service = server$url, authInfo =
-                             list(token = token$token,
-                                  private_key = token$private_key))
+  connect <- connectClient(
+    service = server$url,
+    authInfo = list(token = token$token, private_key = token$private_key)
+  )
 
   repeat {
-    tryCatch({
-      user <- connect$currentUser()
-      break
-    },
-    error = function(e, ...) {
-      # we expect this to return unauthorized until the token becomes active,
-      # but bubble other errors
-      if (length(grep("401 - Unauthorized", e$message)) == 0) {
-        stop(e)
+    tryCatch(
+      {
+        user <- connect$currentUser()
+        break
+      },
+      error = function(e, ...) {
+        # we expect this to return unauthorized until the token becomes active,
+        # but bubble other errors
+        if (length(grep("401 - Unauthorized", e$message)) == 0) {
+          stop(e)
+        }
+        Sys.sleep(1)
       }
-      Sys.sleep(1)
-    })
+    )
   }
 
   # Create and remove an example application
@@ -205,5 +210,4 @@ test_that("Users API", {
 
   apps <- connect$listApplications(accountId)
   expect_false(response$id %in% sapply(apps, "[[", "id"))
-
 })

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -12,7 +12,12 @@ test_that("account file returned with server name", {
 
 test_that("account file containing pattern characters found with server name", {
   local_temp_config()
-  registerAccount("complex", "hatter+mad@example.com", 42, apiKey = "hatter-api-key")
+  registerAccount(
+    "complex",
+    "hatter+mad@example.com",
+    42,
+    apiKey = "hatter-api-key"
+  )
 
   # https://github.com/rstudio/rsconnect/issues/620
   expected <- normalizePath(file.path(

--- a/tests/testthat/test-cookies.R
+++ b/tests/testthat/test-cookies.R
@@ -1,6 +1,9 @@
 test_that("Parsing cookies works", {
   # Note that the Expires field is ignored
-  cookie <- parseCookie("mycookie=myvalue; Path=/; Expires=Sat, 24 Jun 2017 16:16:05 GMT; Max-Age=3600; HttpOnly", "/")
+  cookie <- parseCookie(
+    "mycookie=myvalue; Path=/; Expires=Sat, 24 Jun 2017 16:16:05 GMT; Max-Age=3600; HttpOnly",
+    "/"
+  )
   expect_equal(cookie$name, "mycookie")
   expect_equal(cookie$value, "myvalue")
   expect_true(cookie$expires > Sys.time() + 3595)
@@ -42,7 +45,9 @@ test_that("Parsing cookies works", {
   expect_true(cookie$secure)
 
   # Full cookie with spaces around =s
-  cookie <- parseCookie("mycookie = myvalue; SEcure; Path = /; Expires = Sat, 24 Jun 2017 16:16:05 GMT; Max-Age = 3600; HttpOnly")
+  cookie <- parseCookie(
+    "mycookie = myvalue; SEcure; Path = /; Expires = Sat, 24 Jun 2017 16:16:05 GMT; Max-Age = 3600; HttpOnly"
+  )
   expect_equal(cookie$name, "mycookie")
   expect_equal(cookie$value, "myvalue")
   expect_true(cookie$secure)
@@ -57,7 +62,9 @@ test_that("Parsing cookies works", {
   expect_equal(cookie$path, "/")
 
   # prove #229 is fixed
-  cookie <- parseCookie("my_cookie-which/uses%20strange?characters=foo_-%20+?1234bar; Path = /")
+  cookie <- parseCookie(
+    "my_cookie-which/uses%20strange?characters=foo_-%20+?1234bar; Path = /"
+  )
   expect_equal(cookie$name, "my_cookie-which/uses%20strange?characters")
   expect_equal(cookie$value, "foo_-%20+?1234bar")
   expect_equal(cookie$path, "/")
@@ -77,15 +84,21 @@ test_that("cookies can be stored", {
   local_cookie_store()
 
   parsedUrl <- parseHttpUrl("http://fakedomain:123/test/stuff")
-  expect_warning({
-    storeCookies(parsedUrl, c(
-      "mycookie=myvalue; Path=/; Max-Age=3600; HttpOnly",
-      "anotherCookie=what; Path=/test; Max-Age=100",
-      "wrongpath=huh; Path=/uhoh; Max-Age=100",
-      "secureCookie=123; Secure",
-      "third=cookie; Path=/; Max-Age=500")
-    )
-  }, "Invalid path set for cookie")
+  expect_warning(
+    {
+      storeCookies(
+        parsedUrl,
+        c(
+          "mycookie=myvalue; Path=/; Max-Age=3600; HttpOnly",
+          "anotherCookie=what; Path=/test; Max-Age=100",
+          "wrongpath=huh; Path=/uhoh; Max-Age=100",
+          "secureCookie=123; Secure",
+          "third=cookie; Path=/; Max-Age=500"
+        )
+      )
+    },
+    "Invalid path set for cookie"
+  )
   cookies <- get("fakedomain:123", envir = .cookieStore)
   expect_equal(nrow(cookies), 4)
 
@@ -170,7 +183,10 @@ test_that("appending cookie headers works", {
   # Store a couple more cookies
   storeCookies(parsedUrl, "cookie2=value2; Path=/test; Max-Age=3600")
   # This one has the wrong path, will be filtered out
-  storeCookies(parseHttpUrl("http://fakedomain:123/another"), "cookie3=value3; Path=/another; Max-Age=3600")
+  storeCookies(
+    parseHttpUrl("http://fakedomain:123/another"),
+    "cookie3=value3; Path=/another; Max-Age=3600"
+  )
 
   headers <- appendCookieHeaders(parsedUrl, c(header1 = 123, header2 = "abc"))
   expect_length(headers, 3)
@@ -185,13 +201,22 @@ test_that("appending cookie headers works", {
   expect_equal(headers[2], c(cookie = "cookie2=value2; cookie1=value1"))
 
   # Add a secure cookie
-  storeCookies(parsedUrl, "securecookie=secureval; Path=/; Max-Age=3600; Secure")
+  storeCookies(
+    parsedUrl,
+    "securecookie=secureval; Path=/; Max-Age=3600; Secure"
+  )
   headers <- appendCookieHeaders(parsedUrl, c())
   expect_equal(headers[["cookie"]], "cookie2=value2; cookie1=value1")
 
   # But over a secure channel, you'd include the secure cookie
-  headers <- appendCookieHeaders(parseHttpUrl("https://fakedomain:123/test/stuff"), c())
-  expect_equal(headers[["cookie"]], "securecookie=secureval; cookie2=value2; cookie1=value1")
+  headers <- appendCookieHeaders(
+    parseHttpUrl("https://fakedomain:123/test/stuff"),
+    c()
+  )
+  expect_equal(
+    headers[["cookie"]],
+    "securecookie=secureval; cookie2=value2; cookie1=value1"
+  )
 })
 
 test_that("Expired cookies are removed", {
@@ -229,9 +254,15 @@ test_that("Expired cookies are removed", {
 
 test_that("getCookieHost works", {
   expect_equal(getCookieHost(parseHttpUrl("http://rstudio.com")), "rstudio.com")
-  expect_equal(getCookieHost(parseHttpUrl("http://rstudio.com:3939")), "rstudio.com:3939")
+  expect_equal(
+    getCookieHost(parseHttpUrl("http://rstudio.com:3939")),
+    "rstudio.com:3939"
+  )
   expect_equal(getCookieHost(parseHttpUrl("http://127.0.0.1")), "127.0.0.1")
-  expect_equal(getCookieHost(parseHttpUrl("http://127.0.0.1:3939")), "127.0.0.1:3939")
+  expect_equal(
+    getCookieHost(parseHttpUrl("http://127.0.0.1:3939")),
+    "127.0.0.1:3939"
+  )
 })
 
 test_that("getting and clearing cookies works", {

--- a/tests/testthat/test-deployApp.R
+++ b/tests/testthat/test-deployApp.R
@@ -41,7 +41,6 @@ test_that("findRecordPath() uses recordDir, then appPrimaryDoc, then appDir", {
 # app visibility ----------------------------------------------------------
 
 test_that("needsVisibilityChange() returns FALSE when no change needed", {
-
   dummyApp <- function(visibility) {
     list(
       deployment = list(
@@ -54,13 +53,22 @@ test_that("needsVisibilityChange() returns FALSE when no change needed", {
 
   expect_false(needsVisibilityChange("connect.com"))
   expect_false(needsVisibilityChange("shinyapps.io", dummyApp("public"), NULL))
-  expect_false(needsVisibilityChange("shinyapps.io", dummyApp("public"), "public"))
+  expect_false(needsVisibilityChange(
+    "shinyapps.io",
+    dummyApp("public"),
+    "public"
+  ))
   expect_true(needsVisibilityChange("shinyapps.io", dummyApp(NULL), "private"))
-  expect_true(needsVisibilityChange("shinyapps.io", dummyApp("public"), "private"))
+  expect_true(needsVisibilityChange(
+    "shinyapps.io",
+    dummyApp("public"),
+    "private"
+  ))
 })
 
 test_that("needsVisibilityChange() errors for cloud", {
-  expect_snapshot(error = TRUE,
+  expect_snapshot(
+    error = TRUE,
     needsVisibilityChange("posit.cloud", appVisibility = "public")
   )
 })

--- a/tests/testthat/test-deployDoc.R
+++ b/tests/testthat/test-deployDoc.R
@@ -16,11 +16,13 @@ test_that("turns appDir into appDir + appPrimarySourceDoc", {
 
 test_that("shiny rmd deploys whole directory", {
   skip_on_cran()
-  dir <- local_temp_app(list("foo.Rmd" = c(
-    "---",
-    "runtime: shiny",
-    "---"
-  )))
+  dir <- local_temp_app(list(
+    "foo.Rmd" = c(
+      "---",
+      "runtime: shiny",
+      "---"
+    )
+  ))
   doc <- standardizeSingleDocDeployment(file.path(dir, "foo.Rmd"))
   expect_equal(doc$appFiles, NULL)
 })
@@ -80,7 +82,10 @@ test_that("regular html does not deploy .Rprofile", {
     ".Rprofile" = ""
   ))
 
-  doc <- standardizeSingleDocDeployment(file.path(dir, "foo.html"), quiet = TRUE)
+  doc <- standardizeSingleDocDeployment(
+    file.path(dir, "foo.html"),
+    quiet = TRUE
+  )
   expect_equal(doc$appFiles, c("foo.html"))
 })
 
@@ -91,7 +96,10 @@ test_that("regular html does not deploy requirements.txt", {
     "requirements.txt" = ""
   ))
 
-  doc <- standardizeSingleDocDeployment(file.path(dir, "foo.html"), quiet = TRUE)
+  doc <- standardizeSingleDocDeployment(
+    file.path(dir, "foo.html"),
+    quiet = TRUE
+  )
   expect_equal(doc$appFiles, c("foo.html"))
 })
 
@@ -102,7 +110,10 @@ test_that("regular html does not deploy renv.lock", {
     "renv.lock" = ""
   ))
 
-  doc <- standardizeSingleDocDeployment(file.path(dir, "foo.html"), quiet = TRUE)
+  doc <- standardizeSingleDocDeployment(
+    file.path(dir, "foo.html"),
+    quiet = TRUE
+  )
   expect_equal(doc$appFiles, c("foo.html"))
 })
 

--- a/tests/testthat/test-deploySite.R
+++ b/tests/testthat/test-deploySite.R
@@ -3,13 +3,15 @@ test_that("can extract quarto metadata", {
   skip_if_no_quarto()
   skip_if_not_installed("quarto")
 
-  app <- local_temp_app(list(`_quarto.yaml` = c(
-    "project:",
-    "  type: website",
-    "",
-    "website:",
-    "  title: 'website-quarto'"
-  )))
+  app <- local_temp_app(list(
+    `_quarto.yaml` = c(
+      "project:",
+      "  type: website",
+      "",
+      "website:",
+      "  title: 'website-quarto'"
+    )
+  ))
 
   site <- quartoSite(app)
   expect_equal(site$title, "website-quarto")

--- a/tests/testthat/test-deploymentTarget.R
+++ b/tests/testthat/test-deploymentTarget.R
@@ -39,7 +39,13 @@ test_that("uses appId given a local deployment record; created by a local accoun
   addTestAccount("leslie", "local")
 
   app_dir <- withr::local_tempdir()
-  addTestDeployment(app_dir, appName = "local-record", appId = "the-appid", account = "leslie", server = "local")
+  addTestDeployment(
+    app_dir,
+    appName = "local-record",
+    appId = "the-appid",
+    account = "leslie",
+    server = "local"
+  )
 
   target <- findDeploymentTarget(app_dir, appId = "the-appid")
   accountDetails <- target$accountDetails
@@ -62,7 +68,13 @@ test_that("uses appId given a local deployment record; created by a collaborator
   addTestAccount("leslie", "local")
 
   app_dir <- withr::local_tempdir()
-  addTestDeployment(app_dir, appName = "local-record", appId = "the-appid", account = "ron", server = "local")
+  addTestDeployment(
+    app_dir,
+    appName = "local-record",
+    appId = "the-appid",
+    account = "ron",
+    server = "local"
+  )
 
   target <- findDeploymentTarget(app_dir, appId = "the-appid")
   accountDetails <- target$accountDetails
@@ -82,12 +94,13 @@ test_that("uses appId without local deployment record; created by local account"
   addTestAccount("leslie", "local")
 
   local_mocked_bindings(
-    getApplication = function(...) data.frame(
-      id = "the-appid",
-      name = "remote-record",
-      owner_username = "leslie",
-      stringsAsFactors = FALSE
-    )
+    getApplication = function(...)
+      data.frame(
+        id = "the-appid",
+        name = "remote-record",
+        owner_username = "leslie",
+        stringsAsFactors = FALSE
+      )
   )
 
   app_dir <- withr::local_tempdir()
@@ -112,12 +125,13 @@ test_that("uses appId without local deployment record; created by collaborator",
   app_dir <- withr::local_tempdir()
 
   local_mocked_bindings(
-    getApplication = function(...) data.frame(
-      id = "the-appid",
-      name = "remote-record",
-      owner_username = "ron",
-      stringsAsFactors = FALSE
-    )
+    getApplication = function(...)
+      data.frame(
+        id = "the-appid",
+        name = "remote-record",
+        owner_username = "ron",
+        stringsAsFactors = FALSE
+      )
   )
 
   target <- findDeploymentTarget(app_dir, appId = "the-appid")
@@ -201,7 +215,14 @@ test_that("succeeds if there's a single existing deployment", {
     server = "example.com",
     version = "999"
   )
-  expect_equal(nrow(deployments(app_dir, accountFilter = "ron", serverFilter = "example.com")), 1)
+  expect_equal(
+    nrow(deployments(
+      app_dir,
+      accountFilter = "ron",
+      serverFilter = "example.com"
+    )),
+    1
+  )
   expect_equal(nrow(deployments(app_dir)), 1)
 
   target <- findDeploymentTarget(app_dir)
@@ -306,11 +327,12 @@ test_that("succeeds if there are no deployments and a single account", {
   addTestServer()
   addTestAccount("ron")
   local_mocked_bindings(
-    getAppByName = function(...) data.frame(
-      name = "remotename",
-      url = "app-url",
-      stringsAsFactors = FALSE
-    )
+    getAppByName = function(...)
+      data.frame(
+        name = "remotename",
+        url = "app-url",
+        stringsAsFactors = FALSE
+      )
   )
 
   app_dir <- dirCreate(file.path(withr::local_tempdir(), "my_app"))
@@ -340,7 +362,11 @@ test_that("succeeds if there are no deployments and a single account", {
   expect_equal(deployment$account, "ron")
   expect_equal(deployment$server, "example.com")
 
-  target <- findDeploymentTarget(app_dir, envVars = c("TEST1", "TEST2"), forceUpdate = TRUE)
+  target <- findDeploymentTarget(
+    app_dir,
+    envVars = c("TEST1", "TEST2"),
+    forceUpdate = TRUE
+  )
   accountDetails <- target$accountDetails
   deployment <- target$deployment
   expect_equal(accountDetails$name, "ron")
@@ -367,11 +393,12 @@ test_that("default title is the empty string", {
   addTestServer()
   addTestAccount("ron")
   local_mocked_bindings(
-    getAppByName = function(...) data.frame(
-      name = "remotename",
-      url = "app-url",
-      stringsAsFactors = FALSE
-    )
+    getAppByName = function(...)
+      data.frame(
+        name = "remotename",
+        url = "app-url",
+        stringsAsFactors = FALSE
+      )
   )
 
   app_dir <- withr::local_tempdir()
@@ -384,12 +411,14 @@ confirm_existing_app_used <- function(server) {
   local_temp_config()
   addTestServer()
   addTestAccount("ron", server = server)
-  local_mocked_bindings(getAppByName = function(...) data.frame(
-      name = "my_app",
-      id = 123,
-      url = "http://example.com/test",
-      stringsAsFactors = FALSE
-    ),
+  local_mocked_bindings(
+    getAppByName = function(...)
+      data.frame(
+        name = "my_app",
+        id = 123,
+        url = "http://example.com/test",
+        stringsAsFactors = FALSE
+      ),
     shouldUpdateApp = function(...) TRUE
   )
 
@@ -411,12 +440,14 @@ confirm_existing_app_not_used <- function(server) {
   local_temp_config()
   addTestServer()
   addTestAccount("ron", server = server)
-  local_mocked_bindings(getAppByName = function(...) data.frame(
-      name = "my_app",
-      id = 123,
-      url = "http://example.com/test",
-      stringsAsFactors = FALSE
-    ),
+  local_mocked_bindings(
+    getAppByName = function(...)
+      data.frame(
+        name = "my_app",
+        id = 123,
+        url = "http://example.com/test",
+        stringsAsFactors = FALSE
+      ),
     shouldUpdateApp = function(...) FALSE
   )
 
@@ -467,31 +498,19 @@ test_that("findUnique always returns unique name", {
 })
 
 test_that("createDeploymentFromApplication promotes fields", {
-  expect_equal(createDeploymentFromApplication(
-    application = list(
-      id = "1",
-      name = "app-name",
-      title = "app-title",
-      owner_username = "alice.username"
+  expect_equal(
+    createDeploymentFromApplication(
+      application = list(
+        id = "1",
+        name = "app-name",
+        title = "app-title",
+        owner_username = "alice.username"
+      ),
+      accountDetails = list(
+        name = "alice",
+        server = "example.com"
+      )
     ),
-    accountDetails = list(
-      name = "alice",
-      server = "example.com"
-    )
-  ), list(
-    name = "app-name",
-    title = "app-title",
-    envVars = NULL,
-    appId = "1",
-    username = "alice.username",
-    account = "alice",
-    server = "example.com",
-    version = deploymentRecordVersion
-  ))
-})
-
-test_that("updateDeployment updates fields", {
-  expect_equal(updateDeployment(
     list(
       name = "app-name",
       title = "app-title",
@@ -501,23 +520,55 @@ test_that("updateDeployment updates fields", {
       account = "alice",
       server = "example.com",
       version = deploymentRecordVersion
+    )
+  )
+})
+
+test_that("updateDeployment updates fields", {
+  expect_equal(
+    updateDeployment(
+      list(
+        name = "app-name",
+        title = "app-title",
+        envVars = NULL,
+        appId = "1",
+        username = "alice.username",
+        account = "alice",
+        server = "example.com",
+        version = deploymentRecordVersion
+      ),
+      appTitle = "updated-title",
+      envVars = c("VAR-NAME")
     ),
-    appTitle = "updated-title",
-    envVars = c("VAR-NAME")
-  ), list(
-    name = "app-name",
-    title = "updated-title",
-    envVars = c("VAR-NAME"),
-    appId = "1",
-    username = "alice.username",
-    account = "alice",
-    server = "example.com",
-    version = deploymentRecordVersion
-  ))
+    list(
+      name = "app-name",
+      title = "updated-title",
+      envVars = c("VAR-NAME"),
+      appId = "1",
+      username = "alice.username",
+      account = "alice",
+      server = "example.com",
+      version = deploymentRecordVersion
+    )
+  )
 })
 
 test_that("updateDeployment ignores NULL updates", {
-  expect_equal(updateDeployment(
+  expect_equal(
+    updateDeployment(
+      list(
+        name = "app-name",
+        title = "app-title",
+        envVars = c("VAR-NAME"),
+        appId = "1",
+        username = "alice.username",
+        account = "alice",
+        server = "example.com",
+        version = deploymentRecordVersion
+      ),
+      appTitle = NULL,
+      envVars = NULL
+    ),
     list(
       name = "app-name",
       title = "app-title",
@@ -527,17 +578,6 @@ test_that("updateDeployment ignores NULL updates", {
       account = "alice",
       server = "example.com",
       version = deploymentRecordVersion
-    ),
-    appTitle = NULL,
-    envVars = NULL
-  ), list(
-    name = "app-name",
-    title = "app-title",
-    envVars = c("VAR-NAME"),
-    appId = "1",
-    username = "alice.username",
-    account = "alice",
-    server = "example.com",
-    version = deploymentRecordVersion
-  ))
+    )
+  )
 })

--- a/tests/testthat/test-deployments-find.R
+++ b/tests/testthat/test-deployments-find.R
@@ -15,11 +15,17 @@ test_that("returns stubbed details when single account has no deployments", {
 
   # derived from directory name.
   dep <- findDeployment(app)
-  expect_equal(dep, list(name = basename(app), account = "ron", server = "example.com"))
+  expect_equal(
+    dep,
+    list(name = basename(app), account = "ron", server = "example.com")
+  )
 
   # name given.
   dep <- findDeployment(app, appName = "placeholder")
-  expect_equal(dep, list(name = "placeholder", account = "ron", server = "example.com"))
+  expect_equal(
+    dep,
+    list(name = "placeholder", account = "ron", server = "example.com")
+  )
 })
 
 test_that("finds single deployment", {

--- a/tests/testthat/test-http-internal.R
+++ b/tests/testthat/test-http-internal.R
@@ -1,7 +1,10 @@
 test_that("basic HTTP methods work", {
   skip_if_not_installed("webfakes")
 
-  withr::local_options(rsconnect.http = "internal", lifecycle_verbosity = "quiet")
+  withr::local_options(
+    rsconnect.http = "internal",
+    lifecycle_verbosity = "quiet"
+  )
 
   test_http_GET()
   test_http_POST_JSON()

--- a/tests/testthat/test-ide.R
+++ b/tests/testthat/test-ide.R
@@ -32,7 +32,13 @@ test_that("validateServerUrl() when Connect", {
   # Incomplete (lacks path).
   # Lack of protocol is not easily tested because validateConnectUrl()
   # prefers https://.
-  partial_url <- paste0(service$protocol, "://", service$host, ":", service$port)
+  partial_url <- paste0(
+    service$protocol,
+    "://",
+    service$host,
+    ":",
+    service$port
+  )
   result <- validateServerUrl(partial_url)
   expect_true(result$valid, info = partial_url)
   expect_equal(result$url, expected_url, info = partial_url)
@@ -69,7 +75,9 @@ current_user_service <- function() {
       json_app <- webfakes::new_app()
       json_app$use(webfakes::mw_json())
       json_app$get("/users/current", function(req, res) {
-        res$set_status(200L)$send_json(list(username = jsonlite::unbox("susan")))
+        res$set_status(200L)$send_json(list(
+          username = jsonlite::unbox("susan")
+        ))
       })
       app <- webfakes::new_app_process(json_app)
     }

--- a/tests/testthat/test-lint.R
+++ b/tests/testthat/test-lint.R
@@ -6,10 +6,11 @@ test_that("lints give have useful print method", {
 })
 
 test_that("The linter believes that the Shiny example apps are okay", {
-
-  examples <- list.files(system.file("examples", package = "shiny"), full.names = TRUE)
+  examples <- list.files(
+    system.file("examples", package = "shiny"),
+    full.names = TRUE
+  )
   if (length(examples)) {
-
     results <- lapply(examples, lint)
 
     expect_output(lints <- lapply(results, print))

--- a/tests/testthat/test-linters.R
+++ b/tests/testthat/test-linters.R
@@ -7,14 +7,14 @@ test_that("linter warns about absolute paths and relative paths", {
   expect_snapshot(result)
 
   absPathLintedIndices <- result[["server.R"]]$absolute.paths$indices
-  expect_identical(as.numeric(absPathLintedIndices), 15)
+  expect_identical(as.numeric(absPathLintedIndices), 12)
 })
 
 test_that("The linter identifies files not matching in case sensitivity", {
   result <- lint(test_path("shinyapp-with-absolute-paths"))
   server.R <- result[["server.R"]]
   filepath.capitalization <- server.R[["filepath.capitalization"]]
-  expect_equal(as.integer(filepath.capitalization$indices), 31)
+  expect_equal(as.integer(filepath.capitalization$indices), 28)
 })
 
 test_that("The linter identifies files with Markdown links not matching in case sensitivity", {

--- a/tests/testthat/test-plumber/plumber.R
+++ b/tests/testthat/test-plumber/plumber.R
@@ -1,5 +1,4 @@
-
 #* @get /foo
 fooRoute <- function() {
-    "hello world"
+  "hello world"
 }

--- a/tests/testthat/test-writeManifest.R
+++ b/tests/testthat/test-writeManifest.R
@@ -43,7 +43,10 @@ test_that("Rmd with reticulate as a dependency includes python in the manifest",
 
   appDir <- test_path("test-reticulate-rmds")
   manifest <- makeManifest(appDir, python = python)
-  requirements_file <- file.path(appDir, manifest$python$package_manager$package_file)
+  requirements_file <- file.path(
+    appDir,
+    manifest$python$package_manager$package_file
+  )
   expect_equal(requirements_file, "test-reticulate-rmds/requirements.txt")
   defer(unlink(requirements_file))
 
@@ -59,7 +62,10 @@ test_that("Rmd with reticulate as an inferred dependency includes reticulate and
 
   appDir <- test_path("test-reticulate-rmds")
   manifest <- makeManifest(appDir, "implicit.Rmd", python = python)
-  requirements_file <- file.path(appDir, manifest$python$package_manager$package_file)
+  requirements_file <- file.path(
+    appDir,
+    manifest$python$package_manager$package_file
+  )
   expect_equal(requirements_file, "test-reticulate-rmds/requirements.txt")
   defer(unlink(requirements_file))
 
@@ -310,7 +316,12 @@ test_that("Sets environment.environment_management in the manifest if envManagem
   appDir <- test_path("shinyapp-simple")
 
   # test shorthand arg
-  manifest <- makeManifest(appDir, envManagement = FALSE, envManagementR = TRUE, envManagementPy = TRUE)
+  manifest <- makeManifest(
+    appDir,
+    envManagement = FALSE,
+    envManagementR = TRUE,
+    envManagementPy = TRUE
+  )
   expect_equal(manifest$environment$environment_management$r, FALSE)
   expect_equal(manifest$environment$environment_management$python, FALSE)
 


### PR DESCRIPTION
Ran the commands:

```bash
air format R
air format tests
```

Ran the call:

```r
usethis::use_github_action(url = "https://github.com/posit-dev/setup-air/blob/main/examples/format-suggest.yaml")
```

Reviewed all of the edits and then manually converted a number of `if (expr) foo` to `if (expr) {foo}` so air would flow statement across multiple lines. The original reformatting was especially poor when the statement had if+else or if+if-else+else.