### PR TITLE
Detect plumber vs. plumber2 in `appDependencies()`

### DIFF
--- a/R/appDependencies.R
+++ b/R/appDependencies.R
@@ -157,7 +157,7 @@ inferRPackageDependencies <- function(appMetadata) {
     "quarto-shiny" = c("rmarkdown", "shiny"),
     "rmd-shiny" = c("rmarkdown", "shiny"),
     "shiny" = "shiny",
-    "api" = "plumber"
+    "api" = appMetadata$plumberInfo
   )
   if (appMetadata$documentsHavePython) {
     deps <- c(deps, "reticulate")

--- a/R/appMetadata.R
+++ b/R/appMetadata.R
@@ -82,13 +82,24 @@ appMetadata <- function(
     quartoInfo <- NULL
   }
 
+  plumberInfo <- NULL
+  if (appMode == "api") {
+    if (apiIsPlumber2(appDir)) {
+      server_yaml <- yaml::read_yaml(file.path(appDir, "_server.yml"))
+      plumberInfo <- server_yaml$engine
+    } else {
+      plumberInfo <- "plumber"
+    }
+  }
+
   list(
     appMode = appMode,
     appPrimaryDoc = appPrimaryDoc,
     hasParameters = hasParameters,
     contentCategory = contentCategory,
     documentsHavePython = documentsHavePython,
-    quartoInfo = quartoInfo
+    quartoInfo = quartoInfo,
+    plumberInfo = plumberInfo
   )
 }
 
@@ -316,7 +327,6 @@ appIsQuartoDocument <- function(appMode) {
     )
 }
 
