### PR TITLE
Disable shinyapps.io log streaming

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,12 @@
   when running in Posit Workbench, when available. This allows deploying to
   Connect servers without the need to store long-lived credentials.
 
+* Removed support for log streaming from shinyapps.io due to loss of support
+  for this feature on the shinyapps.io platform (`showLogs(streaming = TRUE)`).
+  If this feature is important to your workflow, please file an issue and we
+  will consider reintroduction of log streaming via rsconnect in Connect Cloud.
+  (#1292)
+
 # rsconnect 1.7.0
 
 * Added support for deploying from `manifest.json` files created by

--- a/man/showLogs.Rd
+++ b/man/showLogs.Rd
@@ -41,9 +41,9 @@ multiple servers.}
 
 \item{entries}{The number of log entries to show. Defaults to 50 entries.}
 
-\item{streaming}{Whether to stream the logs. If \code{TRUE}, then the
-function does not return; instead, log entries are written to the console
-as they are made, until R is interrupted. Defaults to \code{FALSE}.}
+\item{streaming}{Deprecated. Streaming logs is not currently supported
+as the ShinyApps.io backend no longer supports this feature. If \code{TRUE},
+an error will be thrown. Defaults to \code{FALSE}.}
 }
 \value{
 \code{getLogs()} returns a data frame containing the logged lines.


### PR DESCRIPTION
The backend has not properly supported this for a number of years. The removed code in this change was constantly polling the api instead, which generated unreasonable load.

Connect Cloud has a user logs endpoint with a near realtime streaming capability, we may reintroduce it there in future.

Fixes #1292 