### PR TITLE
set bundle limit option defaults on load

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,4 +57,4 @@ Config/testthat/edition: 3
 Config/testthat/parallel: true
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rsconnect (development version)
 
+* `rsconnect` now sets the `rsconnect.max.bundle.size` and
+  `rsconnect.max.bundle.files` options to their default values on startup
+  if they have not yet been set. (#1204)
+
 * Increase the default `rsconnect.max.bundle.size` limit to 5 GiB. (#1200)
 
 # rsconnect 1.5.1

--- a/R/bundleFiles.R
+++ b/R/bundleFiles.R
@@ -228,8 +228,8 @@ isPythonEnv <- function(dir, files) {
 }
 
 enforceBundleLimits <- function(appDir, totalFiles, totalSize) {
-  maxSize <- getOption("rsconnect.max.bundle.size", 5 * 1024^3)
-  maxFiles <- getOption("rsconnect.max.bundle.files", 10000)
+  maxSize <- getOption("rsconnect.max.bundle.size", defaultMaxBundleSize)
+  maxFiles <- getOption("rsconnect.max.bundle.files", defaultMaxBundleFiles)
 
   if (totalSize > maxSize) {
     cli::cli_abort(c(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,29 @@
+
+defaultMaxBundleSize <- 5 * 1024^3
+defaultMaxBundleFiles <- 10000
+
+setOptionDefaults <- function(...) {
+
+  # Resolve dots
+  defaultOptions <- list(...)
+
+  # Get current options
+  currentOptions <- options()
+
+  # Remove any options which have already been set
+  alreadySet <- names(defaultOptions) %in% names(currentOptions)
+  defaultOptions <- defaultOptions[!alreadySet]
+
+  # Set the defaults
+  options(defaultOptions)
+
+}
+
+.onLoad <- function(libname, pkgname) {
+
+  setOptionDefaults(
+    rsconnect.max.bundle.size  = defaultMaxBundleSize,
+    rsconnect.max.bundle.files = defaultMaxBundleFiles
+  )
+
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,9 +1,7 @@
-
 defaultMaxBundleSize <- 5 * 1024^3
 defaultMaxBundleFiles <- 10000
 
 setOptionDefaults <- function(...) {
-
   # Resolve dots
   defaultOptions <- list(...)
 
@@ -16,14 +14,11 @@ setOptionDefaults <- function(...) {
 
   # Set the defaults
   options(defaultOptions)
-
 }
 
 .onLoad <- function(libname, pkgname) {
-
   setOptionDefaults(
-    rsconnect.max.bundle.size  = defaultMaxBundleSize,
+    rsconnect.max.bundle.size = defaultMaxBundleSize,
     rsconnect.max.bundle.files = defaultMaxBundleFiles
   )
-
 }


### PR DESCRIPTION
Closes https://github.com/rstudio/rsconnect/issues/1204.

If we didn't want to do this automatic on-load setting (e.g. because we were worried about existing user code that expected those options to be `NULL`?) then we could just provide the default values as variables, and document that they might be used by external applications. (So, part of the API but not exported / public.)