### PR TITLE
Skip tests if suggested package isn't installed

### DIFF
--- a/tests/testthat/test-bundlePackagePackrat.R
+++ b/tests/testthat/test-bundlePackagePackrat.R
@@ -44,6 +44,7 @@ test_that("recommended packages are snapshotted", {
 test_that("works with BioC packages", {
   skip_on_cran()
   skip_on_ci()
+  skip_if_not_installed("Biobase")
   app <- local_temp_app(list(
     "index.Rmd" = c(
       "```{r}",

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -45,6 +45,8 @@ test_that("extra packages are snapshotted", {
 test_that("works with BioC packages", {
   skip_on_cran()
   skip_on_ci()
+  skip_if_not_installed("BiocManager")
+  skip_if_not_installed("Biobase")
 
   app <- local_temp_app(list(
     "index.R" = c(


### PR DESCRIPTION
These two tests expect BiocManager and/or Biobase to be installed. These are suggested packages in rsconnect's DESCRIPTION so may not be available. This PR adds `skip_if_not_installed()` in order to run them conditionally.