### PR TITLE
fix: parse expires cookie header

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 * Address user registration for Posit Connect deployments hosted in Snowpark
   Container Services when there is more than one configured Snowflake
   connection. (#1189)
+
+* Process cookie expiration dates in addition to the cookie max-age. Some
+  servers return already-expired cookies. (1187)
+
 * Removed unused internal methods from Connect client. (#1182)
 
 # rsconnect 1.5.0

--- a/tests/testthat/test-cookies.R
+++ b/tests/testthat/test-cookies.R
@@ -70,6 +70,25 @@ test_that("Parsing cookies works", {
   expect_equal(cookie$path, "/")
 })
 
+test_that("cookie parsing uses expires= when no max-age=", {
+  expect_equal(
+    parseCookie(
+      "mycookie=myvalue; Path=/; Secure; HttpOnly; Expires=Sat, 24 Jun 2017 16:16:05 GMT"
+    ),
+    list(
+      name = "mycookie",
+      value = "myvalue",
+      expires = strptime(
+        "Sat, 24 Jun 2017 16:16:05 GMT",
+        "%a, %d %b %Y %H:%M:%S GMT",
+        "GMT"
+      ),
+      path = "/",
+      secure = TRUE
+    )
+  )
+})
+
 test_that("Invalid cookies fail parsing", {
   # Invalid path, doesn't match request's path
   expect_snapshot(cookie <- parseCookie("x=1; Path=/something/else", "/path"))


### PR DESCRIPTION
Use the expires= value when max-age= is not present.

Snowflake endpoints return headers with an expiration of `expires=Thu, 01 Jan 1970 00:00:00 GMT` when presented with no auth.

Previously, rsconnect ignored expires= and treated these cookies as "session" cookies, always valid in the current R session.

fixes #1187