### PR TITLE
wrap http response error, as it may be json

### DIFF
--- a/R/http.R
+++ b/R/http.R
@@ -147,8 +147,9 @@ handleResponse <- function(
 ) {
   url <- buildHttpUrl(response$req)
   reportError <- function(msg) {
+    # msg may be JSON; wrapping with "{msg}" avoids treating it as a formatting string.
     cli::cli_abort(
-      c("<{url}> failed with HTTP status {response$status}", msg),
+      c("<{url}> failed with HTTP status {response$status}", "{msg}"),
       class = c(paste0("rsconnect_http_", response$status), "rsconnect_http"),
       call = error_call
     )


### PR DESCRIPTION
Before this change, tests produced warnings like:

```
Warning (test-ide.R:8:3): validateServerUrl() when not Connect
NAs introduced by coercion
Backtrace:
     ▆
  1. ├─testthat::expect_false(validateServerUrl(url)$valid) at test-ide.R:8:3
  2. │ └─testthat::quasi_label(enquo(object), label, arg = "object")
  3. │   └─rlang::eval_bare(expr, quo_get_env(quo))
  4. └─rsconnect:::validateServerUrl(url)
  5.   └─rsconnect:::validateConnectUrl(url, certificate) at rsconnect/R/ide.R:6:3
  6.     ├─rlang::catch_cnd(response <- GET_server_settings(url), "error") at rsconnect/R/servers.R:241:3
  7.     │ ├─rlang::eval_bare(...)
  8.     │ ├─base::tryCatch(...)
  9.     │ │ └─base (local) tryCatchList(expr, classes, parentenv, handlers)
 10.     │ │   └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
 11.     │ │     └─base (local) doTryCatch(return(expr), name, parentenv, handler)
 12.     │ └─base::force(expr)
 13.     └─rsconnect (local) GET_server_settings(url)
 14.       └─rsconnect:::GET(...) at rsconnect/R/servers.R:232:5
 15.         └─rsconnect:::httpRequest(...) at rsconnect/R/http.R:222:3
 16.           └─rsconnect:::handleResponse(...) at rsconnect/R/http.R:53:3
 17.             └─rsconnect (local) reportError(response$content) at rsconnect/R/http.R:162:7
```