### PR TITLE
default `contentCategory = "mcp"` for mcptools MCP servers

### DIFF
--- a/R/appMetadata.R
+++ b/R/appMetadata.R
@@ -81,6 +81,12 @@ appMetadata <- function(
     plumberInfo <- inferPlumberInfo(appDir)
   }
 
+  # mcptools uses plumber2's _server.yml spec (posit-dev/mcptools#106).
+  # the appMode is left as `"api"`.
+  if (is.null(contentCategory) && identical(plumberInfo, "mcptools")) {
+    contentCategory <- "mcp"
+  }
+
   nodejsInfo <- NULL
   if (appMode == "nodejs") {
     nodejsInfo <- inferNodejsInfo(appDir)

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -260,6 +260,24 @@ test_that("can infer mode for API with _server.yml", {
   )
 })
 
+test_that("_server.yml with the mcptools engine defaults contentCategory to mcp", {
+  dir <- local_temp_app(list("_server.yml" = "engine: 'mcptools'"))
+  files <- list.files(dir)
+
+  metadata <- appMetadata(dir, files)
+  expect_equal(metadata$appMode, "api")
+  expect_equal(metadata$contentCategory, "mcp")
+
+  # an explicit contentCategory still wins
+  metadata_explicit <- appMetadata(dir, files, contentCategory = "other")
+  expect_equal(metadata_explicit$contentCategory, "other")
+
+  # other engines are unaffected
+  dir_plumber2 <- local_temp_app(list("_server.yml" = "engine: 'plumber2'"))
+  metadata_plumber2 <- appMetadata(dir_plumber2, list.files(dir_plumber2))
+  expect_null(metadata_plumber2$contentCategory)
+})
+
 test_that("can infer mode for shiny apps with app.R", {
   dir <- local_temp_app(list("app.R" = ""))
   paths <- list.files(dir)


### PR DESCRIPTION
Same changes as #1341, but PRed from a branch rather than a fork. See that PR description for context. cc @joshyam-k, thanks for the add!