### PR TITLE
use rsconnect-specific oauth client

### DIFF
--- a/R/client-cloudAuth.R
+++ b/R/client-cloudAuth.R
@@ -2,9 +2,9 @@
 getClientId <- function() {
   switch(
     connectCloudEnvironment(),
-    production = "posit-publisher",
-    staging = "posit-publisher-staging",
-    development = "posit-publisher-development",
+    production = "rsconnect",
+    staging = "rsconnect-staging",
+    development = "rsconnect-development",
   )
 }
 


### PR DESCRIPTION
Use the designated oauth client for rsconnect, instead of the one for Publisher.