### PR TITLE
fix: only resolve bioc repositories when a project includes a bioc-sourced package

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # rsconnect (development version)
 
+* Fixed a regression where `deployApp()` and `writeManifest()` would install
+  BiocManager and contact bioconductor.org during dependency capture even for
+  projects with no Bioconductor dependencies, breaking deployment of CRAN-only
+  content in air-gapped or offline environments. Bioconductor repositories are
+  now resolved only when a Bioconductor-sourced package is present. (#1337)
+
 * Use `openssl::rsa_sign` rather than PKI signing. (#1333)
 
 # rsconnect 1.10.0

--- a/R/bundlePackageRenv.R
+++ b/R/bundlePackageRenv.R
@@ -59,12 +59,18 @@ parseRenvDependencies <- function(lockfile, bundleDir, snapshot = FALSE) {
     vapply(renvLock$R$Repositories, "[[", "URL", FUN.VALUE = character(1)),
     vapply(renvLock$R$Repositories, "[[", "Name", FUN.VALUE = character(1))
   )
-  bioc <- biocRepos(bundleDir)
-  if (any(bioc %in% repos)) {
-    biocPkgs <- NULL
+  # Only resolve Bioconductor repositories when the project actually contains a
+  # Bioconductor-sourced package.
+  if (hasBiocPackage(renvLock$Packages)) {
+    bioc <- biocRepos(bundleDir)
+    if (any(bioc %in% repos)) {
+      biocPkgs <- NULL
+    } else {
+      signal("evaluating", class = "rsconnect_biocRepos")
+      biocPkgs <- availablePackages(bioc)
+    }
   } else {
-    signal("evaluating", class = "rsconnect_biocRepos")
-    biocPkgs <- availablePackages(bioc)
+    biocPkgs <- NULL
   }
   deps <- standardizeRenvPackages(
     renvLock$Packages,
@@ -118,13 +124,9 @@ standardizeRenvPackage <- function(
   # Convert renv source to manifest source/repository
   # https://github.com/rstudio/renv/blob/0.17.2/R/snapshot.R#L730-L773
 
-  if (
-    is.null(pkg$Repository) &&
-      !is.null(pkg$RemoteRepos) &&
-      grepl("bioconductor.org", pkg$RemoteRepos)
-  ) {
-    # Work around bug where renv fails to detect BioC package installed by pak
-    # https://github.com/rstudio/renv/issues/1202
+  # Normalize Bioconductor packages to Source == "Bioconductor", including those
+  # installed by pak that renv records without a Bioconductor source.
+  if (isBiocPackage(pkg)) {
     pkg$Source <- "Bioconductor"
   }
 
@@ -197,6 +199,23 @@ standardizeRenvPackage <- function(
 biocRepos <- function(bundleDir) {
   repos <- getFromNamespace("renv_bioconductor_repos", "renv")(bundleDir)
   repos[setdiff(names(repos), "CRAN")]
+}
+
+# Is a single renv.lock package record sourced from Bioconductor? True when it
+# has an explicit Bioconductor source, or when it was installed by pak, which
+# renv records without one (https://github.com/rstudio/renv/issues/1202).
+isBiocPackage <- function(pkg) {
+  isTRUE(pkg$Source == "Bioconductor") ||
+    (is.null(pkg$Repository) &&
+      !is.null(pkg$RemoteRepos) &&
+      grepl("bioconductor.org", pkg$RemoteRepos))
+}
+
+# Does the lockfile contain any Bioconductor-sourced package? Used to avoid
+# resolving Bioconductor repositories (a BiocManager install and network call)
+# for CRAN-only content (#1337).
+hasBiocPackage <- function(packages) {
+  any(vapply(packages, isBiocPackage, logical(1)))
 }
 
 # Find the renv lockfile, checking both the renv-resolved path and the

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -130,6 +130,29 @@ test_that("gets DESCRIPTION from renv & system libraries", {
   expect_type(deps$description[[which(deps$Package == "MASS")]], "list")
 })
 
+# https://github.com/rstudio/rsconnect/issues/1337
+test_that("CRAN-only projects don't resolve Bioconductor repos", {
+  skip_if_not_installed("foreign")
+  skip_if_not_installed("MASS")
+
+  withr::local_options(renv.verbose = FALSE)
+
+  # biocRepos() installs BiocManager and contacts bioconductor.org; it must not
+  # be reached when no dependency comes from Bioconductor.
+  local_mocked_bindings(
+    biocRepos = function(...) stop("biocRepos() should not be called")
+  )
+
+  app_dir <- local_temp_app(list("foo.R" = "library(foreign); library(MASS)"))
+  renv::snapshot(app_dir, prompt = FALSE)
+
+  expect_no_condition(
+    deps <- parseRenvDependencies(file.path(app_dir, "renv.lock"), app_dir),
+    class = "rsconnect_biocRepos"
+  )
+  expect_setequal(deps$Package, c("foreign", "MASS", "renv"))
+})
+
 
 test_that("errors if library and project are inconsistent", {
   withr::local_options(renv.verbose = FALSE)
@@ -200,6 +223,26 @@ test_that("BioC gets normalized repo", {
   )
 })
 
+# pak installs BioC packages without a Bioconductor source; renv records them as
+# "Repository" with a Bioconductor RemoteRepos (https://github.com/rstudio/renv/issues/1202).
+test_that("pak-installed BioC packages are treated as Bioconductor", {
+  pak_bioc <- list(
+    Package = "pkg",
+    Source = "Repository",
+    RemoteRepos = "https://bioconductor.org/packages/3.22/bioc"
+  )
+
+  bioc <- data.frame(
+    Package = "pkg",
+    Repository = "https://bioconductor.org/packages/3.22/bioc/src/contrib",
+    stringsAsFactors = FALSE
+  )
+
+  result <- standardizeRenvPackage(pak_bioc, biocPackages = bioc)
+  expect_equal(result$Source, "Bioconductor")
+  expect_equal(result$Repository, "https://bioconductor.org/packages/3.22/bioc")
+})
+
 test_that("BioC prefers biocPackages over availablePackages (#1314)", {
   bioc_pkg <- list(Package = "S4Vectors", Source = "Bioconductor")
 
@@ -217,6 +260,23 @@ test_that("BioC prefers biocPackages over availablePackages (#1314)", {
 
   result <- standardizeRenvPackage(bioc_pkg, avail, biocPackages = bioc)
   expect_equal(result$Repository, "https://bioconductor.org/packages/3.22/bioc")
+})
+
+test_that("hasBiocPackage detects Bioconductor source and pak workaround (#1337)", {
+  cran <- list(Package = "withr", Source = "Repository", Repository = "CRAN")
+  bioc <- list(Package = "Biobase", Source = "Bioconductor")
+  # pak installs BioC packages without a Repository but with a BioC RemoteRepos
+  pak_bioc <- list(
+    Package = "Biobase",
+    Source = "Repository",
+    RemoteRepos = "https://bioconductor.org/packages/3.22/bioc"
+  )
+
+  expect_false(hasBiocPackage(list(cran)))
+  expect_false(hasBiocPackage(list()))
+  expect_true(hasBiocPackage(list(bioc)))
+  expect_true(hasBiocPackage(list(cran, bioc)))
+  expect_true(hasBiocPackage(list(cran, pak_bioc)))
 })
 
 test_that("has special handling for CRAN packages", {

--- a/tests/testthat/test-bundlePackageRenv.R
+++ b/tests/testthat/test-bundlePackageRenv.R
@@ -146,10 +146,7 @@ test_that("CRAN-only projects don't resolve Bioconductor repos", {
   app_dir <- local_temp_app(list("foo.R" = "library(foreign); library(MASS)"))
   renv::snapshot(app_dir, prompt = FALSE)
 
-  expect_no_condition(
-    deps <- parseRenvDependencies(file.path(app_dir, "renv.lock"), app_dir),
-    class = "rsconnect_biocRepos"
-  )
+  deps <- parseRenvDependencies(file.path(app_dir, "renv.lock"), app_dir)
   expect_setequal(deps$Package, c("foreign", "MASS", "renv"))
 })
 


### PR DESCRIPTION
Fixes #1337

Instead of eagerly evaluating Bioconductor repositories, only do so when the project actually contains a Bioconductor-sourced package. This PR also creates a `isBiocPackage` helper that gets reused across `R/bundlePackageRenv.R`

Following the reproduction steps in #1337:

### Before

```console
> rsconnect::writeManifest(appDir = "proj")
ℹ Capturing R dependencies from renv.lock
  Error: invalid version specification 'unknown version: Bioconductor version cannot be validated;
      no internet connection?
      See #troubleshooting section in vignette'
```

### After

```console
> options(repos = c(CRAN = "https://cloud.r-project.org"))
> rsconnect::writeManifest(appDir = "proj")
ℹ Capturing R dependencies from renv.lock
✔ Found 2 dependencies
```

