### PR TITLE
fix bioconductor repository resolution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rsconnect (development version)
 
+* Fixed an issue where Bioconductor packages could be incorrectly associated
+  with a CRAN repository URL when the same package appeared in CRAN's Transit
+  directory. (#1314)
+
 * `deployApp()` with `logLevel = "verbose"` no longer errors using the `httr2` backend. (#1312)
 
 # rsconnect 1.8.0

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -145,10 +145,9 @@ standardizeRenvPackage <- function(
       }
     }
   } else if (pkg$Source == "Bioconductor") {
-    pkg$Repository <- findRepoUrl(pkg$Package, availablePackages)
+    pkg$Repository <- findRepoUrl(pkg$Package, biocPackages)
     if (is.na(pkg$Repository)) {
-      # Try packages defined from default bioC repos
-      pkg$Repository <- findRepoUrl(pkg$Package, biocPackages)
+      pkg$Repository <- findRepoUrl(pkg$Package, availablePackages)
     }
   } else if (pkg$Source %in% c("Bitbucket", "GitHub", "GitLab")) {
     pkg$Source <- tolower(pkg$Source)

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -47,10 +47,17 @@ parseRenvDependencies <- function(lockfile, bundleDir, snapshot = FALSE) {
     vapply(renvLock$R$Repositories, "[[", "URL", FUN.VALUE = character(1)),
     vapply(renvLock$R$Repositories, "[[", "Name", FUN.VALUE = character(1))
   )
+  bioc <- biocRepos(bundleDir)
+  if (any(bioc %in% repos)) {
+    biocPkgs <- NULL
+  } else {
+    signal("evaluating", class = "rsconnect_biocRepos")
+    biocPkgs <- availablePackages(bioc)
+  }
   deps <- standardizeRenvPackages(
     renvLock$Packages,
     repos,
-    biocPackages = biocPackages(bundleDir)
+    biocPackages = biocPkgs
   )
   if (nrow(deps) == 0) {
     return(data.frame())
@@ -174,10 +181,6 @@ standardizeRenvPackage <- function(
   pkg[manifestPackageColumns(pkg)]
 }
 
-biocPackages <- function(bundleDir) {
-  signal("evaluating", class = "rsconnect_biocRepos") # used for testing
-  availablePackages(biocRepos(bundleDir))
-}
 biocRepos <- function(bundleDir) {
   repos <- getFromNamespace("renv_bioconductor_repos", "renv")(bundleDir)
   repos[setdiff(names(repos), "CRAN")]

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -169,6 +169,25 @@ test_that("BioC gets normalized repo", {
   )
 })
 
+test_that("BioC prefers biocPackages over availablePackages (#1314)", {
+  bioc_pkg <- list(Package = "S4Vectors", Source = "Bioconductor")
+
+  avail <- data.frame(
+    Package = "S4Vectors",
+    Repository = "https://cran.rstudio.com/src/contrib/Transit",
+    stringsAsFactors = FALSE
+  )
+
+  bioc <- data.frame(
+    Package = "S4Vectors",
+    Repository = "https://bioconductor.org/packages/3.22/bioc/src/contrib",
+    stringsAsFactors = FALSE
+  )
+
+  result <- standardizeRenvPackage(bioc_pkg, avail, biocPackages = bioc)
+  expect_equal(result$Repository, "https://bioconductor.org/packages/3.22/bioc")
+})
+
 test_that("has special handling for CRAN packages", {
   packages <- as.matrix(data.frame(
     Package = "pkg",


### PR DESCRIPTION
Fixes #1314 

Given the pretty narrow scope of the issue I went with the simpler fix. I'm not against doing version-aware lookups in the future, but this should fix the immediate issue.

Making this fixed caused a test to fail due to lazy evaluation. The second commit fixes this so we check up front whether bioc repositories are in the lockfile and skip the lookup when they are.