### PR TITLE
Sending the appMode in the update requests for publishing to PCC

### DIFF
--- a/R/client-connectCloud.R
+++ b/R/client-connectCloud.R
@@ -158,7 +158,8 @@ connectCloudClient <- function(service, authInfo) {
       contentId,
       envVars,
       newBundle = FALSE,
-      primaryFile
+      primaryFile,
+      appMode
     ) {
       path <- paste0("/contents/", contentId)
       if (newBundle) {
@@ -179,7 +180,8 @@ connectCloudClient <- function(service, authInfo) {
       json <- list(
         secrets = secrets,
         revision_overrides = list(
-          primary_file = primaryFile
+          primary_file = primaryFile,
+          app_mode = appMode
         )
       )
 

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -520,7 +520,8 @@ deployApp <- function(
         application$id,
         deployment$envVars,
         newBundle = upload,
-        primaryFile
+        primaryFile,
+        appMetadata$appMode
       )
       taskComplete(quiet, "Content updated")
     }


### PR DESCRIPTION
Resolves #1233 

Adding the `appMode` to the update request when deploying updated content to Posit connect Cloud. This fix is needed to support the `appMode` changing for the content in the update like in the `deploySite()` case. When deploying a site one may specify the `render` parm to be `server`, this means the site should be rendered on the server and in this case `appMode` will be set to `quarto-static`. However if the `render` param is not specified then the site must be pre-rendered locally and in this case the `appMode` will be set to `static`. Therefore, before this change the changing `appMode` was not being registered by Posit Connect Cloud because the content updates (the 2nd publish and later) would always use the original `appMode` sent on the initial content create request.