### PR TITLE
fix envvars

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -389,11 +389,8 @@ deployApp <- function(
   client <- clientForAccount(accountDetails)
 
   if (
-    # Connect Cloud supports setting environment variables, but not through a
-    # setEnvVars client method
-    !isPositConnectCloudServer(accountDetails$server) &&
-      length(envVars) > 0 &&
-      !"setEnvVars" %in% names(client)
+    !serverSupportsEnvVars(accountDetails$server, client) &&
+      length(envVars) > 0
   ) {
     cli::cli_abort(
       "{accountDetails$server} does not support setting {.arg envVars}"
@@ -660,6 +657,15 @@ deployApp <- function(
   logger("Deployment log finished")
 
   invisible(deploymentSucceeded)
+}
+
+serverSupportsEnvVars <- function(server, client) {
+  return(
+    # Connect Cloud supports setting environment variables, but not through a
+    # setEnvVars client method
+    isPositConnectCloudServer(server) ||
+      (isConnectServer(server) && "setEnvVars" %in% names(client))
+  )
 }
 
 taskStart <- function(quiet, message, .envir = caller_env()) {


### PR DESCRIPTION
Resolves https://github.com/rstudio/rsconnect/issues/1221.

After making this change I was able to test by running:
```R
Sys.setenv('WHEE' = 'yay')
deployApp(appDir='/Users/matthew/code/posit/hosted/examples-shiny-r', account='mslynch', envVars=c('WHEE'))
```