### PR TITLE
fix: envVars enforcement and documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 * The target Python binary is included in Python environment inspection
   errors. (#1207)
 
+* Improved documentation and advice for `deployApp(envVars...)`.
+
 # rsconnect 1.5.1
 
 * Address user registration for Posit Connect deployments hosted in Snowpark

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -74,12 +74,18 @@ Connect only). The values of the environment variables are sent over an
 encrypted connection and are not stored in the bundle, making this a safe
 way to send private data to Connect.
 
+The values of sensitive environment variables should be set in the current
+session via an \code{.Renviron} file or with the help of a credential store like
+\href{https://r-lib.github.io/keyring/index.html}{keyring}. Avoid using
+\code{\link[=Sys.setenv]{Sys.setenv()}} for sensitive values, as that results in the value appearing
+in your \code{.Rhistory}.
+
 The names (not values) are stored in the deployment record so that future
 deployments will automatically update their values. Other environment
 variables on the server will not be affected. This means that removing an
 environment variable from \code{envVars} will leave it unchanged on the server.
 To remove it, either delete it using the Connect UI, or temporarily unset
-it (with \code{Sys.unsetenv()} or similar) then re-deploy.
+it (with \code{\link[=Sys.unsetenv]{Sys.unsetenv()}} or similar) then re-deploy.
 
 Environment variables are set prior to deployment so that your code
 can use them and the first deployment can still succeed. Note that means

--- a/tests/testthat/_snaps/deployApp.md
+++ b/tests/testthat/_snaps/deployApp.md
@@ -79,3 +79,13 @@
       2: Delete existing deployment & create a new app
       Selection: 2
 
+# deployApp() errors if envVars is given a named vector
+
+    Code
+      deployApp(local_temp_app(), envVars = c(FLAG = "true"))
+    Condition
+      Error in `deployApp()`:
+      ! `envVars` must be a character vector containing only environment variable names.
+      i Set environment variables with `Sys.setenv() or an `.Renviron` file.
+      i Use `unname()` to remove the names from the vector passed to `envVars`.
+

--- a/tests/testthat/test-deployApp.R
+++ b/tests/testthat/test-deployApp.R
@@ -108,3 +108,11 @@ test_that("applicationDeleted() errors or prompts as needed", {
   expect_snapshot(. <- applicationDeleted(client, target, app))
   expect_length(dir(app, recursive = TRUE), 0)
 })
+
+# envvars -----------------------------------------------------------------
+
+test_that("deployApp() errors if envVars is given a named vector", {
+  expect_snapshot(error = TRUE, {
+    deployApp(local_temp_app(), envVars = c("FLAG" = "true"))
+  })
+})


### PR DESCRIPTION
Replaces https://github.com/rstudio/rsconnect/pull/994

Took the changes from https://github.com/rstudio/rsconnect/pull/994 and made minor documentation adjustments.

* envVars must be an unnamed character vector.
* envVars is only supported for Connect (adjust length check).

```
> rsconnect::deployApp(appName = "shiny", server = "shinyapps.io", envVars = c(21))
Error in `rsconnect::deployApp()`:
! `envVars` must be a character vector or `NULL`, not the number 21.
Run `rlang::last_trace()` to see where the error occurred.

> rsconnect::deployApp(appName = "shiny", server = "shinyapps.io", envVars = c(VAL="21"))
Error in `rsconnect::deployApp()`:
! `envVars` must be a character vector containing only environment variable names.
ℹ Set environment variables with `Sys.setenv() or an `.Renviron` file.
ℹ Use `unname()` to remove the names from the vector passed to `envVars`.
Run `rlang::last_trace()` to see where the error occurred.

> rsconnect::deployApp(appName = "shiny", server = "shinyapps.io", envVars = c("VAL"))
...
Error in `rsconnect::deployApp()`:
! shinyapps.io does not support setting `envVars`
Run `rlang::last_trace()` to see where the error occurred.
```