### PR TITLE
fix: increase rsconnect.max.bundle.size

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rsconnect (development version)
 
+* Increase the default `rsconnect.max.bundle.size` limit to 5 GiB. (#1200)
+
 # rsconnect 1.5.1
 
 * Address user registration for Posit Connect deployments hosted in Snowpark

--- a/R/bundleFiles.R
+++ b/R/bundleFiles.R
@@ -228,7 +228,7 @@ isPythonEnv <- function(dir, files) {
 }
 
 enforceBundleLimits <- function(appDir, totalFiles, totalSize) {
-  maxSize <- getOption("rsconnect.max.bundle.size", 3000 * 1024^2)
+  maxSize <- getOption("rsconnect.max.bundle.size", 5 * 1024^3)
   maxFiles <- getOption("rsconnect.max.bundle.files", 10000)
 
   if (totalSize > maxSize) {
@@ -236,7 +236,9 @@ enforceBundleLimits <- function(appDir, totalFiles, totalSize) {
       "{.arg appDir} ({.path {appDir}}) is too large to be deployed.",
       x = "The maximum size is {maxSize} bytes.",
       x = "This directory is at least {totalSize} bytes.",
-      i = "Remove some files or adjust the rsconnect.max.bundle.size option."
+      i = "Remove some files or adjust the rsconnect.max.bundle.size option.",
+      " " = "e.g., options(rsconnect.max.bundle.size = 6 * 1024^3)",
+      " " = "See {.topic rsconnect::rsconnectOptions} for additional guidance."
     ))
   }
 
@@ -245,7 +247,9 @@ enforceBundleLimits <- function(appDir, totalFiles, totalSize) {
       "{.arg appDir} ({.path {appDir}}) is too large to be deployed.",
       x = "The maximum number of files is {maxFiles}.",
       x = "This directory contains at least {totalFiles} files.",
-      i = "Remove some files or adjust the rsconnect.max.bundle.files option."
+      i = "Remove some files or adjust the rsconnect.max.bundle.files option.",
+      " " = "e.g., options(rsconnect.max.bundle.files = 15000)",
+      " " = "See {.topic rsconnect::rsconnectOptions} for additional guidance."
     ))
   }
 }

--- a/tests/testthat/_snaps/bundleFiles.md
+++ b/tests/testthat/_snaps/bundleFiles.md
@@ -86,6 +86,8 @@
       x The maximum number of files is 1.
       x This directory contains at least 2 files.
       i Remove some files or adjust the rsconnect.max.bundle.files option.
+        e.g., options(rsconnect.max.bundle.files = 15000)
+        See `?rsconnect::rsconnectOptions` for additional guidance.
     Code
       explodeFiles(dir, "c")
     Condition
@@ -94,6 +96,8 @@
       x The maximum size is 5 bytes.
       x This directory is at least ?? bytes.
       i Remove some files or adjust the rsconnect.max.bundle.size option.
+        e.g., options(rsconnect.max.bundle.size = 6 * 1024^3)
+        See `?rsconnect::rsconnectOptions` for additional guidance.
 
 # detectLongNames produces informative warning if needed
 


### PR DESCRIPTION
additionally, direct folks to `rsconnect::rsconnectOptions` for guidance about where they could set this option.

fixes #1200
fixes #1201
