### PR TITLE
feat: add empty integrations field to manifest upon `writeManifest`

### DIFF
--- a/R/writeManifest.R
+++ b/R/writeManifest.R
@@ -73,6 +73,7 @@ writeManifest <- function(
     verbose = verbose,
     quiet = quiet
   )
+  manifest$integrations <- list()
   manifestJson <- toJSON(manifest)
   manifestPath <- file.path(appDir, "manifest.json")
   writeLines(manifestJson, manifestPath, useBytes = TRUE)

--- a/tests/testthat/test-writeManifest.R
+++ b/tests/testthat/test-writeManifest.R
@@ -530,3 +530,11 @@ test_that("content type (appMode) is inferred and can be overridden", {
   expect_equal(manifest$metadata$appmode, "static")
   expect_named(manifest$files, files)
 })
+
+
+test_that("empty integrations field is added", {
+  appDir <- test_path("shinyapp-simple")
+
+  manifest <- makeManifest(appDir)
+  expect_equal(manifest$integrations, list())
+})


### PR DESCRIPTION
## Intent

Add empty array "integrations" field to the manifest upon writeManifest. This is part of the work around auto-associating integrations with content upon deployment. See the main [ticket](https://github.com/posit-dev/connect/issues/32666) for more information.

Fixes: [#32836](https://github.com/posit-dev/connect/issues/32836)

## Approach
adds empty "integrations" list field to manifest

## Automated Tests

Added additional unit test to check for the empty integrations field.

`devtools::test()` passes 

