### PR TITLE
docs: fix 6 typos in appDependencies.R roxygen docs

### DIFF
--- a/R/appDependencies.R
+++ b/R/appDependencies.R
@@ -4,15 +4,15 @@
 #' `appDependencies()` recursively detects all R package dependencies for an
 #' application by parsing all `.R` and `.Rmd` files and looking for calls
 #' to `library()`, `require()`, `requireNamespace()`, `::`, and so on.
-#' It then adds implicit dependencies (i.e. an `.Rmd` requires Rmarkdown)
+#' It then adds implicit dependencies (i.e. an `.Rmd` requires rmarkdown)
 #' and adds all recursive dependencies to create a complete manifest of
-#' package packages need to be installed to run the app.
+#' packages need to be installed to run the app.
 #'
 #' Supported servers: All servers
 #'
 #' # Dependency discovery
 #'
-#' rsconnect use one of three mechanisms to find which packages your application
+#' rsconnect uses one of three mechanisms to find which packages your application
 #' uses:
 #'
 #' 1. If `renv.lock` is present, it will use the versions and sources defined in
@@ -38,7 +38,7 @@
 #' you used locally. It knows how to install packages from the following
 #' sources:
 #'
-#' * CRAN and BioConductor (`Source: CRAN` or `Source: Bioconductor`). The
+#' * CRAN and Bioconductor (`Source: CRAN` or `Source: Bioconductor`). The
 #'   remote server will ignore the specific CRAN or Bioconductor mirror that
 #'   you use locally, always using the CRAN/BioC mirror that has been configured
 #'   on the server.
@@ -62,9 +62,9 @@
 #'   to override their repository url so that (e.g.) you can use different
 #'   packages versions on staging and production servers.
 #'
-#' * Packages installed from GitHub, GitLab, or BitBucket, have `Source`
+#' * Packages installed from GitHub, GitLab, or Bitbucket, have `Source`
 #'   `github`, `gitlab`, and `bitbucket` respectively. When deployed, the
-#'   bundle contains the additional metadata needed to precisely recreated
+#'   bundle contains the additional metadata needed to precisely recreate
 #'   the installed version.
 #'
 #' It's not possible to recreate the packages that you have built and installed


### PR DESCRIPTION
## Summary

Fix 6 documentation issues in `R/appDependencies.R` roxygen block:

- **Duplicated word**: `package packages need to be installed` → `packages need to be installed`
- **Subject-verb agreement**: `rsconnect use one of three` → `rsconnect uses one of three`
- **Broken infinitive**: `to precisely recreated` → `to precisely recreate`
- **Package name**: `Rmarkdown` → `rmarkdown` (the R package is lowercase)
- **Project name**: `BioConductor` → `Bioconductor` (official capitalization)
- **Company name**: `BitBucket` → `Bitbucket` (official capitalization)

No functional changes — roxygen documentation only.