### PR TITLE
fix: include python binary path in inspection errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
 
 * Increase the default `rsconnect.max.bundle.size` limit to 5 GiB. (#1200)
 
+* The target Python binary is included in Python environment inspection
+  errors. (#1207)
+
 # rsconnect 1.5.1
 
 * Address user registration for Posit Connect deployments hosted in Snowpark

--- a/R/bundlePython.R
+++ b/R/bundlePython.R
@@ -16,7 +16,7 @@ pythonConfigurator <- function(python, forceGenerate = FALSE) {
       ),
       error = function(err) {
         cli::cli_abort(
-          "Failed to detect python environment",
+          "Failed to detect python environment using {.val {python}}",
           parent = err
         )
       }


### PR DESCRIPTION
related to #1207, #1143 

This change will help us understand what Python installation is being referenced during deployment by RStudio.

```
> rsconnect::writeManifest(python="notpython")
ℹ Capturing R dependencies
✔ Found 36 dependencies
Error in `pythonConfig()` at rsconnect/R/bundle.R:207:5:
! Failed to detect python environment using "notpython"
Caused by error in `system2()`:
! error in running command
Run `rlang::last_trace()` to see where the error occurred.
```