### PR TITLE
fix: fix history file maintenance race and cap size

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,6 @@
 
 * `deployApp()` with `logLevel = "verbose"` no longer errors using the `httr2` backend. (#1312)
 
-
 # rsconnect 1.8.0
 
 * `rsconnect` now uses [`httr2`](https://httr2.r-lib.org/) as its HTTP client.
@@ -56,7 +55,6 @@
 * Removed several functions, including `addConnectServer()` and
   `discoverServer()`, as well as HTTP backends other than libcurl,
   which were deprecated in rsconnect 1.0.0. (#1282)
-
 
 # rsconnect 1.7.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,14 @@
   with a CRAN repository URL when the same package appeared in CRAN's Transit
   directory. (#1314)
 
+* The global deployment history file used by the Workbench dashboard no longer
+  uses a fixed temporary file name during updates, eliminating a race
+  condition that could cause the file to rapidly grow during concurrent
+  deployments. The history is also capped at 100 records and resets if the
+  file grows excessively large. (#1320)
+
 * `deployApp()` with `logLevel = "verbose"` no longer errors using the `httr2` backend. (#1312)
+
 
 # rsconnect 1.8.0
 

--- a/R/config.R
+++ b/R/config.R
@@ -106,11 +106,15 @@ accountConfigFiles <- function(server = NULL) {
 
 # deployments -------------------------------------------------------------
 
+# returns the path to the history file. When new=TRUE, computes a temporary location to use during
+# history-file modification. The caller is responsible for removing this temporary file.
 deploymentHistoryPath <- function(new = FALSE) {
-  file.path(
-    rsconnectConfigDir("deployments"),
-    paste0("history", if (new) ".new", ".dcf")
-  )
+  dir <- rsconnectConfigDir("deployments")
+  if (new) {
+    tempfile(pattern = "history", tmpdir = dir, fileext = ".dcf")
+  } else {
+    file.path(dir, "history.dcf")
+  }
 }
 
 # given a path, return the directory under which rsconnect package state is

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -194,7 +194,7 @@ addToDeploymentHistory <- function(appPath, deploymentRecord) {
 
   # Truncate the history file when it grows beyond this size.
   # Do not read large files; they may be enormous (#1320).
-  max_bytes <- getOption("rsconnect.max.history.bytes", 1e6)
+  max_bytes <- getOption("rsconnect.max.history.bytes", 1024^2)
 
   # When the history file is reasonably sized, preserve this number of records.
   max_records <- max(1L, getOption("rsconnect.max.history.records", 100L))

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -187,23 +187,36 @@ writeDeploymentRecord <- function(record, filePath) {
   write.dcf(record, filePath, width = 4096)
 }
 
-# Workbench uses to show a list of recently deployed content on user dashboard
+# Workbench uses to show a list of recently deployed content on user dashboard.
 addToDeploymentHistory <- function(appPath, deploymentRecord) {
-  # add the appPath to the deploymentRecord
+  ## deployment history is global; reference back to the app path.
   deploymentRecord$appPath <- appPath
 
-  # write new history file
-  newHistory <- deploymentHistoryPath(new = TRUE)
-  writeDeploymentRecord(deploymentRecord, newHistory)
+  # Truncate the history file when it grows beyond this size.
+  # Do not read large files; they may be enormous (#1320).
+  max_bytes <- getOption("rsconnect.max.history.bytes", 1e6)
+
+  # When the history file is reasonably sized, preserve this number of records.
+  max_records <- getOption("rsconnect.max.history.records", 100L)
 
   history <- deploymentHistoryPath()
-  # append existing history to new history
-  if (file.exists(history)) {
-    cat("\n", file = newHistory, append = TRUE)
-    file.append(newHistory, history)
+  prior <- if (file.exists(history) && file.size(history) <= max_bytes) {
+    read.dcf(history)
+  } else {
+    matrix(character(0), nrow = 0)
   }
 
-  # overwrite with new history
+  # The history file lists most-recent first; write the new record before
+  # appending older items, capped by max_records.
+  newHistory <- deploymentHistoryPath(new = TRUE)
+  on.exit(unlink(newHistory), add = TRUE)
+  writeDeploymentRecord(deploymentRecord, newHistory)
+  if (nrow(prior) > 0L) {
+    n_prior <- min(nrow(prior), max_records - 1L)
+    cat("\n", file = newHistory, append = TRUE)
+    write.dcf(head(prior, n_prior), newHistory, append = TRUE, width = 4096)
+  }
+
   file.rename(newHistory, history)
   invisible()
 }

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -189,7 +189,7 @@ writeDeploymentRecord <- function(record, filePath) {
 
 # Workbench uses to show a list of recently deployed content on user dashboard.
 addToDeploymentHistory <- function(appPath, deploymentRecord) {
-  ## deployment history is global; reference back to the app path.
+  # deployment history is global; reference back to the app path.
   deploymentRecord$appPath <- appPath
 
   # Truncate the history file when it grows beyond this size.
@@ -197,7 +197,7 @@ addToDeploymentHistory <- function(appPath, deploymentRecord) {
   max_bytes <- getOption("rsconnect.max.history.bytes", 1e6)
 
   # When the history file is reasonably sized, preserve this number of records.
-  max_records <- getOption("rsconnect.max.history.records", 100L)
+  max_records <- max(1L, getOption("rsconnect.max.history.records", 100L))
 
   history <- deploymentHistoryPath()
   prior <- if (file.exists(history) && file.size(history) <= max_bytes) {
@@ -211,8 +211,8 @@ addToDeploymentHistory <- function(appPath, deploymentRecord) {
   newHistory <- deploymentHistoryPath(new = TRUE)
   on.exit(unlink(newHistory), add = TRUE)
   writeDeploymentRecord(deploymentRecord, newHistory)
-  if (nrow(prior) > 0L) {
-    n_prior <- min(nrow(prior), max_records - 1L)
+  n_prior <- min(nrow(prior), max_records - 1L)
+  if (n_prior > 0L) {
     cat("\n", file = newHistory, append = TRUE)
     write.dcf(head(prior, n_prior), newHistory, append = TRUE, width = 4096)
   }

--- a/tests/testthat/_snaps/deployments.md
+++ b/tests/testthat/_snaps/deployments.md
@@ -33,6 +33,15 @@
       x: 3
       appPath: path
 
+# addToDeploymentHistory() preserves only the new record when max_records = 1L
+
+    Code
+      addToDeploymentHistory("path", list(x = 3))
+      writeLines(readLines(deploymentHistoryPath()))
+    Output
+      x: 3
+      appPath: path
+
 # addToDeploymentHistory() restarts when history exceeds rsconnect.max.history.bytes
 
     Code

--- a/tests/testthat/_snaps/deployments.md
+++ b/tests/testthat/_snaps/deployments.md
@@ -16,3 +16,29 @@
       x: 1
       appPath: path
 
+# addToDeploymentHistory() caps records at rsconnect.max.history.records
+
+    Code
+      for (i in 1:5) {
+        addToDeploymentHistory("path", list(x = i))
+      }
+      writeLines(readLines(deploymentHistoryPath()))
+    Output
+      x: 5
+      appPath: path
+      
+      x: 4
+      appPath: path
+      
+      x: 3
+      appPath: path
+
+# addToDeploymentHistory() restarts when history exceeds rsconnect.max.history.bytes
+
+    Code
+      addToDeploymentHistory("path", list(x = 3))
+      writeLines(readLines(deploymentHistoryPath()))
+    Output
+      x: 3
+      appPath: path
+

--- a/tests/testthat/test-deployments.R
+++ b/tests/testthat/test-deployments.R
@@ -195,3 +195,31 @@ test_that("addToDeploymentHistory() adds needed new lines", {
     writeLines(readLines(deploymentHistoryPath()))
   })
 })
+
+test_that("addToDeploymentHistory() caps records at rsconnect.max.history.records", {
+  local_temp_config()
+
+  withr::local_options(rsconnect.max.history.records = 3L)
+
+  expect_snapshot({
+    for (i in 1:5) {
+      addToDeploymentHistory("path", list(x = i))
+    }
+    writeLines(readLines(deploymentHistoryPath()))
+  })
+})
+
+test_that("addToDeploymentHistory() restarts when history exceeds rsconnect.max.history.bytes", {
+  local_temp_config()
+
+  # Create some records before constraining the size of the history file.
+  addToDeploymentHistory("path", list(x = 1))
+  addToDeploymentHistory("path", list(x = 2))
+
+  withr::local_options(rsconnect.max.history.bytes = 0L)
+
+  expect_snapshot({
+    addToDeploymentHistory("path", list(x = 3))
+    writeLines(readLines(deploymentHistoryPath()))
+  })
+})

--- a/tests/testthat/test-deployments.R
+++ b/tests/testthat/test-deployments.R
@@ -209,6 +209,21 @@ test_that("addToDeploymentHistory() caps records at rsconnect.max.history.record
   })
 })
 
+test_that("addToDeploymentHistory() preserves only the new record when max_records = 1L", {
+  local_temp_config()
+
+  # Create existing history before capping.
+  addToDeploymentHistory("path", list(x = 1))
+  addToDeploymentHistory("path", list(x = 2))
+
+  withr::local_options(rsconnect.max.history.records = 1L)
+
+  expect_snapshot({
+    addToDeploymentHistory("path", list(x = 3))
+    writeLines(readLines(deploymentHistoryPath()))
+  })
+})
+
 test_that("addToDeploymentHistory() restarts when history exceeds rsconnect.max.history.bytes", {
   local_temp_config()
 


### PR DESCRIPTION
The history file could rapidly expand in size during concurrent deployments. Previously, history mutations landed in history.new.dcf, meaning two calls could each append the existing history.dcf contents, doubling in size each time the race is hit.

Now, write to a uniquely named temporary file. During concurrent deployments, one of the history entries may be lost.

The history file is now capped at 100 records; the most recent are preserved. If the history file has grown beyond 1MB, it is reset. 1M fits 1k-2k entries; for most users, a file this large indicates that they have hit the growth explosion.

fixes #1320