### PR TITLE
report more details if addServer fails

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,9 @@
 
 * Improved error messages when `renv::snapshot()` fails during dependency
   discovery. (#1078)
+  
+  * `addServer()` now reports the underlying reason a URL was rejected (e.g.
+  connection error, TLS/certificate problem, or unexpected HTTP status). (#1197)
 
 # rsconnect 1.8.0
 

--- a/R/http.R
+++ b/R/http.R
@@ -206,6 +206,8 @@ handleResponse <- function(
     cli::cli_abort(
       c("<{url}> failed with HTTP status {response$status}", "{msg}"),
       class = c(paste0("rsconnect_http_", response$status), "rsconnect_http"),
+      status = response$status,
+      url = url,
       errorType = errorType,
       call = error_call
     )

--- a/R/servers.R
+++ b/R/servers.R
@@ -241,7 +241,10 @@ addServer <- function(
     }
     out <- validateConnectUrl(url, certificate, snowflakeConnectionName)
     if (!out$valid) {
-      cli::cli_abort("{.arg url} does not appear to be a Posit Connect server.")
+      cli::cli_abort(c(
+        "{.arg url} does not appear to be a Posit Connect server.",
+        "x" = out$message
+      ))
     }
     url <- out$url
   }
@@ -300,7 +303,17 @@ validateConnectUrl <- function(
   }
 
   if (!is.null(cnd)) {
-    return(list(valid = FALSE, message = conditionMessage(cnd)))
+    if (inherits(cnd, "rsconnect_http")) {
+      # Server responded but with an error status. Display the status (but not the full response
+      # body, as it may be a large HTML blob)
+      reason <- cli::format_inline(
+        "<{cnd$url}> responded with HTTP status {cnd$status}."
+      )
+    } else {
+      # Transport-level failure (DNS, connection refused, TLS/certificate, etc.)
+      reason <- conditionMessage(cnd)
+    }
+    return(list(valid = FALSE, message = reason))
   }
 
   contentType <- attr(response, "httpContentType")

--- a/tests/testthat/_snaps/servers.md
+++ b/tests/testthat/_snaps/servers.md
@@ -44,6 +44,7 @@
     Condition
       Error in `addServer()`:
       ! `url` does not appear to be a Posit Connect server.
+      x <http://127.0.0.1:{port}/__api__/server_settings> responded with HTTP status 404.
 
 # addServer() and addServerCertificate() inform about their actions
 

--- a/tests/testthat/test-servers.R
+++ b/tests/testthat/test-servers.R
@@ -100,7 +100,10 @@ test_that("validateConnectUrl() returns concise message for HTTP status errors",
   result <- validateConnectUrl(url)
 
   expect_false(result$valid)
-  expect_match(result$message, "__api__/server_settings> responded with HTTP status 404\\.$")
+  expect_match(
+    result$message,
+    "__api__/server_settings> responded with HTTP status 404\\.$"
+  )
 })
 
 test_that("validateConnectUrl() surfaces transport error message verbatim", {

--- a/tests/testthat/test-servers.R
+++ b/tests/testthat/test-servers.R
@@ -89,7 +89,51 @@ test_that("addServer() errors if url not a connect server", {
 
   service <- httpbin_service()
   url <- buildHttpUrl(service)
-  expect_snapshot(addServer(url), error = TRUE)
+  expect_snapshot(addServer(url), transform = strip_port(service), error = TRUE)
+})
+
+test_that("validateConnectUrl() returns concise message for HTTP status errors", {
+  skip_if_not_installed("webfakes")
+
+  service <- httpbin_service()
+  url <- buildHttpUrl(service)
+  result <- validateConnectUrl(url)
+
+  expect_false(result$valid)
+  expect_match(result$message, "__api__/server_settings> responded with HTTP status 404\\.$")
+})
+
+test_that("validateConnectUrl() surfaces transport error message verbatim", {
+  transport_err <- structure(
+    class = c("simulated_transport_error", "error", "condition"),
+    list(message = "Could not resolve host: no-such-host.invalid")
+  )
+  local_mocked_bindings(
+    GET = function(...) stop(transport_err),
+    .package = "rsconnect"
+  )
+
+  result <- validateConnectUrl("https://no-such-host.invalid")
+
+  expect_false(result$valid)
+  expect_equal(result$message, "Could not resolve host: no-such-host.invalid")
+})
+
+test_that("validateConnectUrl() returns message for non-JSON response", {
+  html_response <- structure(
+    "<!DOCTYPE html><html><body>Not Connect</body></html>",
+    httpContentType = "text/html; charset=utf-8",
+    httpUrl = "https://example.com/__api__/server_settings"
+  )
+  local_mocked_bindings(
+    GET = function(...) html_response,
+    .package = "rsconnect"
+  )
+
+  result <- validateConnectUrl("https://example.com")
+
+  expect_false(result$valid)
+  expect_match(result$message, "Endpoint did not return JSON")
 })
 
 test_that("addServer() and addServerCertificate() inform about their actions", {


### PR DESCRIPTION
closes #1197, with less verbose output than #1198. for HTTP errors we report the status, for non-HTTP errors we report the full error message (as it should be fairly short).

```r
rsconnect::addServer("https://this-is-not-a-valid-server")
#> Error in `rsconnect::addServer()`:
#> ! `url` does not appear to be a Posit Connect server.
#> ✖ Failed to perform HTTP request. Caused by error in `curl::curl_fetch_memory()`: ! Could not resolve hostname
#>   [this-is-not-a-valid-server]: Could not resolve host: this-is-not-a-valid-server
#> Run `rlang::last_trace()` to see where the error occurred.
```

```r
rsconnect::addServer("https://google.com")
#> Error in `rsconnect::addServer()`:
#> ! `url` does not appear to be a Posit Connect server.
#> ✖ <https://google.com/__api__/server_settings> responded with HTTP status 404.
#> Run `rlang::last_trace()` to see where the error occurred.