### PR TITLE
chore: use openssl::rsa_sign; remove PKI dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,6 @@ Imports:
     jsonlite,
     lifecycle,
     openssl (>= 2.0.0),
-    PKI,
     packrat (>= 0.6),
     renv (>= 1.0.0),
     rlang (>= 1.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     httr2,
     jsonlite,
     lifecycle,
-    openssl (>= 2.0.0),
+    openssl (>= 2.4.2),
     packrat (>= 0.6),
     renv (>= 1.0.0),
     rlang (>= 1.0.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rsconnect (development version)
 
+* Use `openssl::rsa_sign` rather than PKI signing. (#1333)
+
 # rsconnect 1.10.0
 
 * Added support for deploying Node.js applications to Posit Connect.

--- a/R/http.R
+++ b/R/http.R
@@ -641,14 +641,19 @@ signatureHeaders <- function(authInfo, method, path, file = NULL) {
 }
 
 signRequestPrivateKey <- function(private_key, canonicalRequest) {
-  # Use a custom hash function to avoid using system openssl for
-  # SHA1, which can be problematic in strict FIPS environments.
-  rawsig <- openssl::signature_create(
-    charToRaw(canonicalRequest),
+  # The openssl::signature_create function uses the recommended EVP_PKEY_sign
+  # API, which disallows MD5/SHA1 hashes under FIPS.
+  #
+  # The openssl::rsa_sign uses the deprecated legacy function RSA_sign, which
+  # is limited RSA keys and legacy hash functions and does not enforce FIPS.
+  rawsig <- openssl::rsa_sign(
+    digest::digest(
+      charToRaw(canonicalRequest),
+      algo = "sha1",
+      serialize = FALSE,
+      raw = TRUE
+    ),
     key = private_key,
-    hash = function(x) {
-      digest::digest(x, algo = "sha1", serialize = FALSE, raw = TRUE)
-    }
   )
   openssl::base64_encode(rawsig)
 }

--- a/R/http.R
+++ b/R/http.R
@@ -641,21 +641,15 @@ signatureHeaders <- function(authInfo, method, path, file = NULL) {
 }
 
 signRequestPrivateKey <- function(private_key, canonicalRequest) {
-  # convert key into PKI format for signing, note this only accepts RSA, but
-  # that's what rsconnect generates already
-  pem <- openssl::write_pem(private_key)
-  pem_lines <- readLines(textConnection(pem))
-  pki_key <- PKI::PKI.load.key(pem_lines, format = "PEM")
-
-  # use sha1 digest and then sign. digest and PKI avoid using system openssl which
-  # can be problematic in strict FIPS environments
-  digested <- digest::digest(
+  # Use a custom hash function to avoid using system openssl for
+  # SHA1, which can be problematic in strict FIPS environments.
+  rawsig <- openssl::signature_create(
     charToRaw(canonicalRequest),
-    "sha1",
-    serialize = FALSE,
-    raw = TRUE
+    key = private_key,
+    hash = function(x) {
+      digest::digest(x, algo = "sha1", serialize = FALSE, raw = TRUE)
+    }
   )
-  rawsig <- PKI::PKI.sign(key = pki_key, digest = digested)
   openssl::base64_encode(rawsig)
 }
 

--- a/R/http.R
+++ b/R/http.R
@@ -644,8 +644,8 @@ signRequestPrivateKey <- function(private_key, canonicalRequest) {
   # The openssl::signature_create function uses the recommended EVP_PKEY_sign
   # API, which disallows MD5/SHA1 hashes under FIPS.
   #
-  # The openssl::rsa_sign uses the deprecated legacy function RSA_sign, which
-  # is limited RSA keys and legacy hash functions and does not enforce FIPS.
+  # The openssl::rsa_sign uses the deprecated legacy API RSA_sign, which is
+  # limited to RSA keys and legacy hash functions and does not enforce FIPS.
   rawsig <- openssl::rsa_sign(
     digest::digest(
       charToRaw(canonicalRequest),


### PR DESCRIPTION
Uses the new `openssl::rsa_sign` to avoid the PKI dependency. This function was added to {openssl} 2.4.2 (2026-06-09) after @jeroen suggested removing the PKI dependnecy in #1333.

revisits #1054
fixes #1333

The existing unit tests confirm that an equivalent signature is produced.

The `signRequestPrivateKey` implementation signs requests in FIPS code using the example scripts in #1333.

```dockerfile
FROM rstudio/r-base:4.3-rockylinux9

RUN dnf update -y && dnf install -y openssl-devel
RUN fips-mode-setup --enable

RUN R -e 'install.packages(c("digest","PKI","openssl"), repos = c(CRAN = "https://cran.rstudio.com/"))'

COPY experiment.R /content/
RUN OPENSSL_FORCE_FIPS_MODE=1 R -f /content/experiment.R
```

```R
library(openssl)
library(digest)

url <- "https://example.com"

key_string <- "-----BEGIN PRIVATE KEY-----
MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC/eiSQAKXADslq
GGsbsQu2eEgEHD06BtUhaeU1nvsY7a6u12xpG0OAGYWhnGhR+1K/3qoZQQNmN0MC
ZV0zhueREu3YaqtNwXbnbGCqp7tsLsx2cb2TZscmBNXkOLah2PlsBTfInNlKrpKH
wsMtsL7yruXwJ767ey8JujMAqO90jj57idfhkr4IU47EL8DiIHTOAYLddKe/d4AL
skoEFQM37SJ9JUwZUsvz2eqEXFPV4QrS93T79sA7QfH5zOYTLKPEDxV0U7AYUVKW
bBieVRlu3DIQfdsqXwYYzHUR+HBlxe1VowCS5p5c6coNLdb+RElcSSY2Gd06eBg0
wSoxkyT3AgMBAAECggEAHmQinYCczkkKiv5pMbH+K+4XcB+TUDx5Y55NNR+Qtzoy
eanTmTMsmY5zeV076Zc8YRvUX8HD6ltnFWBFVMJaytn4SltT6TmFx+GZzjxlMRyU
c1BGSLkNbulhkaG2yyWHITAK1Jqgmovu0gGFvSDKjfZYpK+KRHOe2apmIfquVw9d
6CLm7swx30x8qFKEACc3iM/Mcc9uKOWn+NjVKqUVfU/9ZmNxmjZ9e3wkwieI1mSB
gq9q7fmCHHkGWbUkGMphgRyssaJbz+bn/Wz2uwevvtebkTOzvWtKhUGgDByCCCtq
J1ehPCjdRjylb6C5tLbyeng5QnYC7uZJmRsEOUwMEQKBgQD6PsHXwKJ8JRlDGu4G
JQ9fKzYA+B+No0GKtGuuRDD8tJouj5rb1dZt181UHUW/UtjNpz8j8l1RN2gPcu/v
VjwSXDcZHohv4cgQfRCN47wREEEb/LP/fhxIt2H320vh5qvwdJJoGvGoJfR5vO1X
ysdIPBajIgnEo4U7cawaNfeS1QKBgQDD4WgXUb0AYvK6lggVVqgNzxxMQRWCQSGb
y4RISHlC2TpftpbLFdr6fHuf8bzGq462xG5MFMMGBsbESXKNW18QA+uIBIDwttaj
AfQ4+PNu4m+2Ump+RcGu2MYoBJoxjMx00Ba76cEMF0+X+RO4zcfwZ6Y869Fakq+D
7rn4ZetGmwKBgQCMtgsjeUMkUWwCCrt6ow4gslh8dQixCPKKvuapp9hv0FG+CqvG
H1iijSz8tjUI3tnf0cI0QUztpR0TSsrVpoTCwi2NJ1kKqEdp1hkf38VZRu2FgjPo
Xw4iaVNiHmJt1NorrDDC7xuhNC5i4bQHoJMr7/W+px4c/uGkykc+ucfLPQKBgQCG
/E/KOibgHFAfawLZCaW4FnDuz68t2wp5HY/kbCU8fwxuJxrVixMjqSNcfq9TzagE
pWtI/MnE3midnevWJBBnrfvi+Q+OUsGpBdCybkT7tgm8ACGpMRMfFf3AWCOWX+wJ
19jC2HyTg4DzPs9rfEv7jMIPm4bjPtC7P4li94FiXwKBgBTh5tPUEvG0chZvqRT2
g0vvWgJGF52FCXBij3dnNl1eNRQYbDI+hNbZYcHCKHKaOoDWaqYhyjLk6Tz0LhLe
XWAlOP6tE2UbEgi10wyaEI9EyfXg1mgiHlSg+oZMCx05TUE6PrzddS6qUOJfN7P3
a3hEFijsjg/+FDMr+iAVzjry
-----END PRIVATE KEY-----"

key <- openssl::base64_encode(openssl::read_key(key_string))

private_key <- openssl::read_key(
  openssl::base64_decode(key),
  der = TRUE
)

signRequestPrivateKey <- function(private_key, canonicalRequest) {
  # The openssl::signature_create function uses the recommended EVP_PKEY_sign
  # API, which disallows MD5/SHA1 hashes under FIPS.
  #
  # The openssl::rsa_sign uses the deprecated legacy function RSA_sign, which
  # is limited RSA keys and legacy hash functions and does not enforce FIPS.
  rawsig <- openssl::rsa_sign(
    digest::digest(
      charToRaw(canonicalRequest),
      algo = "sha1",
      serialize = FALSE,
      raw = TRUE
    ),
    key = private_key,
  )
  openssl::base64_encode(rawsig)
}

cat("openssl::rsa_sign: ", signRequestPrivateKey(private_key, url), "\n")
```

```bash
# given the Dockerfile and experiment.R script from above:
docker build .
```