### PR TITLE
fix: defer obtaining snowflake token

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rsconnect (development version)
 
+* Address user registration for Posit Connect deployments hosted in Snowpark
+  Container Services when there is more than one configured Snowflake
+  connection. (#1189)
 * Removed unused internal methods from Connect client. (#1182)
 
 # rsconnect 1.5.0

--- a/R/accounts.R
+++ b/R/accounts.R
@@ -120,10 +120,7 @@ getSPCSAuthedUser <- function(server, snowflakeConnectionName) {
   serverAddress <- serverInfo(server)
   account <- list(
     server = server,
-    snowflakeToken = getSnowflakeAuthToken(
-      serverAddress$url,
-      snowflakeConnectionName
-    )
+    snowflakeConnectionName = snowflakeConnectionName
   )
 
   client <- clientForAccount(account)


### PR DESCRIPTION
Provide the Snowflake connection name to clientForAccount from getSPCSAuthedUser. Previously, getSPCSAuthedUser computed a Snowflake token, which was overwritten by clientForAccount using a token always associated with the default connection.

fixes #1189