### PR TITLE
feat: make snowflakeConnectionName optional for some cases

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,11 @@
   `discoverServer()`, as well as HTTP backends other than libcurl,
   which were deprecated in rsconnect 1.0.0. (#1282)
 
+* The `snowflakeConnectionName` parameter now respects the default Snowflake
+  connection name in the `connections.toml` file (when it exists), making it
+  optional in many cases. This is only applicable to Connect servers hosted on
+  Snowflake.
+
 # rsconnect 1.7.0
 
 * Added support for deploying from `manifest.json` files created by

--- a/R/accounts.R
+++ b/R/accounts.R
@@ -100,21 +100,30 @@ connectApiUser <- function(
 #' authentication to reach the Connect server, while the API key identifies
 #' the user to Connect itself.
 #'
+#' If `snowflakeConnectionName` is not provided, \pkg{rsconnect} will attempt to
+#' use the default Snowflake connection from the `connections.toml` file,
+#' provided that the account matches the Connect server's URL.
+#'
 #' Supported servers: Posit Connect servers
 #'
 #' @inheritParams connectApiUser
-#' @param snowflakeConnectionName Name for the Snowflake connection parameters
-#'   stored in `connections.toml`.
+#' @param snowflakeConnectionName Name of the Snowflake connection in
+#'   `connections.toml` to use for authentication or `NULL` to use the default
+#'   (when applicable).
 #' @export
 connectSPCSUser <- function(
   account = NULL,
   server = NULL,
   apiKey,
-  snowflakeConnectionName,
+  snowflakeConnectionName = NULL,
   quiet = FALSE
 ) {
   server <- findServer(server)
   checkConnectServer(server)
+
+  serverUrl <- serverInfo(server)$url
+  snowflakeConnectionName <- snowflakeConnectionName %||%
+    getDefaultSnowflakeConnectionName(serverUrl)
 
   user <- getSPCSAuthedUser(server, apiKey, snowflakeConnectionName)
 

--- a/R/ide.R
+++ b/R/ide.R
@@ -3,7 +3,12 @@
 # This function is poorly named because as well as validating the server
 # url it will also register the server if needed.
 validateServerUrl <- function(url, certificate = NULL) {
-  res <- validateConnectUrl(url, certificate)
+  snowflakeConnectionName <- NULL
+  if (isSPCSUrl(url)) {
+    snowflakeConnectionName <- getDefaultSnowflakeConnectionName(url)
+  }
+
+  res <- validateConnectUrl(url, certificate, snowflakeConnectionName)
 
   if (res$valid) {
     name <- findAndRegisterLocalServer(res$url)

--- a/man/addServer.Rd
+++ b/man/addServer.Rd
@@ -31,8 +31,9 @@ character vector containing the certificate's contents.}
 \item{validate}{Validate that \code{url} actually points to a Posit Connect
 server?}
 
-\item{snowflakeConnectionName}{Name for the Snowflake connection parameters
-stored in \code{connections.toml}.}
+\item{snowflakeConnectionName}{Name for the Snowflake connection in
+\code{connections.toml} to use for authentication or \code{NULL} to use the default
+(when applicable).}
 
 \item{quiet}{Suppress output and prompts where possible.}
 }

--- a/man/connectSPCSUser.Rd
+++ b/man/connectSPCSUser.Rd
@@ -8,7 +8,7 @@ connectSPCSUser(
   account = NULL,
   server = NULL,
   apiKey,
-  snowflakeConnectionName,
+  snowflakeConnectionName = NULL,
   quiet = FALSE
 )
 }
@@ -19,8 +19,9 @@ connectSPCSUser(
 
 \item{apiKey}{The API key used to authenticate the user}
 
-\item{snowflakeConnectionName}{Name for the Snowflake connection parameters
-stored in \code{connections.toml}.}
+\item{snowflakeConnectionName}{Name of the Snowflake connection in
+\code{connections.toml} to use for authentication or \code{NULL} to use the default
+(when applicable).}
 
 \item{quiet}{Whether or not to show messages and prompts while connecting the
 account.}
@@ -36,6 +37,10 @@ SPCS deployments require both Snowflake authentication (via the connection
 name) and a Posit Connect API key. The Snowflake token provides proxied
 authentication to reach the Connect server, while the API key identifies
 the user to Connect itself.
+
+If \code{snowflakeConnectionName} is not provided, \pkg{rsconnect} will attempt to
+use the default Snowflake connection from the \code{connections.toml} file,
+provided that the account matches the Connect server's URL.
 
 Supported servers: Posit Connect servers
 }

--- a/tests/testthat/_snaps/client-connect.md
+++ b/tests/testthat/_snaps/client-connect.md
@@ -44,3 +44,25 @@
     Code
       invisible(client$waitForTask(42, quiet = TRUE))
 
+# getDefaultSnowflakeConnectionName errors when default connection doesn't match server
+
+    Code
+      getDefaultSnowflakeConnectionName(
+        "https://prefix-org-account.snowflakecomputing.app/__api__")
+    Condition
+      Error in `getDefaultSnowflakeConnectionName()`:
+      ! The default Snowflake connection account "different-xyz789" does not appear to match the Connect server.
+      i Pass `snowflakeConnectionName` to use a different connection.
+
+# getDefaultSnowflakeConnectionName errors when no default connection exists
+
+    Code
+      getDefaultSnowflakeConnectionName(
+        "https://prefix-org-account.snowflakecomputing.app/__api__")
+    Condition
+      Error in `getDefaultSnowflakeConnectionName()`:
+      ! No default `snowflakeConnectionName`.
+      i Provide `snowflakeConnectionName` explicitly.
+      Caused by error in `snowflakeauth::snowflake_connection()`:
+      ! No default connection configured
+


### PR DESCRIPTION
This commit allows `addServer()` and `connectSPCSUser()` to provide a default for the `snowflakeConnectionName` parameter using the existing conventions for a default Snowflake connection. This should simplify programmatic deployment from RStudio, particularly in the Native App, where we can assume a default connection is available.

The default connection is only used when it appears to match the account used for the Connect server URL.

Unit tests are included.