### PR TITLE
fix: resolve pak-installed local packages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,9 @@
 * Resolved a bug where `renv.lock` files that had multiple repositories were not
   being translated faithfully when creating the manifest file. (#1268)
 
+* Packages installed locally via pak are resolved against configured
+  repositories. (#1305)
+
 * Added support for overriding R package repository resolution behavior. (#1272)
 
 * Push-button publishing from desktop RStudio is now compatible with Connect

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -152,7 +152,17 @@ standardizeRenvPackage <- function(
     }
   } else if (pkg$Source %in% c("Bitbucket", "GitHub", "GitLab")) {
     pkg$Source <- tolower(pkg$Source)
-  } else if (pkg$Source %in% c("Local", "unknown")) {
+  } else if (pkg$Source == "Local") {
+    # A locally-installed package (e.g. via pak "local::") may still be
+    # available from a configured repository. Make a best effort to locate
+    # it, the same way we handle packages installed from source.
+    pkg$Repository <- findRepoUrl(pkg$Package, availablePackages)
+    pkg$Source <- findRepoName(pkg$Repository, repos)
+    if (is.na(pkg$Source)) {
+      pkg$Source <- NA_character_
+      pkg$Repository <- NA_character_
+    }
+  } else if (pkg$Source == "unknown") {
     pkg$Source <- NA_character_
     pkg$Repository <- NA_character_
   }

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -282,7 +282,7 @@ test_that("packages available in multiple repos use the one from renv.lock", {
   )
 })
 
-test_that("source packages get NA source + repository", {
+test_that("unknown source packages get NA source + repository", {
   source <- list(Package = "pkg", Source = "unknown", Repository = "useless")
   expect_equal(
     standardizeRenvPackage(source),
@@ -290,10 +290,46 @@ test_that("source packages get NA source + repository", {
   )
 })
 
-test_that("Local packages get NA source + repository", {
-  source <- list(Package = "pkg", Source = "Local", Repository = "useless")
+test_that("Local packages resolve from a configured repo when available", {
+  pkg <- list(Package = "pkg", Version = "1.0.0", Source = "Local")
+
+  packages <- as.matrix(data.frame(
+    Package = "pkg",
+    Version = "1.0.0",
+    Repository = "https://cran.com/src/contrib",
+    stringsAsFactors = FALSE
+  ))
+  repos <- c(CRAN = "https://cran.com")
+
   expect_equal(
-    standardizeRenvPackage(source),
-    list(Package = "pkg", Source = NA_character_, Repository = NA_character_)
+    standardizeRenvPackage(pkg, packages, repos = repos),
+    list(
+      Package = "pkg",
+      Version = "1.0.0",
+      Source = "CRAN",
+      Repository = "https://cran.com"
+    )
+  )
+})
+
+test_that("Local packages get NA source + repository when not in any repo", {
+  pkg <- list(Package = "pkg", Version = "1.0.0", Source = "Local")
+
+  packages <- as.matrix(data.frame(
+    Package = "otherpkg",
+    Version = "1.0.0",
+    Repository = "https://cran.com/src/contrib",
+    stringsAsFactors = FALSE
+  ))
+  repos <- c(CRAN = "https://cran.com")
+
+  expect_equal(
+    standardizeRenvPackage(pkg, packages, repos = repos),
+    list(
+      Package = "pkg",
+      Version = "1.0.0",
+      Source = NA_character_,
+      Repository = NA_character_
+    )
   )
 })


### PR DESCRIPTION
renv treats `RemoteType: Local` differently than a vanilla source install.

fixes #1305