-
 appHasParameters <- function(
   appDir,
   appPrimaryDoc,
@@ -373,4 +383,9 @@ documentHasPythonChunk <- function(filename) {
   lines <- readLines(filename, warn = FALSE, encoding = "UTF-8")
   matches <- grep("`{python", lines, fixed = TRUE)
   return(length(matches) > 0)
+}
+
+apiIsPlumber2 <- function(appDir) {
+  files <- list.files(appDir)
+  any(grepl("_server\\.yml", files))
 }

--- a/R/appMetadata.R
+++ b/R/appMetadata.R
@@ -85,7 +85,18 @@ appMetadata <- function(
   plumberInfo <- NULL
   if (appMode == "api") {
     if (apiIsPlumber2(appDir)) {
-      server_yaml <- yaml::read_yaml(file.path(appDir, "_server.yml"))
+      server_file <- list.files(
+        appDir,
+        pattern = "^_server.ya?ml$",
+        full.names = TRUE
+      )
+      if (length(server_file) > 1) {
+        stop(
+          "Found both _server.yaml and _server.yml, please remove one from your project",
+          call. = FALSE
+        )
+      }
+      server_yaml <- yaml::read_yaml(server_file)
       plumberInfo <- server_yaml$engine
     } else {
       plumberInfo <- "plumber"
@@ -128,7 +139,7 @@ inferAppMode <- function(
   }
 
   # general API
-  server_yml <- matchingNames(absoluteRootFiles, "^_server.yml$")
+  server_yml <- matchingNames(absoluteRootFiles, "^_server.ya?ml$")
   if (length(server_yml) > 0) {
     return("api")
   }
@@ -387,5 +398,5 @@ documentHasPythonChunk <- function(filename) {
 
 apiIsPlumber2 <- function(appDir) {
   files <- list.files(appDir)
-  any(grepl("^_server\\.yml$", files))
+  any(grepl("^_server\\.ya?ml$", files))
 }

--- a/R/appMetadata.R
+++ b/R/appMetadata.R
@@ -387,5 +387,5 @@ documentHasPythonChunk <- function(filename) {
 
 apiIsPlumber2 <- function(appDir) {
   files <- list.files(appDir)
-  any(grepl("_server\\.yml", files))
+  any(grepl("^_server\\.yml$", files))
 }

--- a/R/appMetadata.R
+++ b/R/appMetadata.R
@@ -84,23 +84,7 @@ appMetadata <- function(
 
   plumberInfo <- NULL
   if (appMode == "api") {
-    if (apiIsPlumber2(appDir)) {
-      server_file <- list.files(
-        appDir,
-        pattern = "^_server.ya?ml$",
-        full.names = TRUE
-      )
-      if (length(server_file) > 1) {
-        stop(
-          "Found both _server.yaml and _server.yml, please remove one from your project",
-          call. = FALSE
-        )
-      }
-      server_yaml <- yaml::read_yaml(server_file)
-      plumberInfo <- server_yaml$engine
-    } else {
-      plumberInfo <- "plumber"
-    }
+    plumberInfo <- inferPlumberInfo(appDir)
   }
 
   list(
@@ -396,7 +380,25 @@ documentHasPythonChunk <- function(filename) {
   return(length(matches) > 0)
 }
 
-apiIsPlumber2 <- function(appDir) {
+inferPlumberInfo <- function(appDir) {
   files <- list.files(appDir)
-  any(grepl("^_server\\.ya?ml$", files))
+  is_plumber2 <- any(grepl("^_server\\.ya?ml$", files))
+
+  if (!is_plumber2) {
+    return("plumber")
+  }
+
+  server_file <- list.files(
+    appDir,
+    pattern = "^_server.ya?ml$",
+    full.names = TRUE
+  )
+  if (length(server_file) > 1) {
+    stop(
+      "Found both _server.yaml and _server.yml, please remove one from your project",
+      call. = FALSE
+    )
+  }
+  server_yaml <- yaml::read_yaml(server_file)
+  return(server_yaml$engine)
 }

--- a/R/appMetadata.R
+++ b/R/appMetadata.R
@@ -380,6 +380,12 @@ documentHasPythonChunk <- function(filename) {
   return(length(matches) > 0)
 }
 
+#' Infer plumber information
+#'
+#' @param appDir directory containing content
+#' @return `"plumber"` for plumber APIs; the contents of the `engine` field in
+#'   `_server.yml`/`_server.yaml` (usually `"plumber2"`) for plumber2 APIs.
+#' @noRd
 inferPlumberInfo <- function(appDir) {
   files <- list.files(appDir)
   is_plumber2 <- any(grepl("^_server\\.ya?ml$", files))

--- a/R/deployAPI.R
+++ b/R/deployAPI.R
@@ -4,7 +4,8 @@
 #' must contain a script returning a `plumb` object or a plumber API definition.
 #'
 #' @param api Path to the API project directory. Must contain either
-#'   `entrypoint.R` or `plumber.R`
+#'   `entrypoint.R` or `plumber.R` (for plumber APIs) or `_server.yml` (for
+#'   plumber2 APIs)
 #' @param ... Additional arguments to [deployApp()].
 #'
 #' @details Deploy a plumber API definition by either supplying a directory

--- a/R/deployAPI.R
+++ b/R/deployAPI.R
@@ -10,17 +10,12 @@
 #' @details Deploy a plumber API definition by either supplying a directory
 #'   containing `plumber.R` (an API definition) or `entrypoint.R` that returns a
 #'   `plumb` object created by `plumber::plumb()`. See the plumber documentation
-#'   for more information.
+#'   for more information. Alternatively, deploy a plumber2 API by supplying a
+#'   directory containing `_server.yml`.
 #'
 #' @family Deployment functions
 #' @export
 deployAPI <- function(api, ...) {
-  check_installed(
-    "plumber",
-    version = "0.3.2",
-    reason = "to deploy plumber APIs"
-  )
-
   check_directory(api)
 
   # Checking for entrypoint.R or plumber.R is done in `lint-framework.R`

--- a/R/imports.R
+++ b/R/imports.R
@@ -1,3 +1,6 @@
 #' @importFrom stats na.omit setNames
 #' @importFrom utils available.packages installed.packages contrib.url getFromNamespace glob2rx head packageVersion packageDescription read.csv
 NULL
+
+# Create NULL binding to make list.files mockable in tests
+list.files <- NULL

--- a/R/imports.R
+++ b/R/imports.R
@@ -1,6 +1,3 @@
 #' @importFrom stats na.omit setNames
 #' @importFrom utils available.packages installed.packages contrib.url getFromNamespace glob2rx head packageVersion packageDescription read.csv
 NULL
-
-# Create NULL binding to make list.files mockable in tests
-list.files <- NULL

--- a/man/deployAPI.Rd
+++ b/man/deployAPI.Rd
@@ -20,7 +20,8 @@ must contain a script returning a \code{plumb} object or a plumber API definitio
 Deploy a plumber API definition by either supplying a directory
 containing \code{plumber.R} (an API definition) or \code{entrypoint.R} that returns a
 \code{plumb} object created by \code{plumber::plumb()}. See the plumber documentation
-for more information.
+for more information. Alternatively, deploy a plumber2 API by supplying a
+directory containing \verb{_server.yml}.
 }
 \seealso{
 Other Deployment functions: 

--- a/man/deployAPI.Rd
+++ b/man/deployAPI.Rd
@@ -8,7 +8,8 @@ deployAPI(api, ...)
 }
 \arguments{
 \item{api}{Path to the API project directory. Must contain either
-\code{entrypoint.R} or \code{plumber.R}}
+\code{entrypoint.R} or \code{plumber.R} (for plumber APIs) or \verb{_server.yml} (for
+plumber2 APIs)}
 
 \item{...}{Additional arguments to \code{\link[=deployApp]{deployApp()}}.}
 }

--- a/tests/testthat/_snaps/appDependencies.md
+++ b/tests/testthat/_snaps/appDependencies.md
@@ -25,11 +25,16 @@
     Output
       [1] "shiny"
     Code
-      inferRPackageDependencies(simulateMetadata("api"))
+      inferRPackageDependencies(simulateMetadata("api", plumberInfo = "plumber"))
     Output
       [1] "plumber"
     Code
-      inferRPackageDependencies(simulateMetadata("api", documentsHavePython = TRUE))
+      inferRPackageDependencies(simulateMetadata("api", documentsHavePython = TRUE,
+        plumberInfo = "plumber"))
     Output
       [1] "plumber"    "reticulate"
+    Code
+      inferRPackageDependencies(simulateMetadata("api", plumberInfo = "plumber2"))
+    Output
+      [1] "plumber2"
 

--- a/tests/testthat/test-appDependencies.R
+++ b/tests/testthat/test-appDependencies.R
@@ -86,12 +86,14 @@ test_that("infers correct packages for each source", {
   simulateMetadata <- function(
     appMode,
     hasParameters = FALSE,
-    documentsHavePython = FALSE
-  ) {
+    documentsHavePython = FALSE,
+    plumberInfo = NULL
+    ) {
     list(
       appMode = appMode,
       hasParameters = hasParameters,
-      documentsHavePython = documentsHavePython
+      documentsHavePython = documentsHavePython,
+      plumberInfo = plumberInfo
     )
   }
 
@@ -106,10 +108,12 @@ test_that("infers correct packages for each source", {
     inferRPackageDependencies(simulateMetadata("quarto-shiny"))
     inferRPackageDependencies(simulateMetadata("rmd-shiny"))
     inferRPackageDependencies(simulateMetadata("shiny"))
-    inferRPackageDependencies(simulateMetadata("api"))
+    inferRPackageDependencies(simulateMetadata("api", plumberInfo = "plumber"))
     inferRPackageDependencies(simulateMetadata(
       "api",
-      documentsHavePython = TRUE
+      documentsHavePython = TRUE,
+      plumberInfo = "plumber"
     ))
+    inferRPackageDependencies(simulateMetadata("api", plumberInfo = "plumber2"))
   })
 })

--- a/tests/testthat/test-appDependencies.R
+++ b/tests/testthat/test-appDependencies.R
@@ -88,7 +88,7 @@ test_that("infers correct packages for each source", {
     hasParameters = FALSE,
     documentsHavePython = FALSE,
     plumberInfo = NULL
-    ) {
+  ) {
     list(
       appMode = appMode,
       hasParameters = hasParameters,

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -116,18 +116,6 @@ test_that("correct extra packages for APIs are detected", {
   expect_null(metadata_other$plumberInfo, "other")
 })
 
-test_that("appMetadata errors if both _server.yml and _server.yaml are present", {
-  dir <- local_temp_app(
-    list(
-      "_server.yml" = "engine: 'plumber2'",
-      "_server.yaml" = "engine: 'plumber2'"
-    )
-  )
-  files <- list.files(dir)
-  expect_error(appMetadata(dir, files))
-})
-
-
 # checkLayout -------------------------------------------------------------
 
 # inferAppMode ------------------------------------------------------------
@@ -391,39 +379,29 @@ test_that("Rmd or qmd with python chunk has python", {
   expect_true(detectPythonInDocuments(dir))
 })
 
-# apiIsPlumber2 -----------------------------------------------------------
+# inferPlumberInfo --------------------------------------------------------
 
-test_that("apiIsPlumber2 looks for _server.yml", {
-  local_mocked_bindings(list.files = function(...) {
-    c("_server.yml", ".Rprofile", "plumber.R")
-  })
-  expect_true(apiIsPlumber2(tempdir()))
+test_that("inferPlumberInfo returns engine from _server.yml", {
+  dir <- local_temp_app(list("_server.yml" = "engine: 'plumber2'"))
+  expect_equal(inferPlumberInfo(dir), "plumber2")
 })
 
-test_that("apiIsPlumber2 looks for _server.yaml", {
-  local_mocked_bindings(list.files = function(...) {
-    c("_server.yaml", ".Rprofile", "plumber.R")
-  })
-  expect_true(apiIsPlumber2(tempdir()))
+test_that("inferPlumberInfo returns engine from _server.yaml", {
+  dir <- local_temp_app(list("_server.yaml" = "engine: 'plumber2'"))
+  expect_equal(inferPlumberInfo(dir), "plumber2")
 })
 
-test_that("apiIsPlumber2 doesn't return TRUE for yaml files with different names", {
-  local_mocked_bindings(list.files = function(...) {
-    c("test_server.yml", "_server.yml.backup")
-  })
-  expect_false(apiIsPlumber2(tempdir()))
+test_that("inferPlumberInfo returns 'plumber' for plumber APIs", {
+  dir <- local_temp_app(list("plumber.R" = ""))
+  expect_equal(inferPlumberInfo(dir), "plumber")
 })
 
-test_that("apiIsPlumber returns FALSE for regular plumber APIs (plumber.R)", {
-  local_mocked_bindings(list.files = function(...) {
-    c("plumber.R", "anotherfile.R")
-  })
-  expect_false(apiIsPlumber2(tempdir()))
-})
-
-test_that("apiIsPlumber returns FALSE for regular plumber APIs (entrypoint.R)", {
-  local_mocked_bindings(list.files = function(...) {
-    c("entrypoint.R", "anotherfile.R")
-  })
-  expect_false(apiIsPlumber2(tempdir()))
+test_that("inferPlumberInfo errors if both _server.yml and _server.yaml present", {
+  dir <- local_temp_app(
+    list(
+      "_server.yml" = "engine: 'plumber2'",
+      "_server.yaml" = "engine: 'plumber2'"
+    )
+  )
+  expect_error(inferPlumberInfo(dir))
 })

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -363,6 +363,8 @@ test_that("Rmd or qmd with python chunk has python", {
   expect_true(detectPythonInDocuments(dir))
 })
 
+# apiIsPlumber2 -----------------------------------------------------------
+
 test_that("apiIsPlumber2 looks for _server.yaml", {
   local_mocked_bindings(list.files = function(...) {
     c("_server.yml", ".Rprofile", "plumber.R")

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -116,6 +116,17 @@ test_that("correct extra packages for APIs are detected", {
   expect_null(metadata_other$plumberInfo, "other")
 })
 
+test_that("appMetadata errors if both _server.yml and _server.yaml are present", {
+  dir <- local_temp_app(
+    list(
+      "_server.yml" = "engine: 'plumber2'",
+      "_server.yaml" = "engine: 'plumber2'"
+    )
+  )
+  files <- list.files(dir)
+  expect_error(appMetadata(dir, files))
+})
+
 
 # checkLayout -------------------------------------------------------------
 
@@ -389,7 +400,12 @@ test_that("apiIsPlumber2 looks for _server.yml", {
   expect_true(apiIsPlumber2(tempdir()))
 })
 
-test_that("apiIsPlumber2 ", {
+test_that("apiIsPlumber2 looks for _server.yaml", {
+  local_mocked_bindings(list.files = function(...) {
+    c("_server.yaml", ".Rprofile", "plumber.R")
+  })
+  expect_true(apiIsPlumber2(tempdir()))
+})
 
 test_that("apiIsPlumber2 doesn't return TRUE for yaml files with different names", {
   local_mocked_bindings(list.files = function(...) {

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -99,6 +99,23 @@ test_that("Shiny Quarto with the jupyter engine is OK", {
   expect_contains(metadata$quartoInfo$engines, "jupyter")
 })
 
+test_that("correct extra packages for APIs are detected", {
+  dir_plumber <- local_temp_app(list("plumber.R" = ""))
+  files_plumber <- list.files(dir_plumber)
+  metadata_plumber <- appMetadata(dir_plumber, files_plumber)
+  expect_equal(metadata_plumber$plumberInfo, "plumber")
+
+  dir_plumber2 <- local_temp_app(list("_server.yml" = "engine: 'plumber2'"))
+  files_plumber2 <- list.files(dir_plumber2)
+  metadata_plumber2 <- appMetadata(dir_plumber2, files_plumber2)
+  expect_equal(metadata_plumber2$plumberInfo, "plumber2")
+
+  dir_other <- local_temp_app(list("app.R" = ""))
+  files_other <- list.files(dir_other)
+  metadata_other <- appMetadata(dir_other, files_other)
+  expect_null(metadata_other$plumberInfo, "other")
+})
+
 
 # checkLayout -------------------------------------------------------------
 

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -370,6 +370,13 @@ test_that("apiIsPlumber2 looks for _server.yaml", {
   expect_true(apiIsPlumber2(tempdir()))
 })
 
+test_that("apiIsPlumber2 ", {
+  local_mocked_bindings(list.files = function(...) {
+    c("test_server.yml", "_server.yml.backup")
+  })
+  expect_false(apiIsPlumber2(tempdir()))
+})
+
 test_that("apiIsPlumber returns FALSE for regular plumber APIs (plumber.R)", {
   local_mocked_bindings(list.files = function(...) {
     c("plumber.R", "anotherfile.R")

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -362,3 +362,24 @@ test_that("Rmd or qmd with python chunk has python", {
   dir <- local_temp_app(list("foo.qmd" = c("```{python}", "1+1", "````")))
   expect_true(detectPythonInDocuments(dir))
 })
+
+test_that("apiIsPlumber2 looks for _server.yaml", {
+  local_mocked_bindings(list.files = function(...) {
+    c("_server.yml", ".Rprofile", "plumber.R")
+  })
+  expect_true(apiIsPlumber2(tempdir()))
+})
+
+test_that("apiIsPlumber returns FALSE for regular plumber APIs (plumber.R)", {
+  local_mocked_bindings(list.files = function(...) {
+    c("plumber.R", "anotherfile.R")
+  })
+  expect_false(apiIsPlumber2(tempdir()))
+})
+
+test_that("apiIsPlumber returns FALSE for regular plumber APIs (entrypoint.R)", {
+  local_mocked_bindings(list.files = function(...) {
+    c("entrypoint.R", "anotherfile.R")
+  })
+  expect_false(apiIsPlumber2(tempdir()))
+})

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -382,7 +382,7 @@ test_that("Rmd or qmd with python chunk has python", {
 
 # apiIsPlumber2 -----------------------------------------------------------
 
-test_that("apiIsPlumber2 looks for _server.yaml", {
+test_that("apiIsPlumber2 looks for _server.yml", {
   local_mocked_bindings(list.files = function(...) {
     c("_server.yml", ".Rprofile", "plumber.R")
   })
@@ -390,6 +390,8 @@ test_that("apiIsPlumber2 looks for _server.yaml", {
 })
 
 test_that("apiIsPlumber2 ", {
+
+test_that("apiIsPlumber2 doesn't return TRUE for yaml files with different names", {
   local_mocked_bindings(list.files = function(...) {
     c("test_server.yml", "_server.yml.backup")
   })


### PR DESCRIPTION
Updates `appDependencies()` to determine whether plumber or plumber2 (or another package provided as the engine in a plumber2 `_server.yml` file) is needed. 

Also removes `deployAPI()`'s check for plumber. I believe in our discussions we settled on feeling ok about removing this check altogether, however we could alternatively rewrite it to:

```
if (apiIsPlumber2(api)) { 
  # check for plumber 2
} else { 
  # check for plumber
}
```

Closes #1151, closes #1170.