### PR TITLE
tests: use expect_in rather than expect_contains

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -171,8 +171,5 @@ expect_known_manifest_fields <- function(manifest) {
     "files",
     "users"
   )
-  testthat::expect_contains(
-    known_fields,
-    names(manifest)
-  )
+  expect_in(names(manifest), known_fields)
 }


### PR DESCRIPTION
lets the manifest names become the "actual" rather than the "expected".