### PR TITLE
Mimic major-minor Connect behavior

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -139,7 +139,12 @@ versionFromLockfile <- function(appDir) {
   tryCatch(
     {
       lockfile <- suppressWarnings(renv::lockfile_read(project = appDir))
-      paste("~=", lockfile$R$Version)
+      v <- lockfile$R$Version
+      # only major specified “3” → ~=3.0 → >=3.0,<4.0
+      # major and minor specified “3.8” or “3.8.11” → ~=3.8.0 → >=3.8.0,<3.9.0
+      parts <- strsplit(v, "\\.")[[1]]
+      new_parts <- c(head(parts, 2), "0")
+      paste0("~=", paste(new_parts, collapse = "."))
     },
     error = function(e) {
       return(NULL)

--- a/tests/testthat/test-writeManifest.R
+++ b/tests/testthat/test-writeManifest.R
@@ -326,7 +326,7 @@ test_that("environment.r.requires - renv.lock - Existing R version is added", {
 
   manifest <- makeManifest(appDir)
 
-  maj  <- R.Version()$major
+  maj <- R.Version()$major
   min1 <- strsplit(R.Version()$minor, "\\.")[[1]][1]
   expected <- sprintf("~=%s.%s.0", maj, min1)
   expect_equal(
@@ -337,7 +337,14 @@ test_that("environment.r.requires - renv.lock - Existing R version is added", {
 
 test_that("versionFromLockfile formats various R versions with patch .0", {
   versions <- c("3", "3.8", "3.8.11", "3.25", "4.0.2", "10.5.3")
-  expected <- c("~=3.0", "~=3.8.0", "~=3.8.0", "~=3.25.0", "~=4.0.0", "~=10.5.0")
+  expected <- c(
+    "~=3.0",
+    "~=3.8.0",
+    "~=3.8.0",
+    "~=3.25.0",
+    "~=4.0.0",
+    "~=10.5.0"
+  )
 
   for (i in seq_along(versions)) {
     # Create a temporary directory with a renv.lock file
@@ -346,14 +353,23 @@ test_that("versionFromLockfile formats various R versions with patch .0", {
     dir.create(appDir)
     jsonlite::write_json(
       list(R = list(Version = versions[i])),
-      path      = file.path(appDir, "renv.lock"),
+      path = file.path(appDir, "renv.lock"),
       auto_unbox = TRUE,
-      pretty     = TRUE
+      pretty = TRUE
     )
 
     res <- versionFromLockfile(appDir)
-    expect_equal(res, expected[i],
-      info = paste("Input:", versions[i], "→ got", res, "but expected", expected[i])
+    expect_equal(
+      res,
+      expected[i],
+      info = paste(
+        "Input:",
+        versions[i],
+        "→ got",
+        res,
+        "but expected",
+        expected[i]
+      )
     )
   }
 })

--- a/tests/testthat/test-writeManifest.R
+++ b/tests/testthat/test-writeManifest.R
@@ -325,10 +325,37 @@ test_that("environment.r.requires - renv.lock - Existing R version is added", {
   renv::snapshot(appDir, prompt = FALSE)
 
   manifest <- makeManifest(appDir)
+
+  maj  <- R.Version()$major
+  min1 <- strsplit(R.Version()$minor, "\\.")[[1]][1]
+  expected <- sprintf("~=%s.%s.0", maj, min1)
   expect_equal(
     manifest$environment$r$requires,
-    paste("~= ", R.Version()$major, ".", R.Version()$minor, sep = "")
+    expected
   )
+})
+
+test_that("versionFromLockfile formats various R versions with patch .0", {
+  versions <- c("3", "3.8", "3.8.11", "3.25", "4.0.2", "10.5.3")
+  expected <- c("~=3.0", "~=3.8.0", "~=3.8.0", "~=3.25.0", "~=4.0.0", "~=10.5.0")
+
+  for (i in seq_along(versions)) {
+    # Create a temporary directory with a renv.lock file
+    # containing the specified R version
+    appDir <- tempfile("app")
+    dir.create(appDir)
+    jsonlite::write_json(
+      list(R = list(Version = versions[i])),
+      path      = file.path(appDir, "renv.lock"),
+      auto_unbox = TRUE,
+      pretty     = TRUE
+    )
+
+    res <- versionFromLockfile(appDir)
+    expect_equal(res, expected[i],
+      info = paste("Input:", versions[i], "→ got", res, "but expected", expected[i])
+    )
+  }
 })
 
 test_that("environment.r.requires - DESCRIPTION file takes precedence over renv.lock", {

--- a/tests/testthat/test-writeManifest.R
+++ b/tests/testthat/test-writeManifest.R
@@ -349,8 +349,7 @@ test_that("versionFromLockfile formats various R versions with patch .0", {
   for (i in seq_along(versions)) {
     # Create a temporary directory with a renv.lock file
     # containing the specified R version
-    appDir <- tempfile("app")
-    dir.create(appDir)
+    appDir <- local_temp_app()
     jsonlite::write_json(
       list(R = list(Version = versions[i])),
       path = file.path(appDir, "renv.lock"),


### PR DESCRIPTION
Adapt all version numbers that don't have a constraint to a compatible constraint that accepts any patch release.

