### PR TITLE
fix: Allow browser authentication to Snowflake from the Deploy pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,8 @@
   Snowflake.
 
 * Push-button publishing from desktop RStudio is now compatible with Connect
-  servers hosted on Snowflake.
+  servers hosted on Snowflake. This includes support for browser-based
+  authentication during deployment. (#1289)
 
 * Added support for using identity federation to authenticate against Connect
   when running in Posit Workbench, when available. This allows deploying to

--- a/R/client-connect.R
+++ b/R/client-connect.R
@@ -165,6 +165,13 @@ getSnowflakeAuthToken <- function(url, snowflakeConnectionName) {
   parsedURL <- parseHttpUrl(url)
   ingressURL <- parsedURL$host
 
+  # Detect when we're running in the Deploy pane of RStudio and enable
+  # "interactive" temporarily so that external browser authentication is
+  # permitted.
+  if (rstudioapi::isBackgroundJob()) {
+    rlang::local_options(rlang_interactive = TRUE)
+  }
+
   token <- snowflakeauth::snowflake_credentials(
     snowflakeauth::snowflake_connection(snowflakeConnectionName),
     spcs_endpoint = ingressURL


### PR DESCRIPTION
The `snowflakeauth` package only permits external browser authentication from interactive contexts, which makes sense in most cases.

However, push-button deployments from the RStudio IDE actually run in a separate Deploy pane, not from the interactive console -- which isn't considered "interactive" by default.

So this commit tells `rlang` to temporarily treat this as an interactive context, which allows the browser flow to work.

This actually requires a change to the `snowflakeauth` package as well: https://github.com/posit-dev/snowflakeauth/commit/dbd4830f1db8cf4c73b59608d6289a60a280142f. We'll have to get another release of that package out to enable this fix to work properly.

Fixes #1289.