### PR TITLE
purge apps from shinyapps.io at end of test run

### DIFF
--- a/tests/shinyapps-integration/setup.R
+++ b/tests/shinyapps-integration/setup.R
@@ -25,8 +25,25 @@ rsconnect::setAccountInfo(
   secret = shinyapps_secret
 )
 
+# apps from this run will have names starting with this prefix. we use this on
+# cleanup to know which apps to purge from the test account.
+run_prefix <- paste(sample(c(letters, LETTERS, 0:9), 5), collapse = "")
+
 withr::defer(
   {
+    tryCatch(
+      {
+        apps <- applications(account = shinyapps_name)
+        to_purge <- apps[grepl(paste0("^", run_prefix), apps$name), "name"]
+        # purge applications from the current run
+        lapply(to_purge, purgeApp, account = shinyapps_name)
+      },
+      error = function(e) {
+        warning(
+          "Unable to clean up test applications from shinyapps.io account"
+        )
+      }
+    )
     removeAccount(shinyapps_name)
     # Clean up any rsconnect deployment artifacts
     files <- grep(

--- a/tests/shinyapps-integration/test-shinyapps-deploy.R
+++ b/tests/shinyapps-integration/test-shinyapps-deploy.R
@@ -1,5 +1,9 @@
 test_that("can deploy to shinyapps.io and terminate", {
-  app_name <- paste0("rsconnect-test-", strftime(Sys.time(), "%Y%m%d%H%M%S"))
+  app_name <- paste0(
+    run_prefix,
+    "-rsconnect-test-",
+    strftime(Sys.time(), "%Y%m%d%H%M%S")
+  )
   expect_no_error(
     deployApp(
       appDir = "example-shiny",

--- a/tests/shinyapps-integration/test-shinyapps-deploy.R
+++ b/tests/shinyapps-integration/test-shinyapps-deploy.R
@@ -1,6 +1,5 @@
-app_name <- paste0("rsconnect-test-", strftime(Sys.time(), "%Y%m%d%H%M%S"))
-
-test_that("deploy to shinyapps.io does not error", {
+test_that("can deploy to shinyapps.io and terminate", {
+  app_name <- paste0("rsconnect-test-", strftime(Sys.time(), "%Y%m%d%H%M%S"))
   expect_no_error(
     deployApp(
       appDir = "example-shiny",
@@ -10,9 +9,6 @@ test_that("deploy to shinyapps.io does not error", {
       manifestPath = "example-shiny/manifest.json"
     )
   )
-})
-
-test_that("terminate app on shinyapps.io", {
   expect_no_error(
     terminateApp(app_name, account = shinyapps_name)
   )


### PR DESCRIPTION
Currently our integration test suite creates and terminates a shiny app on shinyapps.io, however it doesn't ever delete it. This can lead to us exceeding the app limit in our account.

With this PR, we will purge all apps from the current test run (currently only one, but in theory there could be more) after the test suite runs. If cleanup fails we issue a warning. Fixes #1309.

Note if `terminateApp` in `test-shinyapps-deploy.R` fails, cleanup will also fail because only terminated applications can be purged AFAIK. So it is still possible we'd end up with some cruft in the account, but it can also be cleaned up manually.