### PR TITLE
fix: ignore expires= values which cannot be parsed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,9 @@
 * The target Python binary is included in Python environment inspection
   errors. (#1207)
 
-* Improved documentation and advice for `deployApp(envVars...)`.
+* Improve cookie expiration date handling. (#1212)
+
+* Improve documentation and advice for `deployApp(envVars...)`.
 
 # rsconnect 1.5.1
 


### PR DESCRIPTION
Both strptime and curl::parse_date return NA when the incoming date cannot be parsed. Ignore NA results and treat those cookies as session cookies.

Shift to curl::parse_date because it recognizes more date formats.

Add tests showing treatment of expires= values which are not valid dates.

Fixes #1212