### PR TITLE
Fix verbose deploy

### DIFF
--- a/R/http-httr2.R
+++ b/R/http-httr2.R
@@ -65,7 +65,7 @@ httr2Request <- function(
   req <- httr2::req_error(req, is_error = function(resp) FALSE)
 
   resp <- httr2::req_perform(req)
-  httpTrace(method, path, httr2::resp_timing(resp)$total)
+  httpTrace(method, path, httr2::resp_timing(resp)["total"])
 
   # Store cookies from response (same as libcurl backend)
   cookieHeaders <- httr2::resp_headers(resp, "set-cookie")

--- a/R/http-libcurl.R
+++ b/R/http-libcurl.R
@@ -67,7 +67,7 @@ httpLibCurl <- function(
   response <- curl::curl_fetch_memory(url, handle = handle)
   time <- proc.time() - start
 
-  httpTrace(method, path, time)
+  httpTrace(method, path, time[["elapsed"]])
 
   # Process headers
   headers <- curl::parse_headers_list(rawToChar(response$headers))

--- a/R/http.R
+++ b/R/http.R
@@ -476,7 +476,7 @@ httpTrace <- function(method, path, time) {
       " ",
       path,
       " ",
-      as.integer(time[["elapsed"]] * 1000),
+      as.integer(time * 1000),
       "ms\n",
       sep = ""
     )

--- a/tests/integration/test-deploy.R
+++ b/tests/integration/test-deploy.R
@@ -1,5 +1,11 @@
 test_that("deploy does not error", {
-  expect_true(deployApp("example-shiny", appTitle = "Test", account = account))
+  # Also test verbose logging
+  expect_true(deployApp(
+    "example-shiny",
+    appTitle = "Test",
+    account = account,
+    logLevel = "verbose"
+  ))
 })
 
 test_that("re-deploy does not error", {


### PR DESCRIPTION
Fixes #1311

* Adds an integration test that covers verbose logLevel
* Correctly passes in the time value from the two different HTTP implementations, slight refactor