### PR TITLE
fix: skip signature testing on CRAN

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rsconnect (development version)
 
+* Address CRAN test failures with some versions seen with some openssl
+  configurations. (#1255)
+
 # rsconnect 1.6.1
 
 * Fix account registration from RStudio. (#1250)

--- a/tests/testthat/test-http.R
+++ b/tests/testthat/test-http.R
@@ -6,6 +6,8 @@ test_that("non-libCurl methods are deprecated", {
 # headers -----------------------------------------------------------------
 
 test_that("authHeaders() picks correct method based on supplied fields", {
+  skip_on_cran() # CRAN may not have an openssl that permits SHA-1 signatures.
+
   url <- "https://example.com"
 
   expect_equal(


### PR DESCRIPTION
some installations have openssl configurations which prohibit SHA-1 signatures.

fixes #1255