### PR TITLE
Add dependencySource parameter to bypass renv.lock during deployment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,18 @@
 
 * `deployApp()` with `logLevel = "verbose"` no longer errors using the `httr2` backend. (#1312)
 
+* `deployApp()`, `writeManifest()`, and `appDependencies()` gain a
+  `checkLockfile` parameter. Set `checkLockfile = FALSE` to skip the
+  verification that `renv.lock` versions match the local library. This is
+  useful when deploying from CI/CD environments where the local library
+  differs from the lockfile, or when the lockfile has been manually edited
+  (e.g. with `renv::record()`). (#1046, #1315, #1317)
+
+* Improved error messages when `renv::snapshot()` fails during dependency
+  discovery. The error now suggests actionable workarounds such as
+  `renv::settings$ignored.packages()` for locally-developed packages.
+  (#1078)
+
 # rsconnect 1.8.0
 
 * `rsconnect` now uses [`httr2`](https://httr2.r-lib.org/) as its HTTP client.

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@
 * `deployApp()` with `logLevel = "verbose"` no longer errors using the `httr2` backend. (#1312)
 
 * `deployApp()`, `writeManifest()`, and `appDependencies()` gain a
-  `dependencySource` parameter. Set `dependencySource = "library"` to ignore
+  `dependencyResolution` parameter. Set `dependencyResolution = "library"` to ignore
   the `renv.lock` file and resolve package dependencies by scanning the code.
   The version that is recorded is what is installed in the libraries active in the
   R session (i.e. what is displayed with `.libPaths()`). This is useful when

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,12 +19,11 @@
 
 * `deployApp()` with `logLevel = "verbose"` no longer errors using the `httr2` backend. (#1312)
 
-* `deployApp()`, `writeManifest()`, and `appDependencies()` gain a
-  `checkLockfile` parameter. Set `checkLockfile = FALSE` to skip the
-  verification that `renv.lock` versions match the local library. This is
-  useful when deploying from CI/CD environments where the local library
-  differs from the lockfile, or when the lockfile has been manually edited
-  (e.g. with `renv::record()`). (#1046, #1315, #1317)
+* `deployApp()`, `writeManifest()`, and `appDependencies()` gain an
+  `ignoreLockfile` parameter. Set `ignoreLockfile = TRUE` to ignore the
+  `renv.lock` file and resolve package dependencies from the local library
+  instead. This is useful when deploying from CI/CD environments where the
+  local library doesn't match the lockfile. (#1046, #1315, #1317)
 
 * Improved error messages when `renv::snapshot()` fails during dependency
   discovery. The error now suggests actionable workarounds such as

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,12 +25,10 @@
   The version that is recorded is what is installed in the libraries active in the
   R session (i.e. what is displayed with `.libPaths()`). This is useful when
   deploying from environments where there is a mismatch between the
-  renv lock file (#1046, #1315, #1317)
+  renv lock file and the user's environment. (#1046, #1315, #1317)
 
 * Improved error messages when `renv::snapshot()` fails during dependency
-  discovery. The error now suggests actionable workarounds such as
-  `renv::settings$ignored.packages()` for locally-developed packages.
-  (#1078)
+  discovery. (#1078)
 
 # rsconnect 1.8.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,9 +21,11 @@
 
 * `deployApp()`, `writeManifest()`, and `appDependencies()` gain an
   `ignoreLockfile` parameter. Set `ignoreLockfile = TRUE` to ignore the
-  `renv.lock` file and resolve package dependencies from the local library
-  instead. This is useful when deploying from CI/CD environments where the
-  local library doesn't match the lockfile. (#1046, #1315, #1317)
+  `renv.lock` file and resolve package dependencies by scanning the code. 
+  The version that is recorded is what is installed in the libraries active in the 
+  R session (i.e. what is displayed with `.libPaths()`). This is useful when 
+  deploying from environments where there is a mismatch between the 
+  renv lock file (#1046, #1315, #1317)
 
 * Improved error messages when `renv::snapshot()` fails during dependency
   discovery. The error now suggests actionable workarounds such as

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,12 +19,12 @@
 
 * `deployApp()` with `logLevel = "verbose"` no longer errors using the `httr2` backend. (#1312)
 
-* `deployApp()`, `writeManifest()`, and `appDependencies()` gain an
-  `ignoreLockfile` parameter. Set `ignoreLockfile = TRUE` to ignore the
-  `renv.lock` file and resolve package dependencies by scanning the code. 
-  The version that is recorded is what is installed in the libraries active in the 
-  R session (i.e. what is displayed with `.libPaths()`). This is useful when 
-  deploying from environments where there is a mismatch between the 
+* `deployApp()`, `writeManifest()`, and `appDependencies()` gain a
+  `dependencySource` parameter. Set `dependencySource = "library"` to ignore
+  the `renv.lock` file and resolve package dependencies by scanning the code.
+  The version that is recorded is what is installed in the libraries active in the
+  R session (i.e. what is displayed with `.libPaths()`). This is useful when
+  deploying from environments where there is a mismatch between the
   renv lock file (#1046, #1315, #1317)
 
 * Improved error messages when `renv::snapshot()` fails during dependency

--- a/R/appDependencies.R
+++ b/R/appDependencies.R
@@ -136,7 +136,12 @@ appDependencies <- function(
   defer(unlink(bundleDir, recursive = TRUE))
 
   extraPackages <- inferRPackageDependencies(appMetadata)
-  deps <- computePackageDependencies(bundleDir, extraPackages, quiet = TRUE, checkLockfile = checkLockfile)
+  deps <- computePackageDependencies(
+    bundleDir,
+    extraPackages,
+    quiet = TRUE,
+    checkLockfile = checkLockfile
+  )
   deps[c("Package", "Version", "Source", "Repository")]
 }
 

--- a/R/appDependencies.R
+++ b/R/appDependencies.R
@@ -114,7 +114,7 @@ appDependencies <- function(
   appFiles = NULL,
   appFileManifest = NULL,
   appMode = NULL,
-  checkLockfile = TRUE
+  ignoreLockfile = FALSE
 ) {
   appFiles <- listDeploymentFiles(appDir, appFiles, appFileManifest)
   appMetadata <- appMetadata(appDir, appFiles = appFiles, appMode = appMode)
@@ -140,7 +140,7 @@ appDependencies <- function(
     bundleDir,
     extraPackages,
     quiet = TRUE,
-    checkLockfile = checkLockfile
+    ignoreLockfile = ignoreLockfile
   )
   deps[c("Package", "Version", "Source", "Repository")]
 }

--- a/R/appDependencies.R
+++ b/R/appDependencies.R
@@ -113,7 +113,8 @@ appDependencies <- function(
   appDir = getwd(),
   appFiles = NULL,
   appFileManifest = NULL,
-  appMode = NULL
+  appMode = NULL,
+  checkLockfile = TRUE
 ) {
   appFiles <- listDeploymentFiles(appDir, appFiles, appFileManifest)
   appMetadata <- appMetadata(appDir, appFiles = appFiles, appMode = appMode)
@@ -135,7 +136,7 @@ appDependencies <- function(
   defer(unlink(bundleDir, recursive = TRUE))
 
   extraPackages <- inferRPackageDependencies(appMetadata)
-  deps <- computePackageDependencies(bundleDir, extraPackages, quiet = TRUE)
+  deps <- computePackageDependencies(bundleDir, extraPackages, quiet = TRUE, checkLockfile = checkLockfile)
   deps[c("Package", "Version", "Source", "Repository")]
 }
 

--- a/R/appDependencies.R
+++ b/R/appDependencies.R
@@ -114,9 +114,9 @@ appDependencies <- function(
   appFiles = NULL,
   appFileManifest = NULL,
   appMode = NULL,
-  dependencySource = "strict"
+  dependencySource = c("strict", "library")
 ) {
-  dependencySource <- match.arg(dependencySource, c("strict", "library"))
+  dependencySource <- match.arg(dependencySource)
 
   appFiles <- listDeploymentFiles(appDir, appFiles, appFileManifest)
   appMetadata <- appMetadata(appDir, appFiles = appFiles, appMode = appMode)

--- a/R/appDependencies.R
+++ b/R/appDependencies.R
@@ -114,9 +114,9 @@ appDependencies <- function(
   appFiles = NULL,
   appFileManifest = NULL,
   appMode = NULL,
-  dependencySource = "default"
+  dependencySource = "strict"
 ) {
-  dependencySource <- match.arg(dependencySource, c("default", "library"))
+  dependencySource <- match.arg(dependencySource, c("strict", "library"))
 
   appFiles <- listDeploymentFiles(appDir, appFiles, appFileManifest)
   appMetadata <- appMetadata(appDir, appFiles = appFiles, appMode = appMode)

--- a/R/appDependencies.R
+++ b/R/appDependencies.R
@@ -114,8 +114,10 @@ appDependencies <- function(
   appFiles = NULL,
   appFileManifest = NULL,
   appMode = NULL,
-  ignoreLockfile = FALSE
+  dependencySource = "default"
 ) {
+  dependencySource <- match.arg(dependencySource, c("default", "library"))
+
   appFiles <- listDeploymentFiles(appDir, appFiles, appFileManifest)
   appMetadata <- appMetadata(appDir, appFiles = appFiles, appMode = appMode)
   if (!needsR(appMetadata)) {
@@ -140,7 +142,7 @@ appDependencies <- function(
     bundleDir,
     extraPackages,
     quiet = TRUE,
-    ignoreLockfile = ignoreLockfile
+    dependencySource = dependencySource
   )
   deps[c("Package", "Version", "Source", "Repository")]
 }

--- a/R/appDependencies.R
+++ b/R/appDependencies.R
@@ -114,9 +114,9 @@ appDependencies <- function(
   appFiles = NULL,
   appFileManifest = NULL,
   appMode = NULL,
-  dependencySource = c("strict", "library")
+  dependencyResolution = c("strict", "library")
 ) {
-  dependencySource <- match.arg(dependencySource)
+  dependencyResolution <- match.arg(dependencyResolution)
 
   appFiles <- listDeploymentFiles(appDir, appFiles, appFileManifest)
   appMetadata <- appMetadata(appDir, appFiles = appFiles, appMode = appMode)
@@ -142,7 +142,7 @@ appDependencies <- function(
     bundleDir,
     extraPackages,
     quiet = TRUE,
-    dependencySource = dependencySource
+    dependencyResolution = dependencyResolution
   )
   deps[c("Package", "Version", "Source", "Repository")]
 }

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -190,7 +190,7 @@ createAppManifest <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  dependencySource = "strict",
+  dependencyResolution = "strict",
   verbose = FALSE,
   quiet = FALSE
 ) {
@@ -217,7 +217,7 @@ createAppManifest <- function(
       extraPackages = extraPackages,
       verbose = verbose,
       quiet = quiet,
-      dependencySource = dependencySource
+      dependencyResolution = dependencyResolution
     )
     rVersionReq <- rVersionRequires(appDir)
   } else {

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -190,7 +190,7 @@ createAppManifest <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  dependencySource = "default",
+  dependencySource = "strict",
   verbose = FALSE,
   quiet = FALSE
 ) {

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -190,6 +190,7 @@ createAppManifest <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
+  checkLockfile = TRUE,
   verbose = FALSE,
   quiet = FALSE
 ) {
@@ -215,7 +216,8 @@ createAppManifest <- function(
       bundleDir = appDir,
       extraPackages = extraPackages,
       verbose = verbose,
-      quiet = quiet
+      quiet = quiet,
+      checkLockfile = checkLockfile
     )
     rVersionReq <- rVersionRequires(appDir)
   } else {

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -190,7 +190,7 @@ createAppManifest <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  checkLockfile = TRUE,
+  ignoreLockfile = FALSE,
   verbose = FALSE,
   quiet = FALSE
 ) {
@@ -217,7 +217,7 @@ createAppManifest <- function(
       extraPackages = extraPackages,
       verbose = verbose,
       quiet = quiet,
-      checkLockfile = checkLockfile
+      ignoreLockfile = ignoreLockfile
     )
     rVersionReq <- rVersionRequires(appDir)
   } else {

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -190,7 +190,7 @@ createAppManifest <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  ignoreLockfile = FALSE,
+  dependencySource = "default",
   verbose = FALSE,
   quiet = FALSE
 ) {
@@ -217,7 +217,7 @@ createAppManifest <- function(
       extraPackages = extraPackages,
       verbose = verbose,
       quiet = quiet,
-      ignoreLockfile = ignoreLockfile
+      dependencySource = dependencySource
     )
     rVersionReq <- rVersionRequires(appDir)
   } else {

--- a/R/bundlePackage.R
+++ b/R/bundlePackage.R
@@ -80,7 +80,8 @@ computePackageDependencies <- function(
       bundleDir,
       extraPackages,
       quiet = quiet,
-      verbose = verbose
+      verbose = verbose,
+      force = ignoreLockfile
     )
   }
   taskComplete(quiet, "Found {nrow(deps)} dependenc{?y/ies}")

--- a/R/bundlePackage.R
+++ b/R/bundlePackage.R
@@ -3,13 +3,15 @@ bundlePackages <- function(
   extraPackages = character(),
   quiet = FALSE,
   verbose = FALSE,
+  checkLockfile = TRUE,
   error_call = caller_env()
 ) {
   deps <- computePackageDependencies(
     bundleDir,
     extraPackages,
     quiet = quiet,
-    verbose = verbose
+    verbose = verbose,
+    checkLockfile = checkLockfile
   )
   if (nrow(deps) == 0) {
     return(list())
@@ -45,7 +47,8 @@ computePackageDependencies <- function(
   bundleDir,
   extraPackages = character(),
   quiet = FALSE,
-  verbose = FALSE
+  verbose = FALSE,
+  checkLockfile = TRUE
 ) {
   if (usePackrat()) {
     taskStart(quiet, "Capturing R dependencies with packrat")
@@ -63,7 +66,7 @@ computePackageDependencies <- function(
     # This ignores extraPackages; if you're using a lockfile it's your
     # responsibility to install any other packages you need
     taskStart(quiet, "Capturing R dependencies from renv.lock")
-    deps <- parseRenvDependencies(lockfile, bundleDir)
+    deps <- parseRenvDependencies(lockfile, bundleDir, checkLockfile = checkLockfile)
     # Once we've captured the deps, we can remove the renv directory
     # from the bundle (retaining the renv.lock).
     removeRenv(bundleDir, lockfile = FALSE)

--- a/R/bundlePackage.R
+++ b/R/bundlePackage.R
@@ -3,7 +3,7 @@ bundlePackages <- function(
   extraPackages = character(),
   quiet = FALSE,
   verbose = FALSE,
-  checkLockfile = TRUE,
+  ignoreLockfile = FALSE,
   error_call = caller_env()
 ) {
   deps <- computePackageDependencies(
@@ -11,7 +11,7 @@ bundlePackages <- function(
     extraPackages,
     quiet = quiet,
     verbose = verbose,
-    checkLockfile = checkLockfile
+    ignoreLockfile = ignoreLockfile
   )
   if (nrow(deps) == 0) {
     return(list())
@@ -48,7 +48,7 @@ computePackageDependencies <- function(
   extraPackages = character(),
   quiet = FALSE,
   verbose = FALSE,
-  checkLockfile = TRUE
+  ignoreLockfile = FALSE
 ) {
   if (usePackrat()) {
     taskStart(quiet, "Capturing R dependencies with packrat")
@@ -61,15 +61,14 @@ computePackageDependencies <- function(
       extraPackages,
       verbose = verbose
     )
-  } else if (!is.null(resolveRenvLockFile(bundleDir))) {
+  } else if (!ignoreLockfile && !is.null(resolveRenvLockFile(bundleDir))) {
     lockfile <- resolveRenvLockFile(bundleDir)
     # This ignores extraPackages; if you're using a lockfile it's your
     # responsibility to install any other packages you need
     taskStart(quiet, "Capturing R dependencies from renv.lock")
     deps <- parseRenvDependencies(
       lockfile,
-      bundleDir,
-      checkLockfile = checkLockfile
+      bundleDir
     )
     # Once we've captured the deps, we can remove the renv directory
     # from the bundle (retaining the renv.lock).

--- a/R/bundlePackage.R
+++ b/R/bundlePackage.R
@@ -66,7 +66,11 @@ computePackageDependencies <- function(
     # This ignores extraPackages; if you're using a lockfile it's your
     # responsibility to install any other packages you need
     taskStart(quiet, "Capturing R dependencies from renv.lock")
-    deps <- parseRenvDependencies(lockfile, bundleDir, checkLockfile = checkLockfile)
+    deps <- parseRenvDependencies(
+      lockfile,
+      bundleDir,
+      checkLockfile = checkLockfile
+    )
     # Once we've captured the deps, we can remove the renv directory
     # from the bundle (retaining the renv.lock).
     removeRenv(bundleDir, lockfile = FALSE)

--- a/R/bundlePackage.R
+++ b/R/bundlePackage.R
@@ -62,7 +62,8 @@ computePackageDependencies <- function(
       verbose = verbose
     )
   } else if (
-    dependencyResolution != "library" && !is.null(resolveRenvLockFile(bundleDir))
+    dependencyResolution != "library" &&
+      !is.null(resolveRenvLockFile(bundleDir))
   ) {
     lockfile <- resolveRenvLockFile(bundleDir)
     # This ignores extraPackages; if you're using a lockfile it's your

--- a/R/bundlePackage.R
+++ b/R/bundlePackage.R
@@ -3,7 +3,7 @@ bundlePackages <- function(
   extraPackages = character(),
   quiet = FALSE,
   verbose = FALSE,
-  ignoreLockfile = FALSE,
+  dependencySource = "default",
   error_call = caller_env()
 ) {
   deps <- computePackageDependencies(
@@ -11,7 +11,7 @@ bundlePackages <- function(
     extraPackages,
     quiet = quiet,
     verbose = verbose,
-    ignoreLockfile = ignoreLockfile
+    dependencySource = dependencySource
   )
   if (nrow(deps) == 0) {
     return(list())
@@ -48,7 +48,7 @@ computePackageDependencies <- function(
   extraPackages = character(),
   quiet = FALSE,
   verbose = FALSE,
-  ignoreLockfile = FALSE
+  dependencySource = "default"
 ) {
   if (usePackrat()) {
     taskStart(quiet, "Capturing R dependencies with packrat")
@@ -61,7 +61,7 @@ computePackageDependencies <- function(
       extraPackages,
       verbose = verbose
     )
-  } else if (!ignoreLockfile && !is.null(resolveRenvLockFile(bundleDir))) {
+  } else if (dependencySource != "library" && !is.null(resolveRenvLockFile(bundleDir))) {
     lockfile <- resolveRenvLockFile(bundleDir)
     # This ignores extraPackages; if you're using a lockfile it's your
     # responsibility to install any other packages you need
@@ -81,7 +81,7 @@ computePackageDependencies <- function(
       extraPackages,
       quiet = quiet,
       verbose = verbose,
-      force = ignoreLockfile
+      force = dependencySource == "library"
     )
   }
   taskComplete(quiet, "Found {nrow(deps)} dependenc{?y/ies}")

--- a/R/bundlePackage.R
+++ b/R/bundlePackage.R
@@ -82,8 +82,7 @@ computePackageDependencies <- function(
       bundleDir,
       extraPackages,
       quiet = quiet,
-      verbose = verbose,
-      force = dependencySource == "library"
+      verbose = verbose
     )
   }
   taskComplete(quiet, "Found {nrow(deps)} dependenc{?y/ies}")

--- a/R/bundlePackage.R
+++ b/R/bundlePackage.R
@@ -3,7 +3,7 @@ bundlePackages <- function(
   extraPackages = character(),
   quiet = FALSE,
   verbose = FALSE,
-  dependencySource = "strict",
+  dependencyResolution = "strict",
   error_call = caller_env()
 ) {
   deps <- computePackageDependencies(
@@ -11,7 +11,7 @@ bundlePackages <- function(
     extraPackages,
     quiet = quiet,
     verbose = verbose,
-    dependencySource = dependencySource
+    dependencyResolution = dependencyResolution
   )
   if (nrow(deps) == 0) {
     return(list())
@@ -48,7 +48,7 @@ computePackageDependencies <- function(
   extraPackages = character(),
   quiet = FALSE,
   verbose = FALSE,
-  dependencySource = "strict"
+  dependencyResolution = "strict"
 ) {
   if (usePackrat()) {
     taskStart(quiet, "Capturing R dependencies with packrat")
@@ -62,7 +62,7 @@ computePackageDependencies <- function(
       verbose = verbose
     )
   } else if (
-    dependencySource != "library" && !is.null(resolveRenvLockFile(bundleDir))
+    dependencyResolution != "library" && !is.null(resolveRenvLockFile(bundleDir))
   ) {
     lockfile <- resolveRenvLockFile(bundleDir)
     # This ignores extraPackages; if you're using a lockfile it's your

--- a/R/bundlePackage.R
+++ b/R/bundlePackage.R
@@ -3,7 +3,7 @@ bundlePackages <- function(
   extraPackages = character(),
   quiet = FALSE,
   verbose = FALSE,
-  dependencySource = "default",
+  dependencySource = "strict",
   error_call = caller_env()
 ) {
   deps <- computePackageDependencies(
@@ -48,7 +48,7 @@ computePackageDependencies <- function(
   extraPackages = character(),
   quiet = FALSE,
   verbose = FALSE,
-  dependencySource = "default"
+  dependencySource = "strict"
 ) {
   if (usePackrat()) {
     taskStart(quiet, "Capturing R dependencies with packrat")

--- a/R/bundlePackage.R
+++ b/R/bundlePackage.R
@@ -61,7 +61,9 @@ computePackageDependencies <- function(
       extraPackages,
       verbose = verbose
     )
-  } else if (dependencySource != "library" && !is.null(resolveRenvLockFile(bundleDir))) {
+  } else if (
+    dependencySource != "library" && !is.null(resolveRenvLockFile(bundleDir))
+  ) {
     lockfile <- resolveRenvLockFile(bundleDir)
     # This ignores extraPackages; if you're using a lockfile it's your
     # responsibility to install any other packages you need

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -31,7 +31,12 @@ snapshotRenvDependencies <- function(
     progress = FALSE
   )
   withCallingHandlers(
-    renv::snapshot(bundleDir, packages = deps$Package, prompt = FALSE, force = force),
+    renv::snapshot(
+      bundleDir,
+      packages = deps$Package,
+      prompt = FALSE,
+      force = force
+    ),
     error = function(err) {
       cli::cli_abort(
         c(

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -2,7 +2,8 @@ snapshotRenvDependencies <- function(
   bundleDir,
   extraPackages = character(),
   quiet = FALSE,
-  verbose = FALSE
+  verbose = FALSE,
+  force = FALSE
 ) {
   recordExtraDependencies(bundleDir, extraPackages)
 
@@ -30,14 +31,13 @@ snapshotRenvDependencies <- function(
     progress = FALSE
   )
   withCallingHandlers(
-    renv::snapshot(bundleDir, packages = deps$Package, prompt = FALSE),
+    renv::snapshot(bundleDir, packages = deps$Package, prompt = FALSE, force = force),
     error = function(err) {
       cli::cli_abort(
         c(
           "Failed to snapshot dependencies with renv.",
           i = "This can happen when a locally-developed package is not installed from a known source.",
-          i = "Set {.code ignoreLockfile = TRUE} when deploying to ignore the
-          {.file renv.lock} and resolve dependencies from the local library."
+          i = "Set {.code ignoreLockfile = TRUE} to force dependency resolution from the local library."
         ),
         parent = err
       )

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -36,7 +36,8 @@ snapshotRenvDependencies <- function(
         c(
           "Failed to snapshot dependencies with renv.",
           i = "This can happen when a locally-developed package is not installed from a known source.",
-          i = "You can set {.code ignoreLockfile = TRUE} when deploying to ignore the {.file renv.lock} file and resolve package dependencies from the local library instead."
+          i = "Set {.code ignoreLockfile = TRUE} when deploying to ignore the
+          {.file renv.lock} and resolve dependencies from the local library."
         ),
         parent = err
       )

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -30,19 +30,14 @@ snapshotRenvDependencies <- function(
     quiet = if (quiet) TRUE else NULL,
     progress = FALSE
   )
-  withCallingHandlers(
-    renv::snapshot(
-      bundleDir,
-      packages = deps$Package,
-      prompt = FALSE,
-      force = force
-    ),
+
+  tryCatch(
+    renv::snapshot(bundleDir, packages = deps$Package, prompt = FALSE, force = force),
     error = function(err) {
       cli::cli_abort(
         c(
           "Failed to snapshot dependencies with renv.",
-          i = "This can happen when a locally-developed package is not installed from a known source.",
-          i = "Set {.code ignoreLockfile = TRUE} to force dependency resolution from the local library."
+          i = "For example you have a locally-developed package that is not installed from a known source."
         ),
         parent = err
       )
@@ -89,7 +84,7 @@ parseRenvDependencies <- function(lockfile, bundleDir, snapshot = FALSE) {
         "Library and lockfile are out of sync",
         i = "Use renv::restore() or renv::snapshot() to synchronise",
         i = "Or ignore the lockfile by adding to your .rscignore",
-        i = "Or set {.code ignoreLockfile = TRUE} to ignore the lockfile and use the local library instead"
+        i = "Or set {.code dependencySource = \"library\"} to ignore the lockfile and use the local library instead"
       ))
     }
   }

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -29,7 +29,20 @@ snapshotRenvDependencies <- function(
     quiet = if (quiet) TRUE else NULL,
     progress = FALSE
   )
-  renv::snapshot(bundleDir, packages = deps$Package, prompt = FALSE)
+  withCallingHandlers(
+    renv::snapshot(bundleDir, packages = deps$Package, prompt = FALSE),
+    error = function(err) {
+      cli::cli_abort(
+        c(
+          "Failed to snapshot dependencies with renv.",
+          i = "This can happen when a locally-developed package is not installed from a known source.",
+          i = "Use {.code renv::settings$ignored.packages(\"pkg\")} to exclude it from the snapshot.",
+          i = "Or create your own {.file renv.lock} and set {.code checkLockfile = FALSE} when deploying."
+        ),
+        parent = err
+      )
+    }
+  )
   # renv::snapshot() respects RENV_PATHS_LOCKFILE and renv profiles, so the
   # lockfile may have been written to a non-standard location.
   lockfile <- resolveRenvLockFile(bundleDir)
@@ -41,7 +54,12 @@ snapshotRenvDependencies <- function(
   parseRenvDependencies(lockfile, bundleDir, snapshot = TRUE)
 }
 
-parseRenvDependencies <- function(lockfile, bundleDir, snapshot = FALSE) {
+parseRenvDependencies <- function(
+  lockfile,
+  bundleDir,
+  snapshot = FALSE,
+  checkLockfile = TRUE
+) {
   renvLock <- jsonlite::read_json(lockfile)
   repos <- setNames(
     vapply(renvLock$R$Repositories, "[[", "URL", FUN.VALUE = character(1)),
@@ -63,14 +81,15 @@ parseRenvDependencies <- function(lockfile, bundleDir, snapshot = FALSE) {
     return(data.frame())
   }
   deps$description <- lapply(deps$Package, package_record)
-  if (!snapshot) {
+  if (!snapshot && checkLockfile) {
     lib_versions <- unlist(lapply(deps$description, "[[", "Version"))
 
     if (any(deps$Version != lib_versions)) {
       cli::cli_abort(c(
         "Library and lockfile are out of sync",
         i = "Use renv::restore() or renv::snapshot() to synchronise",
-        i = "Or ignore the lockfile by adding to your .rscignore"
+        i = "Or ignore the lockfile by adding to your .rscignore",
+        i = "Or set `checkLockfile = FALSE` to trust the lockfile as-is"
       ))
     }
   }

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -36,8 +36,7 @@ snapshotRenvDependencies <- function(
         c(
           "Failed to snapshot dependencies with renv.",
           i = "This can happen when a locally-developed package is not installed from a known source.",
-          i = "Use {.code renv::settings$ignored.packages(\"pkg\")} to exclude it from the snapshot.",
-          i = "Or create your own {.file renv.lock} and set {.code checkLockfile = FALSE} when deploying."
+          i = "You can set {.code ignoreLockfile = TRUE} when deploying to ignore the {.file renv.lock} file and resolve package dependencies from the local library instead."
         ),
         parent = err
       )
@@ -54,12 +53,7 @@ snapshotRenvDependencies <- function(
   parseRenvDependencies(lockfile, bundleDir, snapshot = TRUE)
 }
 
-parseRenvDependencies <- function(
-  lockfile,
-  bundleDir,
-  snapshot = FALSE,
-  checkLockfile = TRUE
-) {
+parseRenvDependencies <- function(lockfile, bundleDir, snapshot = FALSE) {
   renvLock <- jsonlite::read_json(lockfile)
   repos <- setNames(
     vapply(renvLock$R$Repositories, "[[", "URL", FUN.VALUE = character(1)),
@@ -81,7 +75,7 @@ parseRenvDependencies <- function(
     return(data.frame())
   }
   deps$description <- lapply(deps$Package, package_record)
-  if (!snapshot && checkLockfile) {
+  if (!snapshot) {
     lib_versions <- unlist(lapply(deps$description, "[[", "Version"))
 
     if (any(deps$Version != lib_versions)) {
@@ -89,7 +83,7 @@ parseRenvDependencies <- function(
         "Library and lockfile are out of sync",
         i = "Use renv::restore() or renv::snapshot() to synchronise",
         i = "Or ignore the lockfile by adding to your .rscignore",
-        i = "Or set `checkLockfile = FALSE` to trust the lockfile as-is"
+        i = "Or set {.code ignoreLockfile = TRUE} to ignore the lockfile and use the local library instead"
       ))
     }
   }

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -2,8 +2,7 @@ snapshotRenvDependencies <- function(
   bundleDir,
   extraPackages = character(),
   quiet = FALSE,
-  verbose = FALSE,
-  force = FALSE
+  verbose = FALSE
 ) {
   recordExtraDependencies(bundleDir, extraPackages)
 
@@ -32,12 +31,7 @@ snapshotRenvDependencies <- function(
   )
 
   tryCatch(
-    renv::snapshot(
-      bundleDir,
-      packages = deps$Package,
-      prompt = FALSE,
-      force = force
-    ),
+    renv::snapshot(bundleDir, packages = deps$Package, prompt = FALSE),
     error = function(err) {
       cli::cli_abort(
         c(

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -83,7 +83,7 @@ parseRenvDependencies <- function(lockfile, bundleDir, snapshot = FALSE) {
         "Library and lockfile are out of sync",
         i = "Use renv::restore() or renv::snapshot() to synchronise",
         i = "Or ignore the lockfile by adding to your .rscignore",
-        i = "Or set {.code dependencySource = \"library\"} to ignore the lockfile and use the local library instead"
+        i = "Or set {.code dependencyResolution = \"library\"} to ignore the lockfile and use the local library instead"
       ))
     }
   }

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -32,7 +32,12 @@ snapshotRenvDependencies <- function(
   )
 
   tryCatch(
-    renv::snapshot(bundleDir, packages = deps$Package, prompt = FALSE, force = force),
+    renv::snapshot(
+      bundleDir,
+      packages = deps$Package,
+      prompt = FALSE,
+      force = force
+    ),
     error = function(err) {
       cli::cli_abort(
         c(

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -42,7 +42,7 @@ snapshotRenvDependencies <- function(
       cli::cli_abort(
         c(
           "Failed to snapshot dependencies with renv.",
-          i = "For example you have a locally-developed package that is not installed from a known source."
+          i = "For example, you have a locally-developed package that is installed from disk."
         ),
         parent = err
       )

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -279,13 +279,13 @@ deployApp <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  dependencySource = "strict"
+  dependencySource = c("strict", "library")
 ) {
   check_string(appDir)
   check_directory(appDir)
   appDir <- normalizePath(appDir)
 
-  dependencySource <- match.arg(dependencySource, c("strict", "library"))
+  dependencySource <- match.arg(dependencySource)
   check_string(appName, allow_null = TRUE)
 
   if (!is.null(appPrimaryDoc)) {

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -205,7 +205,7 @@
 #'   Must be one of `"strict"` or `"library"`. When `"strict"`, the
 #'   `renv.lock` file is used if present and must match the local library.
 #'   When `"library"`, the lockfile is ignored and dependencies are resolved
-#'   from the locally installed library instead. This is useful when the
+#'   from the available local libraries instead. This is useful when the
 #'   lockfile is out of sync with the local library and cannot be updated
 #'   (e.g. in CI/CD environments). Note that the deployed content will
 #'   reflect the local library, not the lockfile. Defaults to `"strict"`.

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -201,12 +201,12 @@
 #'   `"legacy"`, `"lockfile"`, or `NULL`. The default, `NULL`, will not write
 #'   any values to the bundle manifest and Connect will fall back to the
 #'   server's package repository resolution strategy.
-#' @param checkLockfile If `TRUE` (the default), verifies that the versions in
-#'   `renv.lock` match the locally installed library before deploying. Set to
-#'   `FALSE` to skip this check and trust the lockfile as-is. This is useful
-#'   when deploying from a CI/CD environment where the local library doesn't
-#'   match the lockfile, or when the lockfile has been manually edited (e.g.
-#'   with `renv::record()`). Only applies when an `renv.lock` file is present.
+#' @param ignoreLockfile If `TRUE`, the `renv.lock` file is ignored and
+#'   package dependencies are resolved from the locally installed library
+#'   instead. This is useful when the lockfile is out of sync with the local
+#'   library and cannot be updated (e.g. in CI/CD environments). Note that
+#'   the deployed content will reflect the local library, not the lockfile.
+#'   Defaults to `FALSE`.
 #' @examples
 #' \dontrun{
 #'
@@ -278,13 +278,13 @@ deployApp <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  checkLockfile = TRUE
+  ignoreLockfile = FALSE
 ) {
   check_string(appDir)
   check_directory(appDir)
   appDir <- normalizePath(appDir)
 
-  check_bool(checkLockfile)
+  check_bool(ignoreLockfile)
   check_string(appName, allow_null = TRUE)
 
   if (!is.null(appPrimaryDoc)) {
@@ -649,6 +649,10 @@ deployApp <- function(
     python <- getPythonForTarget(python, accountDetails)
     pythonConfig <- pythonConfigurator(python, forceGeneratePythonEnvironment)
 
+    if (ignoreLockfile) {
+      confirmIgnoreLockfile()
+    }
+
     taskStart(quiet, "Bundling {length(appFiles)} file{?s}: {.file {appFiles}}")
     bundlePath <- bundleApp(
       appName = deployment$name,
@@ -664,7 +668,7 @@ deployApp <- function(
       envManagementPy = envManagementPy,
       envManagementNodejs = envManagementNodejs,
       packageRepositoryResolutionR = packageRepositoryResolutionR,
-      checkLockfile = checkLockfile,
+      ignoreLockfile = ignoreLockfile,
       existingManifest = manifest
     )
     size <- format(file_size(bundlePath), big.mark = ",")
@@ -940,7 +944,7 @@ bundleApp <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  checkLockfile = TRUE,
+  ignoreLockfile = FALSE,
   existingManifest = NULL
 ) {
   logger <- verboseLogger(verbose)
@@ -980,7 +984,7 @@ bundleApp <- function(
       envManagementPy = envManagementPy,
       envManagementNodejs = envManagementNodejs,
       packageRepositoryResolutionR = packageRepositoryResolutionR,
-      checkLockfile = checkLockfile,
+      ignoreLockfile = ignoreLockfile,
       verbose = verbose,
       quiet = quiet
     )
@@ -996,6 +1000,20 @@ bundleApp <- function(
   bundlePath <- tempfile("rsconnect-bundle", fileext = ".tar.gz")
   writeBundle(bundleDir, bundlePath)
   bundlePath
+}
+
+confirmIgnoreLockfile <- function() {
+  cli::cli_warn(c(
+    "{.file renv.lock} will be ignored.",
+    "!" = "Package dependencies will be resolved from the local library instead.",
+    "!" = "The deployed content may differ from what the lockfile specifies."
+  ))
+  if (is_interactive()) {
+    response <- cli_readline("Do you want to proceed? [Y/n]: ")
+    if (nzchar(response) && tolower(substring(response, 1, 1)) != "y") {
+      cli::cli_abort("Deployment cancelled.")
+    }
+  }
 }
 
 validURL <- function(url) {

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -202,13 +202,13 @@
 #'   any values to the bundle manifest and Connect will fall back to the
 #'   server's package repository resolution strategy.
 #' @param dependencySource Controls how R package dependencies are resolved.
-#'   Must be one of `"default"` or `"library"`. When `"default"`, the
-#'   `renv.lock` file is used if present. When `"library"`, the lockfile is
-#'   ignored and dependencies are resolved from the locally installed library
-#'   instead. This is useful when the lockfile is out of sync with the local
-#'   library and cannot be updated (e.g. in CI/CD environments). Note that
-#'   the deployed content will reflect the local library, not the lockfile.
-#'   Defaults to `"default"`.
+#'   Must be one of `"strict"` or `"library"`. When `"strict"`, the
+#'   `renv.lock` file is used if present and must match the local library.
+#'   When `"library"`, the lockfile is ignored and dependencies are resolved
+#'   from the locally installed library instead. This is useful when the
+#'   lockfile is out of sync with the local library and cannot be updated
+#'   (e.g. in CI/CD environments). Note that the deployed content will
+#'   reflect the local library, not the lockfile. Defaults to `"strict"`.
 #' @examples
 #' \dontrun{
 #'
@@ -280,13 +280,13 @@ deployApp <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  dependencySource = "default"
+  dependencySource = "strict"
 ) {
   check_string(appDir)
   check_directory(appDir)
   appDir <- normalizePath(appDir)
 
-  dependencySource <- match.arg(dependencySource, c("default", "library"))
+  dependencySource <- match.arg(dependencySource, c("strict", "library"))
   check_string(appName, allow_null = TRUE)
 
   if (!is.null(appPrimaryDoc)) {
@@ -946,7 +946,7 @@ bundleApp <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  dependencySource = "default",
+  dependencySource = "strict",
   existingManifest = NULL
 ) {
   logger <- verboseLogger(verbose)

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -201,12 +201,14 @@
 #'   `"legacy"`, `"lockfile"`, or `NULL`. The default, `NULL`, will not write
 #'   any values to the bundle manifest and Connect will fall back to the
 #'   server's package repository resolution strategy.
-#' @param ignoreLockfile If `TRUE`, the `renv.lock` file is ignored and
-#'   package dependencies are resolved from the locally installed library
+#' @param dependencySource Controls how R package dependencies are resolved.
+#'   Must be one of `"default"` or `"library"`. When `"default"`, the
+#'   `renv.lock` file is used if present. When `"library"`, the lockfile is
+#'   ignored and dependencies are resolved from the locally installed library
 #'   instead. This is useful when the lockfile is out of sync with the local
 #'   library and cannot be updated (e.g. in CI/CD environments). Note that
 #'   the deployed content will reflect the local library, not the lockfile.
-#'   Defaults to `FALSE`.
+#'   Defaults to `"default"`.
 #' @examples
 #' \dontrun{
 #'
@@ -278,13 +280,13 @@ deployApp <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  ignoreLockfile = FALSE
+  dependencySource = "default"
 ) {
   check_string(appDir)
   check_directory(appDir)
   appDir <- normalizePath(appDir)
 
-  check_bool(ignoreLockfile)
+  dependencySource <- match.arg(dependencySource, c("default", "library"))
   check_string(appName, allow_null = TRUE)
 
   if (!is.null(appPrimaryDoc)) {
@@ -649,8 +651,8 @@ deployApp <- function(
     python <- getPythonForTarget(python, accountDetails)
     pythonConfig <- pythonConfigurator(python, forceGeneratePythonEnvironment)
 
-    if (ignoreLockfile) {
-      confirmIgnoreLockfile()
+    if (dependencySource == "library") {
+      confirmDependencySourceLibrary()
     }
 
     taskStart(quiet, "Bundling {length(appFiles)} file{?s}: {.file {appFiles}}")
@@ -668,7 +670,7 @@ deployApp <- function(
       envManagementPy = envManagementPy,
       envManagementNodejs = envManagementNodejs,
       packageRepositoryResolutionR = packageRepositoryResolutionR,
-      ignoreLockfile = ignoreLockfile,
+      dependencySource = dependencySource,
       existingManifest = manifest
     )
     size <- format(file_size(bundlePath), big.mark = ",")
@@ -944,7 +946,7 @@ bundleApp <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  ignoreLockfile = FALSE,
+  dependencySource = "default",
   existingManifest = NULL
 ) {
   logger <- verboseLogger(verbose)
@@ -984,7 +986,7 @@ bundleApp <- function(
       envManagementPy = envManagementPy,
       envManagementNodejs = envManagementNodejs,
       packageRepositoryResolutionR = packageRepositoryResolutionR,
-      ignoreLockfile = ignoreLockfile,
+      dependencySource = dependencySource,
       verbose = verbose,
       quiet = quiet
     )
@@ -1002,7 +1004,7 @@ bundleApp <- function(
   bundlePath
 }
 
-confirmIgnoreLockfile <- function() {
+confirmDependencySourceLibrary <- function() {
   cli::cli_warn(c(
     "{.file renv.lock} will be ignored.",
     "!" = "Package dependencies will be resolved from the local library instead.",

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -1005,16 +1005,20 @@ bundleApp <- function(
 }
 
 confirmDependencySourceLibrary <- function() {
-  cli::cli_warn(c(
-    "{.file renv.lock} will be ignored.",
-    "!" = "Package dependencies will be resolved from the local library instead.",
-    "!" = "The deployed content may differ from what the lockfile specifies."
-  ))
   if (is_interactive()) {
-    response <- cli_readline("Do you want to proceed? [Y/n]: ")
+    response <- cli_readline(paste0(
+      "renv.lock will be ignored. ",
+      "Package dependencies will be resolved from the local library instead.\n",
+      "Do you want to proceed? [Y/n]: "
+    ))
     if (nzchar(response) && tolower(substring(response, 1, 1)) != "y") {
       cli::cli_abort("Deployment cancelled.")
     }
+  } else {
+    cli::cli_inform(c(
+      "{.file renv.lock} will be ignored.",
+      "!" = "Package dependencies will be resolved from the local library instead."
+    ))
   }
 }
 

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -201,6 +201,12 @@
 #'   `"legacy"`, `"lockfile"`, or `NULL`. The default, `NULL`, will not write
 #'   any values to the bundle manifest and Connect will fall back to the
 #'   server's package repository resolution strategy.
+#' @param checkLockfile If `TRUE` (the default), verifies that the versions in
+#'   `renv.lock` match the locally installed library before deploying. Set to
+#'   `FALSE` to skip this check and trust the lockfile as-is. This is useful
+#'   when deploying from a CI/CD environment where the local library doesn't
+#'   match the lockfile, or when the lockfile has been manually edited (e.g.
+#'   with `renv::record()`). Only applies when an `renv.lock` file is present.
 #' @examples
 #' \dontrun{
 #'
@@ -271,12 +277,14 @@ deployApp <- function(
   envManagementR = NULL,
   envManagementPy = NULL,
   envManagementNodejs = NULL,
-  packageRepositoryResolutionR = NULL
+  packageRepositoryResolutionR = NULL,
+  checkLockfile = TRUE
 ) {
   check_string(appDir)
   check_directory(appDir)
   appDir <- normalizePath(appDir)
 
+  check_bool(checkLockfile)
   check_string(appName, allow_null = TRUE)
 
   if (!is.null(appPrimaryDoc)) {
@@ -656,6 +664,7 @@ deployApp <- function(
       envManagementPy = envManagementPy,
       envManagementNodejs = envManagementNodejs,
       packageRepositoryResolutionR = packageRepositoryResolutionR,
+      checkLockfile = checkLockfile,
       existingManifest = manifest
     )
     size <- format(file_size(bundlePath), big.mark = ",")
@@ -931,6 +940,7 @@ bundleApp <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
+  checkLockfile = TRUE,
   existingManifest = NULL
 ) {
   logger <- verboseLogger(verbose)
@@ -970,6 +980,7 @@ bundleApp <- function(
       envManagementPy = envManagementPy,
       envManagementNodejs = envManagementNodejs,
       packageRepositoryResolutionR = packageRepositoryResolutionR,
+      checkLockfile = checkLockfile,
       verbose = verbose,
       quiet = quiet
     )

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -206,8 +206,7 @@
 #'   `renv.lock` file is used if present and must match the local library.
 #'   When `"library"`, the lockfile is ignored and dependencies are resolved
 #'   from the available local libraries instead. This is useful when the
-#'   lockfile is out of sync with the local library and cannot be updated
-#'   (e.g. in CI/CD environments). Note that the deployed content will
+#'   lockfile is out of sync with the local library and cannot be updated. Note that the deployed content will
 #'   reflect the local library, not the lockfile. Defaults to `"strict"`.
 #' @examples
 #' \dontrun{

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -201,7 +201,7 @@
 #'   `"legacy"`, `"lockfile"`, or `NULL`. The default, `NULL`, will not write
 #'   any values to the bundle manifest and Connect will fall back to the
 #'   server's package repository resolution strategy.
-#' @param dependencySource Controls how R package dependencies are resolved.
+#' @param dependencyResolution Controls how R package dependencies are resolved.
 #'   Must be one of `"strict"` or `"library"`. When `"strict"`, the
 #'   `renv.lock` file is used if present and must match the local library.
 #'   When `"library"`, the lockfile is ignored and dependencies are resolved
@@ -279,13 +279,13 @@ deployApp <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  dependencySource = c("strict", "library")
+  dependencyResolution = c("strict", "library")
 ) {
   check_string(appDir)
   check_directory(appDir)
   appDir <- normalizePath(appDir)
 
-  dependencySource <- match.arg(dependencySource)
+  dependencyResolution <- match.arg(dependencyResolution)
   check_string(appName, allow_null = TRUE)
 
   if (!is.null(appPrimaryDoc)) {
@@ -650,7 +650,7 @@ deployApp <- function(
     python <- getPythonForTarget(python, accountDetails)
     pythonConfig <- pythonConfigurator(python, forceGeneratePythonEnvironment)
 
-    if (dependencySource == "library") {
+    if (dependencyResolution == "library") {
       confirmDependencySourceLibrary()
     }
 
@@ -669,7 +669,7 @@ deployApp <- function(
       envManagementPy = envManagementPy,
       envManagementNodejs = envManagementNodejs,
       packageRepositoryResolutionR = packageRepositoryResolutionR,
-      dependencySource = dependencySource,
+      dependencyResolution = dependencyResolution,
       existingManifest = manifest
     )
     size <- format(file_size(bundlePath), big.mark = ",")
@@ -945,7 +945,7 @@ bundleApp <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  dependencySource = "strict",
+  dependencyResolution = "strict",
   existingManifest = NULL
 ) {
   logger <- verboseLogger(verbose)
@@ -985,7 +985,7 @@ bundleApp <- function(
       envManagementPy = envManagementPy,
       envManagementNodejs = envManagementNodejs,
       packageRepositoryResolutionR = packageRepositoryResolutionR,
-      dependencySource = dependencySource,
+      dependencyResolution = dependencyResolution,
       verbose = verbose,
       quiet = quiet
     )

--- a/R/writeManifest.R
+++ b/R/writeManifest.R
@@ -34,10 +34,11 @@ writeManifest <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  dependencySource = "strict",
+  dependencySource = c("strict", "library"),
   verbose = FALSE,
   quiet = FALSE
 ) {
+  dependencySource <- match.arg(dependencySource)
   appFiles <- listDeploymentFiles(
     appDir,
     appFiles = appFiles,

--- a/R/writeManifest.R
+++ b/R/writeManifest.R
@@ -34,7 +34,7 @@ writeManifest <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  ignoreLockfile = FALSE,
+  dependencySource = "default",
   verbose = FALSE,
   quiet = FALSE
 ) {
@@ -65,8 +65,8 @@ writeManifest <- function(
   python <- getPython(python)
   pythonConfig <- pythonConfigurator(python, forceGeneratePythonEnvironment)
 
-  if (ignoreLockfile) {
-    confirmIgnoreLockfile()
+  if (dependencySource == "library") {
+    confirmDependencySourceLibrary()
   }
 
   # generate the manifest and write it into the bundle dir
@@ -81,7 +81,7 @@ writeManifest <- function(
     envManagementPy = envManagementPy,
     envManagementNodejs = envManagementNodejs,
     packageRepositoryResolutionR = packageRepositoryResolutionR,
-    ignoreLockfile = ignoreLockfile,
+    dependencySource = dependencySource,
     verbose = verbose,
     quiet = quiet
   )

--- a/R/writeManifest.R
+++ b/R/writeManifest.R
@@ -34,6 +34,7 @@ writeManifest <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
+  checkLockfile = TRUE,
   verbose = FALSE,
   quiet = FALSE
 ) {
@@ -76,6 +77,7 @@ writeManifest <- function(
     envManagementPy = envManagementPy,
     envManagementNodejs = envManagementNodejs,
     packageRepositoryResolutionR = packageRepositoryResolutionR,
+    checkLockfile = checkLockfile,
     verbose = verbose,
     quiet = quiet
   )

--- a/R/writeManifest.R
+++ b/R/writeManifest.R
@@ -34,7 +34,7 @@ writeManifest <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  dependencySource = "default",
+  dependencySource = "strict",
   verbose = FALSE,
   quiet = FALSE
 ) {

--- a/R/writeManifest.R
+++ b/R/writeManifest.R
@@ -34,7 +34,7 @@ writeManifest <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  checkLockfile = TRUE,
+  ignoreLockfile = FALSE,
   verbose = FALSE,
   quiet = FALSE
 ) {
@@ -65,6 +65,10 @@ writeManifest <- function(
   python <- getPython(python)
   pythonConfig <- pythonConfigurator(python, forceGeneratePythonEnvironment)
 
+  if (ignoreLockfile) {
+    confirmIgnoreLockfile()
+  }
+
   # generate the manifest and write it into the bundle dir
   manifest <- createAppManifest(
     appDir = bundleDir,
@@ -77,7 +81,7 @@ writeManifest <- function(
     envManagementPy = envManagementPy,
     envManagementNodejs = envManagementNodejs,
     packageRepositoryResolutionR = packageRepositoryResolutionR,
-    checkLockfile = checkLockfile,
+    ignoreLockfile = ignoreLockfile,
     verbose = verbose,
     quiet = quiet
   )

--- a/R/writeManifest.R
+++ b/R/writeManifest.R
@@ -34,11 +34,11 @@ writeManifest <- function(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  dependencySource = c("strict", "library"),
+  dependencyResolution = c("strict", "library"),
   verbose = FALSE,
   quiet = FALSE
 ) {
-  dependencySource <- match.arg(dependencySource)
+  dependencyResolution <- match.arg(dependencyResolution)
   appFiles <- listDeploymentFiles(
     appDir,
     appFiles = appFiles,
@@ -66,7 +66,7 @@ writeManifest <- function(
   python <- getPython(python)
   pythonConfig <- pythonConfigurator(python, forceGeneratePythonEnvironment)
 
-  if (dependencySource == "library") {
+  if (dependencyResolution == "library") {
     confirmDependencySourceLibrary()
   }
 
@@ -82,7 +82,7 @@ writeManifest <- function(
     envManagementPy = envManagementPy,
     envManagementNodejs = envManagementNodejs,
     packageRepositoryResolutionR = packageRepositoryResolutionR,
-    dependencySource = dependencySource,
+    dependencyResolution = dependencyResolution,
     verbose = verbose,
     quiet = quiet
   )

--- a/man/appDependencies.Rd
+++ b/man/appDependencies.Rd
@@ -8,7 +8,8 @@ appDependencies(
   appDir = getwd(),
   appFiles = NULL,
   appFileManifest = NULL,
-  appMode = NULL
+  appMode = NULL,
+  checkLockfile = TRUE
 )
 }
 \arguments{
@@ -29,6 +30,13 @@ Shiny application \code{app.R}. Accepted values include \code{"shiny"}, \code{"a
 \code{"rmd-static"}, \code{"rmd-shiny"}, \code{"quarto-static"}, \code{"quarto-shiny"},
 \code{"nodejs"}, and \code{"static"}. The Posit Connect API Reference contains a
 full set of available values. Not all servers support all types of content.}
+
+\item{checkLockfile}{If \code{TRUE} (the default), verifies that the versions in
+\code{renv.lock} match the locally installed library before deploying. Set to
+\code{FALSE} to skip this check and trust the lockfile as-is. This is useful
+when deploying from a CI/CD environment where the local library doesn't
+match the lockfile, or when the lockfile has been manually edited (e.g.
+with \code{renv::record()}). Only applies when an \code{renv.lock} file is present.}
 }
 \value{
 A data frame with one row for each dependency (direct, indirect,

--- a/man/appDependencies.Rd
+++ b/man/appDependencies.Rd
@@ -9,7 +9,7 @@ appDependencies(
   appFiles = NULL,
   appFileManifest = NULL,
   appMode = NULL,
-  dependencySource = "default"
+  dependencySource = "strict"
 )
 }
 \arguments{
@@ -32,13 +32,14 @@ Shiny application \code{app.R}. Accepted values include \code{"shiny"}, \code{"a
 full set of available values. Not all servers support all types of content.}
 
 \item{dependencySource}{Controls how R package dependencies are resolved.
-Must be one of \code{"default"} or \code{"library"}. When \code{"default"}, the
-\code{renv.lock} file is used if present. When \code{"library"}, the lockfile is
-ignored and dependencies are resolved from the locally installed library
-instead. This is useful when the lockfile is out of sync with the local
-library and cannot be updated (e.g. in CI/CD environments). Note that
-the deployed content will reflect the local library, not the lockfile.
-Defaults to \code{"default"}.}
+Must be one of \code{"strict"} or \code{"library"}. When \code{"strict"}, the
+\code{renv.lock} file is used if present and must match the local library.
+When \code{"library"}, the lockfile is ignored and dependencies are resolved
+from the locally installed library instead. This is useful when the
+lockfile is out of sync with the local library and cannot be updated
+(e.g. in CI/CD environments). Note that the deployed content will
+reflect the local library, not the lockfile.
+Defaults to \code{"strict"}.}
 }
 \value{
 A data frame with one row for each dependency (direct, indirect,

--- a/man/appDependencies.Rd
+++ b/man/appDependencies.Rd
@@ -9,7 +9,7 @@ appDependencies(
   appFiles = NULL,
   appFileManifest = NULL,
   appMode = NULL,
-  checkLockfile = TRUE
+  ignoreLockfile = FALSE
 )
 }
 \arguments{
@@ -31,12 +31,12 @@ Shiny application \code{app.R}. Accepted values include \code{"shiny"}, \code{"a
 \code{"nodejs"}, and \code{"static"}. The Posit Connect API Reference contains a
 full set of available values. Not all servers support all types of content.}
 
-\item{checkLockfile}{If \code{TRUE} (the default), verifies that the versions in
-\code{renv.lock} match the locally installed library before deploying. Set to
-\code{FALSE} to skip this check and trust the lockfile as-is. This is useful
-when deploying from a CI/CD environment where the local library doesn't
-match the lockfile, or when the lockfile has been manually edited (e.g.
-with \code{renv::record()}). Only applies when an \code{renv.lock} file is present.}
+\item{ignoreLockfile}{If \code{TRUE}, the \code{renv.lock} file is ignored and
+package dependencies are resolved from the locally installed library
+instead. This is useful when the lockfile is out of sync with the local
+library and cannot be updated (e.g. in CI/CD environments). Note that
+the deployed content will reflect the local library, not the lockfile.
+Defaults to \code{FALSE}.}
 }
 \value{
 A data frame with one row for each dependency (direct, indirect,

--- a/man/appDependencies.Rd
+++ b/man/appDependencies.Rd
@@ -9,7 +9,7 @@ appDependencies(
   appFiles = NULL,
   appFileManifest = NULL,
   appMode = NULL,
-  ignoreLockfile = FALSE
+  dependencySource = "default"
 )
 }
 \arguments{
@@ -31,12 +31,14 @@ Shiny application \code{app.R}. Accepted values include \code{"shiny"}, \code{"a
 \code{"nodejs"}, and \code{"static"}. The Posit Connect API Reference contains a
 full set of available values. Not all servers support all types of content.}
 
-\item{ignoreLockfile}{If \code{TRUE}, the \code{renv.lock} file is ignored and
-package dependencies are resolved from the locally installed library
+\item{dependencySource}{Controls how R package dependencies are resolved.
+Must be one of \code{"default"} or \code{"library"}. When \code{"default"}, the
+\code{renv.lock} file is used if present. When \code{"library"}, the lockfile is
+ignored and dependencies are resolved from the locally installed library
 instead. This is useful when the lockfile is out of sync with the local
 library and cannot be updated (e.g. in CI/CD environments). Note that
 the deployed content will reflect the local library, not the lockfile.
-Defaults to \code{FALSE}.}
+Defaults to \code{"default"}.}
 }
 \value{
 A data frame with one row for each dependency (direct, indirect,

--- a/man/appDependencies.Rd
+++ b/man/appDependencies.Rd
@@ -9,7 +9,7 @@ appDependencies(
   appFiles = NULL,
   appFileManifest = NULL,
   appMode = NULL,
-  dependencySource = c("strict", "library")
+  dependencyResolution = c("strict", "library")
 )
 }
 \arguments{
@@ -31,7 +31,7 @@ Shiny application \code{app.R}. Accepted values include \code{"shiny"}, \code{"a
 \code{"nodejs"}, and \code{"static"}. The Posit Connect API Reference contains a
 full set of available values. Not all servers support all types of content.}
 
-\item{dependencySource}{Controls how R package dependencies are resolved.
+\item{dependencyResolution}{Controls how R package dependencies are resolved.
 Must be one of \code{"strict"} or \code{"library"}. When \code{"strict"}, the
 \code{renv.lock} file is used if present and must match the local library.
 When \code{"library"}, the lockfile is ignored and dependencies are resolved

--- a/man/appDependencies.Rd
+++ b/man/appDependencies.Rd
@@ -9,7 +9,7 @@ appDependencies(
   appFiles = NULL,
   appFileManifest = NULL,
   appMode = NULL,
-  dependencySource = "strict"
+  dependencySource = c("strict", "library")
 )
 }
 \arguments{

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -37,7 +37,7 @@ deployApp(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  ignoreLockfile = FALSE
+  dependencySource = "default"
 )
 }
 \arguments{
@@ -246,12 +246,14 @@ resolution strategy for R packages. Must be one of \code{"lax"}, \code{"strict"}
 any values to the bundle manifest and Connect will fall back to the
 server's package repository resolution strategy.}
 
-\item{ignoreLockfile}{If \code{TRUE}, the \code{renv.lock} file is ignored and
-package dependencies are resolved from the locally installed library
+\item{dependencySource}{Controls how R package dependencies are resolved.
+Must be one of \code{"default"} or \code{"library"}. When \code{"default"}, the
+\code{renv.lock} file is used if present. When \code{"library"}, the lockfile is
+ignored and dependencies are resolved from the locally installed library
 instead. This is useful when the lockfile is out of sync with the local
 library and cannot be updated (e.g. in CI/CD environments). Note that
 the deployed content will reflect the local library, not the lockfile.
-Defaults to \code{FALSE}.}
+Defaults to \code{"default"}.}
 }
 \description{
 Deploy a \link[shiny:shiny-package]{shiny} application, an

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -37,7 +37,7 @@ deployApp(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  dependencySource = "strict"
+  dependencySource = c("strict", "library")
 )
 }
 \arguments{

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -37,7 +37,7 @@ deployApp(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  dependencySource = "default"
+  dependencySource = "strict"
 )
 }
 \arguments{
@@ -247,13 +247,14 @@ any values to the bundle manifest and Connect will fall back to the
 server's package repository resolution strategy.}
 
 \item{dependencySource}{Controls how R package dependencies are resolved.
-Must be one of \code{"default"} or \code{"library"}. When \code{"default"}, the
-\code{renv.lock} file is used if present. When \code{"library"}, the lockfile is
-ignored and dependencies are resolved from the locally installed library
-instead. This is useful when the lockfile is out of sync with the local
-library and cannot be updated (e.g. in CI/CD environments). Note that
-the deployed content will reflect the local library, not the lockfile.
-Defaults to \code{"default"}.}
+Must be one of \code{"strict"} or \code{"library"}. When \code{"strict"}, the
+\code{renv.lock} file is used if present and must match the local library.
+When \code{"library"}, the lockfile is ignored and dependencies are resolved
+from the locally installed library instead. This is useful when the
+lockfile is out of sync with the local library and cannot be updated
+(e.g. in CI/CD environments). Note that the deployed content will
+reflect the local library, not the lockfile.
+Defaults to \code{"strict"}.}
 }
 \description{
 Deploy a \link[shiny:shiny-package]{shiny} application, an

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -37,7 +37,7 @@ deployApp(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  dependencySource = c("strict", "library")
+  dependencyResolution = c("strict", "library")
 )
 }
 \arguments{
@@ -246,7 +246,7 @@ resolution strategy for R packages. Must be one of \code{"lax"}, \code{"strict"}
 any values to the bundle manifest and Connect will fall back to the
 server's package repository resolution strategy.}
 
-\item{dependencySource}{Controls how R package dependencies are resolved.
+\item{dependencyResolution}{Controls how R package dependencies are resolved.
 Must be one of \code{"strict"} or \code{"library"}. When \code{"strict"}, the
 \code{renv.lock} file is used if present and must match the local library.
 When \code{"library"}, the lockfile is ignored and dependencies are resolved

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -36,7 +36,8 @@ deployApp(
   envManagementR = NULL,
   envManagementPy = NULL,
   envManagementNodejs = NULL,
-  packageRepositoryResolutionR = NULL
+  packageRepositoryResolutionR = NULL,
+  checkLockfile = TRUE
 )
 }
 \arguments{
@@ -244,6 +245,13 @@ resolution strategy for R packages. Must be one of \code{"lax"}, \code{"strict"}
 \code{"legacy"}, \code{"lockfile"}, or \code{NULL}. The default, \code{NULL}, will not write
 any values to the bundle manifest and Connect will fall back to the
 server's package repository resolution strategy.}
+
+\item{checkLockfile}{If \code{TRUE} (the default), verifies that the versions in
+\code{renv.lock} match the locally installed library before deploying. Set to
+\code{FALSE} to skip this check and trust the lockfile as-is. This is useful
+when deploying from a CI/CD environment where the local library doesn't
+match the lockfile, or when the lockfile has been manually edited (e.g.
+with \code{renv::record()}). Only applies when an \code{renv.lock} file is present.}
 }
 \description{
 Deploy a \link[shiny:shiny-package]{shiny} application, an

--- a/man/deployApp.Rd
+++ b/man/deployApp.Rd
@@ -37,7 +37,7 @@ deployApp(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  checkLockfile = TRUE
+  ignoreLockfile = FALSE
 )
 }
 \arguments{
@@ -246,12 +246,12 @@ resolution strategy for R packages. Must be one of \code{"lax"}, \code{"strict"}
 any values to the bundle manifest and Connect will fall back to the
 server's package repository resolution strategy.}
 
-\item{checkLockfile}{If \code{TRUE} (the default), verifies that the versions in
-\code{renv.lock} match the locally installed library before deploying. Set to
-\code{FALSE} to skip this check and trust the lockfile as-is. This is useful
-when deploying from a CI/CD environment where the local library doesn't
-match the lockfile, or when the lockfile has been manually edited (e.g.
-with \code{renv::record()}). Only applies when an \code{renv.lock} file is present.}
+\item{ignoreLockfile}{If \code{TRUE}, the \code{renv.lock} file is ignored and
+package dependencies are resolved from the locally installed library
+instead. This is useful when the lockfile is out of sync with the local
+library and cannot be updated (e.g. in CI/CD environments). Note that
+the deployed content will reflect the local library, not the lockfile.
+Defaults to \code{FALSE}.}
 }
 \description{
 Deploy a \link[shiny:shiny-package]{shiny} application, an

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -20,7 +20,7 @@ writeManifest(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  dependencySource = c("strict", "library"),
+  dependencyResolution = c("strict", "library"),
   verbose = FALSE,
   quiet = FALSE
 )
@@ -116,7 +116,7 @@ resolution strategy for R packages. Must be one of \code{"lax"}, \code{"strict"}
 any values to the bundle manifest and Connect will fall back to the
 server's package repository resolution strategy.}
 
-\item{dependencySource}{Controls how R package dependencies are resolved.
+\item{dependencyResolution}{Controls how R package dependencies are resolved.
 Must be one of \code{"strict"} or \code{"library"}. When \code{"strict"}, the
 \code{renv.lock} file is used if present and must match the local library.
 When \code{"library"}, the lockfile is ignored and dependencies are resolved

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -20,7 +20,7 @@ writeManifest(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  ignoreLockfile = FALSE,
+  dependencySource = "default",
   verbose = FALSE,
   quiet = FALSE
 )
@@ -116,12 +116,14 @@ resolution strategy for R packages. Must be one of \code{"lax"}, \code{"strict"}
 any values to the bundle manifest and Connect will fall back to the
 server's package repository resolution strategy.}
 
-\item{ignoreLockfile}{If \code{TRUE}, the \code{renv.lock} file is ignored and
-package dependencies are resolved from the locally installed library
+\item{dependencySource}{Controls how R package dependencies are resolved.
+Must be one of \code{"default"} or \code{"library"}. When \code{"default"}, the
+\code{renv.lock} file is used if present. When \code{"library"}, the lockfile is
+ignored and dependencies are resolved from the locally installed library
 instead. This is useful when the lockfile is out of sync with the local
 library and cannot be updated (e.g. in CI/CD environments). Note that
 the deployed content will reflect the local library, not the lockfile.
-Defaults to \code{FALSE}.}
+Defaults to \code{"default"}.}
 
 \item{verbose}{If \code{TRUE}, prints detailed progress messages.}
 

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -20,7 +20,7 @@ writeManifest(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  dependencySource = "strict",
+  dependencySource = c("strict", "library"),
   verbose = FALSE,
   quiet = FALSE
 )

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -20,7 +20,7 @@ writeManifest(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  checkLockfile = TRUE,
+  ignoreLockfile = FALSE,
   verbose = FALSE,
   quiet = FALSE
 )
@@ -116,12 +116,12 @@ resolution strategy for R packages. Must be one of \code{"lax"}, \code{"strict"}
 any values to the bundle manifest and Connect will fall back to the
 server's package repository resolution strategy.}
 
-\item{checkLockfile}{If \code{TRUE} (the default), verifies that the versions in
-\code{renv.lock} match the locally installed library before deploying. Set to
-\code{FALSE} to skip this check and trust the lockfile as-is. This is useful
-when deploying from a CI/CD environment where the local library doesn't
-match the lockfile, or when the lockfile has been manually edited (e.g.
-with \code{renv::record()}). Only applies when an \code{renv.lock} file is present.}
+\item{ignoreLockfile}{If \code{TRUE}, the \code{renv.lock} file is ignored and
+package dependencies are resolved from the locally installed library
+instead. This is useful when the lockfile is out of sync with the local
+library and cannot be updated (e.g. in CI/CD environments). Note that
+the deployed content will reflect the local library, not the lockfile.
+Defaults to \code{FALSE}.}
 
 \item{verbose}{If \code{TRUE}, prints detailed progress messages.}
 

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -20,6 +20,7 @@ writeManifest(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
+  checkLockfile = TRUE,
   verbose = FALSE,
   quiet = FALSE
 )
@@ -114,6 +115,13 @@ resolution strategy for R packages. Must be one of \code{"lax"}, \code{"strict"}
 \code{"legacy"}, \code{"lockfile"}, or \code{NULL}. The default, \code{NULL}, will not write
 any values to the bundle manifest and Connect will fall back to the
 server's package repository resolution strategy.}
+
+\item{checkLockfile}{If \code{TRUE} (the default), verifies that the versions in
+\code{renv.lock} match the locally installed library before deploying. Set to
+\code{FALSE} to skip this check and trust the lockfile as-is. This is useful
+when deploying from a CI/CD environment where the local library doesn't
+match the lockfile, or when the lockfile has been manually edited (e.g.
+with \code{renv::record()}). Only applies when an \code{renv.lock} file is present.}
 
 \item{verbose}{If \code{TRUE}, prints detailed progress messages.}
 

--- a/man/writeManifest.Rd
+++ b/man/writeManifest.Rd
@@ -20,7 +20,7 @@ writeManifest(
   envManagementPy = NULL,
   envManagementNodejs = NULL,
   packageRepositoryResolutionR = NULL,
-  dependencySource = "default",
+  dependencySource = "strict",
   verbose = FALSE,
   quiet = FALSE
 )
@@ -117,13 +117,14 @@ any values to the bundle manifest and Connect will fall back to the
 server's package repository resolution strategy.}
 
 \item{dependencySource}{Controls how R package dependencies are resolved.
-Must be one of \code{"default"} or \code{"library"}. When \code{"default"}, the
-\code{renv.lock} file is used if present. When \code{"library"}, the lockfile is
-ignored and dependencies are resolved from the locally installed library
-instead. This is useful when the lockfile is out of sync with the local
-library and cannot be updated (e.g. in CI/CD environments). Note that
-the deployed content will reflect the local library, not the lockfile.
-Defaults to \code{"default"}.}
+Must be one of \code{"strict"} or \code{"library"}. When \code{"strict"}, the
+\code{renv.lock} file is used if present and must match the local library.
+When \code{"library"}, the lockfile is ignored and dependencies are resolved
+from the locally installed library instead. This is useful when the
+lockfile is out of sync with the local library and cannot be updated
+(e.g. in CI/CD environments). Note that the deployed content will
+reflect the local library, not the lockfile.
+Defaults to \code{"strict"}.}
 
 \item{verbose}{If \code{TRUE}, prints detailed progress messages.}
 

--- a/tests/testthat/_snaps/bundlePackageRenv.md
+++ b/tests/testthat/_snaps/bundlePackageRenv.md
@@ -12,4 +12,5 @@
       ! Library and lockfile are out of sync
       i Use renv::restore() or renv::snapshot() to synchronise
       i Or ignore the lockfile by adding to your .rscignore
+      i Or set `checkLockfile = FALSE` to trust the lockfile as-is
 

--- a/tests/testthat/_snaps/bundlePackageRenv.md
+++ b/tests/testthat/_snaps/bundlePackageRenv.md
@@ -12,5 +12,5 @@
       ! Library and lockfile are out of sync
       i Use renv::restore() or renv::snapshot() to synchronise
       i Or ignore the lockfile by adding to your .rscignore
-      i Or set `checkLockfile = FALSE` to trust the lockfile as-is
+      i Or set `ignoreLockfile = TRUE` to ignore the lockfile and use the local library instead
 

--- a/tests/testthat/_snaps/bundlePackageRenv.md
+++ b/tests/testthat/_snaps/bundlePackageRenv.md
@@ -3,6 +3,17 @@
     Code
       deps <- snapshotRenvDependencies(app_dir)
 
+# errors when renv::snapshot fails
+
+    Code
+      snapshotRenvDependencies(app_dir)
+    Condition
+      Error in `snapshotRenvDependencies()`:
+      ! Failed to snapshot dependencies with renv.
+      i For example you have a locally-developed package that is not installed from a known source.
+      Caused by error in `renv::snapshot()`:
+      ! can't snapshot this package
+
 # errors if library and project are inconsistent
 
     Code
@@ -12,5 +23,5 @@
       ! Library and lockfile are out of sync
       i Use renv::restore() or renv::snapshot() to synchronise
       i Or ignore the lockfile by adding to your .rscignore
-      i Or set `ignoreLockfile = TRUE` to ignore the lockfile and use the local library instead
+      i Or set `dependencySource = "library"` to ignore the lockfile and use the local library instead
 

--- a/tests/testthat/_snaps/bundlePackageRenv.md
+++ b/tests/testthat/_snaps/bundlePackageRenv.md
@@ -10,7 +10,7 @@
     Condition
       Error in `snapshotRenvDependencies()`:
       ! Failed to snapshot dependencies with renv.
-      i For example you have a locally-developed package that is not installed from a known source.
+      i For example, you have a locally-developed package that is installed from disk.
       Caused by error in `renv::snapshot()`:
       ! can't snapshot this package
 

--- a/tests/testthat/_snaps/bundlePackageRenv.md
+++ b/tests/testthat/_snaps/bundlePackageRenv.md
@@ -23,5 +23,5 @@
       ! Library and lockfile are out of sync
       i Use renv::restore() or renv::snapshot() to synchronise
       i Or ignore the lockfile by adding to your .rscignore
-      i Or set `dependencySource = "library"` to ignore the lockfile and use the local library instead
+      i Or set `dependencyResolution = "library"` to ignore the lockfile and use the local library instead
 

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -133,6 +133,24 @@ test_that("errors if library and project are inconsistent", {
   )
 })
 
+test_that("checkLockfile = FALSE skips sync check", {
+  skip_if_not_installed("foreign")
+  skip_if_not_installed("MASS")
+
+  withr::local_options(renv.verbose = FALSE)
+
+  app_dir <- local_temp_app(list("foo.R" = "library(foreign); library(MASS)"))
+  renv::snapshot(app_dir, prompt = FALSE)
+  renv::record("MASS@0.1.1", project = app_dir)
+
+  deps <- parseRenvDependencies(
+    file.path(app_dir, "renv.lock"),
+    app_dir,
+    checkLockfile = FALSE
+  )
+  expect_true("MASS" %in% deps$Package)
+})
+
 # standardizeRenvPackage -----------------------------------------
 
 test_that("SCM get names translated", {

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -144,6 +144,7 @@ test_that("ignoreLockfile = TRUE bypasses lockfile and uses local library", {
   renv::snapshot(app_dir, prompt = FALSE)
   renv::record("MASS@0.1.1", project = app_dir)
 
+  # Without ignoreLockfile, this would error with "out of sync"
   deps <- computePackageDependencies(
     app_dir,
     quiet = TRUE,
@@ -151,7 +152,7 @@ test_that("ignoreLockfile = TRUE bypasses lockfile and uses local library", {
   )
   expect_true("MASS" %in% deps$Package)
   mass_dep <- deps[deps$Package == "MASS", ]
-  expect_equal(mass_dep$Version, as.character(packageVersion("MASS")))
+  expect_true(mass_dep$Version != "0.1.1")
 })
 
 # standardizeRenvPackage -----------------------------------------

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -133,7 +133,8 @@ test_that("errors if library and project are inconsistent", {
   )
 })
 
-test_that("checkLockfile = FALSE skips sync check", {
+test_that("ignoreLockfile = TRUE bypasses lockfile and uses local library", {
+  skip_on_cran()
   skip_if_not_installed("foreign")
   skip_if_not_installed("MASS")
 
@@ -143,12 +144,10 @@ test_that("checkLockfile = FALSE skips sync check", {
   renv::snapshot(app_dir, prompt = FALSE)
   renv::record("MASS@0.1.1", project = app_dir)
 
-  deps <- parseRenvDependencies(
-    file.path(app_dir, "renv.lock"),
-    app_dir,
-    checkLockfile = FALSE
-  )
+  deps <- computePackageDependencies(app_dir, quiet = TRUE, ignoreLockfile = TRUE)
   expect_true("MASS" %in% deps$Package)
+  mass_dep <- deps[deps$Package == "MASS", ]
+  expect_equal(mass_dep$Version, as.character(packageVersion("MASS")))
 })
 
 # standardizeRenvPackage -----------------------------------------

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -144,7 +144,11 @@ test_that("ignoreLockfile = TRUE bypasses lockfile and uses local library", {
   renv::snapshot(app_dir, prompt = FALSE)
   renv::record("MASS@0.1.1", project = app_dir)
 
-  deps <- computePackageDependencies(app_dir, quiet = TRUE, ignoreLockfile = TRUE)
+  deps <- computePackageDependencies(
+    app_dir,
+    quiet = TRUE,
+    ignoreLockfile = TRUE
+  )
   expect_true("MASS" %in% deps$Package)
   mass_dep <- deps[deps$Package == "MASS", ]
   expect_equal(mass_dep$Version, as.character(packageVersion("MASS")))

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -149,12 +149,11 @@ test_that("errors if library and project are inconsistent", {
 
 test_that("dependencySource = 'library' bypasses lockfile and uses local library", {
   skip_on_cran()
-  skip_if_not_installed("foreign")
   skip_if_not_installed("MASS")
 
   withr::local_options(renv.verbose = FALSE)
 
-  app_dir <- local_temp_app(list("foo.R" = "library(foreign); library(MASS)"))
+  app_dir <- local_temp_app(list("foo.R" = "library(MASS)"))
   renv::snapshot(app_dir, prompt = FALSE)
   renv::record("MASS@0.1.1", project = app_dir)
 

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -147,7 +147,7 @@ test_that("errors if library and project are inconsistent", {
   )
 })
 
-test_that("dependencySource = 'library' bypasses lockfile and uses local library", {
+test_that("dependencyResolution = 'library' bypasses lockfile and uses local library", {
   skip_on_cran()
   skip_if_not_installed("MASS")
 
@@ -157,11 +157,11 @@ test_that("dependencySource = 'library' bypasses lockfile and uses local library
   renv::snapshot(app_dir, prompt = FALSE)
   renv::record("MASS@0.1.1", project = app_dir)
 
-  # Without dependencySource = "library", this would error with "out of sync"
+  # Without dependencyResolution = "library", this would error with "out of sync"
   deps <- computePackageDependencies(
     app_dir,
     quiet = TRUE,
-    dependencySource = "library"
+    dependencyResolution = "library"
   )
   expect_true("MASS" %in% deps$Package)
   mass_dep <- deps[deps$Package == "MASS", ]

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -97,6 +97,20 @@ test_that("large directories are analyzed", {
   expect_contains(deps$Package, "foreign")
 })
 
+test_that("errors when renv::snapshot fails", {
+  local_mocked_bindings(
+    dependencies = function(...) data.frame(Package = "fakepkg"),
+    snapshot = function(...) stop("can't snapshot this package"),
+    .package = "renv"
+  )
+
+  app_dir <- local_temp_app(list("foo.R" = "library(foreign)"))
+  expect_snapshot(
+    snapshotRenvDependencies(app_dir),
+    error = TRUE
+  )
+})
+
 # parseRenvDependencies ---------------------------------------------------
 
 test_that("gets DESCRIPTION from renv & system libraries", {
@@ -133,7 +147,7 @@ test_that("errors if library and project are inconsistent", {
   )
 })
 
-test_that("ignoreLockfile = TRUE bypasses lockfile and uses local library", {
+test_that("dependencySource = 'library' bypasses lockfile and uses local library", {
   skip_on_cran()
   skip_if_not_installed("foreign")
   skip_if_not_installed("MASS")
@@ -144,11 +158,11 @@ test_that("ignoreLockfile = TRUE bypasses lockfile and uses local library", {
   renv::snapshot(app_dir, prompt = FALSE)
   renv::record("MASS@0.1.1", project = app_dir)
 
-  # Without ignoreLockfile, this would error with "out of sync"
+  # Without dependencySource = "library", this would error with "out of sync"
   deps <- computePackageDependencies(
     app_dir,
     quiet = TRUE,
-    ignoreLockfile = TRUE
+    dependencySource = "library"
   )
   expect_true("MASS" %in% deps$Package)
   mass_dep <- deps[deps$Package == "MASS", ]

--- a/tests/testthat/test-deployApp.R
+++ b/tests/testthat/test-deployApp.R
@@ -269,3 +269,36 @@ test_that("manifestPath ignored when NULL", {
     )
   })
 })
+
+# confirmIgnoreLockfile ---------------------------------------------------
+
+test_that("confirmIgnoreLockfile proceeds when user answers Y", {
+  simulate_user_input("Y")
+  expect_warning(
+    confirmIgnoreLockfile(),
+    "renv.lock.*will be ignored"
+  )
+})
+
+test_that("confirmIgnoreLockfile proceeds on empty input (default Y)", {
+  simulate_user_input("")
+  expect_warning(
+    confirmIgnoreLockfile(),
+    "renv.lock.*will be ignored"
+  )
+})
+
+test_that("confirmIgnoreLockfile aborts when user answers n", {
+  simulate_user_input("n")
+  expect_error(
+    suppressWarnings(confirmIgnoreLockfile()),
+    "Deployment cancelled"
+  )
+})
+
+test_that("confirmIgnoreLockfile proceeds non-interactively with warning", {
+  expect_warning(
+    confirmIgnoreLockfile(),
+    "renv.lock.*will be ignored"
+  )
+})

--- a/tests/testthat/test-deployApp.R
+++ b/tests/testthat/test-deployApp.R
@@ -274,30 +274,30 @@ test_that("manifestPath ignored when NULL", {
 
 test_that("confirmDependencySourceLibrary proceeds when user answers Y", {
   simulate_user_input("Y")
-  expect_warning(
+  expect_message(
     confirmDependencySourceLibrary(),
-    "renv.lock.*will be ignored"
+    "renv.lock will be ignored"
   )
 })
 
 test_that("confirmDependencySourceLibrary proceeds on empty input (default Y)", {
   simulate_user_input("")
-  expect_warning(
+  expect_message(
     confirmDependencySourceLibrary(),
-    "renv.lock.*will be ignored"
+    "renv.lock will be ignored"
   )
 })
 
 test_that("confirmDependencySourceLibrary aborts when user answers n", {
   simulate_user_input("n")
   expect_error(
-    suppressWarnings(confirmDependencySourceLibrary()),
+    suppressMessages(confirmDependencySourceLibrary()),
     "Deployment cancelled"
   )
 })
 
-test_that("confirmDependencySourceLibrary proceeds non-interactively with warning", {
-  expect_warning(
+test_that("confirmDependencySourceLibrary informs non-interactively", {
+  expect_message(
     confirmDependencySourceLibrary(),
     "renv.lock.*will be ignored"
   )

--- a/tests/testthat/test-deployApp.R
+++ b/tests/testthat/test-deployApp.R
@@ -270,35 +270,35 @@ test_that("manifestPath ignored when NULL", {
   })
 })
 
-# confirmIgnoreLockfile ---------------------------------------------------
+# confirmDependencySourceLibrary -------------------------------------------
 
-test_that("confirmIgnoreLockfile proceeds when user answers Y", {
+test_that("confirmDependencySourceLibrary proceeds when user answers Y", {
   simulate_user_input("Y")
   expect_warning(
-    confirmIgnoreLockfile(),
+    confirmDependencySourceLibrary(),
     "renv.lock.*will be ignored"
   )
 })
 
-test_that("confirmIgnoreLockfile proceeds on empty input (default Y)", {
+test_that("confirmDependencySourceLibrary proceeds on empty input (default Y)", {
   simulate_user_input("")
   expect_warning(
-    confirmIgnoreLockfile(),
+    confirmDependencySourceLibrary(),
     "renv.lock.*will be ignored"
   )
 })
 
-test_that("confirmIgnoreLockfile aborts when user answers n", {
+test_that("confirmDependencySourceLibrary aborts when user answers n", {
   simulate_user_input("n")
   expect_error(
-    suppressWarnings(confirmIgnoreLockfile()),
+    suppressWarnings(confirmDependencySourceLibrary()),
     "Deployment cancelled"
   )
 })
 
-test_that("confirmIgnoreLockfile proceeds non-interactively with warning", {
+test_that("confirmDependencySourceLibrary proceeds non-interactively with warning", {
   expect_warning(
-    confirmIgnoreLockfile(),
+    confirmDependencySourceLibrary(),
     "renv.lock.*will be ignored"
   )
 })


### PR DESCRIPTION
## Summary

- `deployApp()`, `writeManifest()`, and `appDependencies()` gain a `dependencySource` parameter (default `"strict"`). When set to `"library"`, the `renv.lock` file is ignored and package dependencies are resolved from the local library instead via `renv::snapshot()`.
- A warning and interactive confirmation prompt are shown when `dependencySource = "library"`, making it clear that the deployed content will reflect the local library, not the lockfile.
- Improved error messages when `renv::snapshot()` fails during dependency discovery, with actionable workarounds.

Closes #1046, #1315. Related: #1078, #1317.

## Behavior

When `dependencySource = "library"`:
1. The lockfile branch in `computePackageDependencies()` is skipped entirely.
2. Dependencies fall through to `snapshotRenvDependencies()`, which does a fresh `renv::snapshot()` from the local library.
3. The user sees a warning and (in interactive sessions) a `[Y/n]` confirmation prompt before proceeding.

This avoids the "Library and lockfile are out of sync" error for users who:
- Deploy from CI/CD environments where the local library differs from the lockfile.
- Manually edit the lockfile (e.g. with `renv::record()`).
- Develop Shiny apps packaged as R packages (golem pattern).

### Screenshots
**non-sync library -message "Or set dependencySource = ..."**

<img width="1468" height="325" alt="Screenshot 2026-05-14 at 11 42 23 a m" src="https://github.com/user-attachments/assets/e1571f5c-5300-4878-a9cd-4a27458b9f53" />

**Deploying with `dependencySource = "library"`**

<img width="1506" height="522" alt="Screenshot 2026-05-14 at 11 43 12 a m" src="https://github.com/user-attachments/assets/4ee294c9-3003-4fa1-a87d-54d8ec9d4c63" />

**`writeManifest(dependencySource = "library")` also asks for confirmation**

<img width="961" height="181" alt="Screenshot 2026-05-14 at 11 35 38 a m" src="https://github.com/user-attachments/assets/0c59b0b7-ddc5-4a9a-9b42-b0e618723b8c" />



## Test plan

- [x] Existing `parseRenvDependencies` sync-check test still passes (snapshot updated with new hint)
- [x] New test: `dependencySource = "library"` bypasses lockfile and resolves from local library
- [x] New test: mocked `renv::snapshot` failure produces expected error message (snapshot test)
- [x] New tests for `confirmDependencySourceLibrary()`: user answers Y, empty input (default Y), user answers n (aborts), non-interactive (proceeds with warning)
- [x] Rd files regenerated with `roxygen2::roxygenise()`