### PR TITLE
Notify about newer versions of rsconnect

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,10 @@
 * rsconnect checks whether a newer version of itself is available from your
   configured repositories, and lets you know: as a startup message when the
   package is attached interactively, and as a note appended to deployment errors
-  otherwise. The check can be disabled by setting
-  `options(rsconnect.check_updates = FALSE)`. (#1342)
+  otherwise. `deployApp()` also reports the rsconnect version in use (and the
+  newer version, when one is known) so that captured deploy logs record it. The
+  check can be disabled by setting `options(rsconnect.check_updates = FALSE)`.
+  (#1342)
   
 # rsconnect 1.10.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # rsconnect (development version)
 
+* rsconnect checks whether a newer version of itself is available from your
+  configured repositories, and lets you know: as a startup message when the
+  package is attached interactively, and as a note appended to deployment errors
+  otherwise. The check can be disabled by setting
+  `options(rsconnect.check_updates = FALSE)`. (#1342)
+  
 # rsconnect 1.10.1
 
 * Fixed a regression where `deployApp()` and `writeManifest()` would install

--- a/R/cookies.R
+++ b/R/cookies.R
@@ -71,15 +71,17 @@ storeCookies <- function(requestURL, cookieHeaders) {
   lapply(cookies, function(co) {
     # Remove any duplicates
     # RFC says duplicate cookies are ones that have the same domain, name, and path
-    hostCookies <<- hostCookies[ # nolint
+    # nolint start
+    hostCookies <<- hostCookies[
       !(co$name == hostCookies$name & co$path == hostCookies$path),
     ]
 
     # append this new cookie on
-    hostCookies <<- rbind( # nolint
+    hostCookies <<- rbind(
       as.data.frame(co, stringsAsFactors = FALSE),
       hostCookies
     )
+    # nolint end
   })
 
   # Save this host's cookies into the cookies store.

--- a/R/cookies.R
+++ b/R/cookies.R
@@ -71,12 +71,12 @@ storeCookies <- function(requestURL, cookieHeaders) {
   lapply(cookies, function(co) {
     # Remove any duplicates
     # RFC says duplicate cookies are ones that have the same domain, name, and path
-    hostCookies <<- hostCookies[
+    hostCookies <<- hostCookies[ # nolint
       !(co$name == hostCookies$name & co$path == hostCookies$path),
     ]
 
     # append this new cookie on
-    hostCookies <<- rbind(
+    hostCookies <<- rbind( # nolint
       as.data.frame(co, stringsAsFactors = FALSE),
       hostCookies
     )

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -434,6 +434,10 @@ deployApp <- function(
 
   if (!quiet) {
     cli::cli_rule("Preparing for deployment")
+    newer <- tryCatch(checkForNewerVersion(), error = function(e) NULL)
+    cli::cli_alert_info(
+      deployVersionMessage(utils::packageVersion("rsconnect"), newer)
+    )
   }
 
   forceUpdate <- forceUpdate %||%

--- a/R/http.R
+++ b/R/http.R
@@ -202,9 +202,20 @@ handleResponse <- function(
 ) {
   url <- buildHttpUrl(response$req)
   reportError <- function(msg, errorType = NULL) {
+    # If a newer rsconnect version is available, mention it -- this is
+    # purely informational (we don't know whether it would fix this error).
+    # Bounded by rsconnect.update_check_timeout so a slow/unreachable repo
+    # can't meaningfully delay error reporting.
+    newer <- tryCatch(checkForNewerVersion(), error = function(e) NULL)
+    hint <- if (!is.null(newer)) {
+      updateErrorHint(utils::packageVersion("rsconnect"), newer)
+    } else {
+      NULL
+    }
+
     # msg may be JSON; wrapping with "{msg}" avoids treating it as a formatting string.
     cli::cli_abort(
-      c("<{url}> failed with HTTP status {response$status}", "{msg}"),
+      c("<{url}> failed with HTTP status {response$status}", "{msg}", hint),
       class = c(paste0("rsconnect_http_", response$status), "rsconnect_http"),
       status = response$status,
       url = url,

--- a/R/version-check.R
+++ b/R/version-check.R
@@ -230,6 +230,23 @@ updateStartupMessage <- function(installed, latest) {
   )
 }
 
+# Emitted at the start of every deployApp() call so that captured deploy
+# logs always record the rsconnect version in use, plus the newer available
+# version when one is known.
+deployVersionMessage <- function(installed, latest = NULL) {
+  if (is.null(latest)) {
+    paste0("This is rsconnect ", installed)
+  } else {
+    paste0(
+      "This is rsconnect ",
+      installed,
+      " (",
+      latest,
+      " is latest available)"
+    )
+  }
+}
+
 # A neutral bullet appended to HTTP error messages. Deliberately avoids
 # implying that updating will resolve the error -- rsconnect has no way of
 # knowing whether an outdated version caused the failure.

--- a/R/version-check.R
+++ b/R/version-check.R
@@ -10,71 +10,201 @@
 #
 # The check never blocks deployment or throws: any failure (offline,
 # air-gapped repositories, timeout, etc.) is swallowed and simply results in
-# no notifiication.
+# no notification. The result (including a failed/unknown result) is cached
+# to disk for rsconnect.update_check_interval seconds (default 1 day), so
+# the network is only actually touched once per interval.
+
+# Fetches and parses a single repo's PACKAGES index, returning the version
+# listed for `pkg`, or NULL if it can't be determined. Uses httr2 rather
+# than available.packages()/download.file() because httr2::req_timeout()
+# reliably bounds the connection phase too -- options(timeout=) does not.
+latestVersionInRepo <- function(pkg, repo, timeout) {
+  url <- paste0(sub("/+$", "", repo), "/src/contrib/PACKAGES")
+
+  packages <- tryCatch(
+    httr2::request(url) |>
+      httr2::req_timeout(timeout) |>
+      httr2::req_perform() |>
+      httr2::resp_body_string(),
+    error = function(e) NULL
+  )
+
+  if (is.null(packages)) {
+    return(NULL)
+  }
+
+  parsePackagesVersion(packages, pkg)
+}
+
+# Pure parsing step, split out from latestVersionInRepo() so it's testable
+# without a network call.
+parsePackagesVersion <- function(packagesText, pkg) {
+  tryCatch(
+    {
+      fields <- read.dcf(textConnection(packagesText))
+      idx <- match(pkg, fields[, "Package"])
+      if (is.na(idx)) NULL else unname(fields[idx, "Version"])
+    },
+    error = function(e) NULL
+  )
+}
 
 # Returns the newest version of `pkg` available from `repos`, or NULL if it
 # can't be determined.
-latestAvailableVersion <- function(
-  pkg = "rsconnect",
-  repos = getOption("repos")
-) {
+latestAvailableVersion <- function(pkg = "rsconnect", repos = getOption("repos")) {
   repos <- repos[repos != "@CRAN@"]
   if (length(repos) == 0) {
     return(NULL)
   }
 
-  old_timeout <- options(
-    timeout = getOption("rsconnect.update_check_timeout", 5)
-  )
-  on.exit(options(old_timeout), add = TRUE)
+  timeout <- getOption("rsconnect.update_check_timeout", 2)
+  versions <- unlist(lapply(repos, latestVersionInRepo, pkg = pkg, timeout = timeout))
+  versions <- versions[vapply(versions, isValidVersion, logical(1))]
+  if (length(versions) == 0) {
+    NULL
+  } else {
+    as.character(max(package_version(versions)))
+  }
+}
 
-  tryCatch(
-    suppressWarnings({
-      db <- availablePackages(repos)
-      idx <- match(pkg, db[, "Package"])
-      if (is.na(idx)) {
-        NULL
-      } else {
-        unname(db[idx, "Version"])
-      }
-    }),
-    error = function(e) NULL
-  )
+# Whether `x` is a string package_version() can parse, without throwing.
+isValidVersion <- function(x) {
+  !is.null(tryCatch(package_version(x), error = function(e) NULL))
 }
 
 # Returns `latest` if it represents a version newer than `installed`,
-# otherwise NULL. A locally-built dev version (e.g. 1.10.0.9000) is never
-# considered outdated.
+# otherwise NULL. `latest` may come from an untrusted source (a repo's
+# PACKAGES file, or a cache file written by a hand-edited or future/past
+# version of this code) so a value package_version() can't parse is treated
+# as "not newer" rather than thrown.
 newerVersionAvailable <- function(installed, latest) {
   if (is.null(latest)) {
     return(NULL)
   }
 
-  if (package_version(latest) > package_version(installed)) {
-    latest
-  } else {
-    NULL
-  }
+  newer <- tryCatch(
+    package_version(latest) > package_version(installed),
+    error = function(e) FALSE
+  )
+
+  if (newer) latest else NULL
 }
 
 checkUpdatesEnabled <- function() {
-  isTRUE(getOption("rsconnect.check_updates", TRUE)) &&
-    !identical(tolower(Sys.getenv("RSCONNECT_CHECK_UPDATES", "true")), "false")
+  # Use RSCONNECT_CHECK_UPDATES when it has any value; fall back to
+  # rsconnect.check_updates when the environment variable is unset.
+  value <- Sys.getenv("RSCONNECT_CHECK_UPDATES", unset = NA)
+  if (is.na(value)) {
+    value <- getOption("rsconnect.check_updates", default = TRUE)
+  }
+
+  truthy(value, default = TRUE)
+}
+
+# Cache ---------------------------------------------------------------------
+#
+# A session-level environment cache backed by an on-disk .dcf file under
+# rsconnectConfigDir("cache"). Entries -- including a failed/unknown lookup
+# -- are fresh for rsconnect.update_check_interval seconds, and invalidated
+# if the configured repos change.
+
+versionCheckCache <- new.env(parent = emptyenv())
+
+versionCheckCacheFile <- function(pkg, cacheDir) {
+  file.path(cacheDir, paste0(pkg, "-update-check.dcf"))
+}
+
+readVersionCheckCache <- function(pkg, cacheDir) {
+  path <- versionCheckCacheFile(pkg, cacheDir)
+  if (!file.exists(path)) {
+    return(NULL)
+  }
+
+  tryCatch(
+    {
+      dcf <- read.dcf(path)
+      list(
+        checked = as.numeric(dcf[1, "Checked"]),
+        latest = if (nzchar(dcf[1, "Latest"])) unname(dcf[1, "Latest"]) else NULL,
+        repos = unname(dcf[1, "Repos"])
+      )
+    },
+    error = function(e) NULL
+  )
+}
+
+writeVersionCheckCache <- function(pkg, latest, reposKey, cacheDir) {
+  dcf <- cbind(
+    Checked = as.character(as.numeric(Sys.time())),
+    Latest = if (is.null(latest)) "" else latest,
+    Repos = reposKey
+  )
+  tryCatch(
+    write.dcf(dcf, versionCheckCacheFile(pkg, cacheDir)),
+    error = function(e) NULL
+  )
+  invisible()
+}
+
+# A short, fixed-length key identifying a set of repos, used to invalidate
+# the cache if the user's configured repos change. Deliberately not the raw
+# joined URLs: DCF folds long field values across multiple lines, and
+# read.dcf() doesn't reliably restore the original whitespace, which would
+# make a multi-repo (or just long-URL) key never compare equal to itself
+# after a round trip through the cache file.
+reposCacheKey <- function(repos) {
+  digest::digest(repos, algo = "xxhash32")
+}
+
+# Returns the latest known version of `pkg` from `repos`, refreshing from
+# the network only if the cache is missing, older than
+# rsconnect.update_check_interval seconds (default 1 day), or was recorded
+# for a different set of repos. A failed/unknown lookup is cached too, so an
+# unreachable repo is retried at most once per interval, not on every call.
+cachedLatestVersion <- function(pkg, repos, cacheDir) {
+  reposKey <- reposCacheKey(repos)
+  sessionKey <- paste(pkg, cacheDir, sep = "|")
+
+  cached <- env_get(versionCheckCache, sessionKey, default = NULL)
+  if (is.null(cached)) {
+    cached <- readVersionCheckCache(pkg, cacheDir)
+  }
+
+  interval <- getOption("rsconnect.update_check_interval", 60 * 60 * 24)
+  fresh <- !is.null(cached) &&
+    identical(cached$repos, reposKey) &&
+    (as.numeric(Sys.time()) - cached$checked) < interval
+
+  if (fresh) {
+    latest <- cached$latest
+  } else {
+    latest <- latestAvailableVersion(pkg, repos)
+    writeVersionCheckCache(pkg, latest, reposKey, cacheDir)
+  }
+
+  env_poke(
+    versionCheckCache,
+    sessionKey,
+    list(checked = as.numeric(Sys.time()), latest = latest, repos = reposKey)
+  )
+
+  latest
 }
 
 # The single entry point: returns the newer version of `pkg` available from
-# `repos`, if any, or NULL. Always checks live (no caching), respecting
+# `repos`, if any, or NULL, using the cache above. Respects
 # `rsconnect.check_updates`/`RSCONNECT_CHECK_UPDATES` as an opt-out.
 checkForNewerVersion <- function(
   pkg = "rsconnect",
-  repos = getOption("repos")
+  repos = getOption("repos"),
+  cacheDir = rsconnectConfigDir("cache")
 ) {
   if (!checkUpdatesEnabled()) {
     return(NULL)
   }
 
   installed <- utils::packageVersion(pkg)
-  newerVersionAvailable(installed, latestAvailableVersion(pkg, repos))
+  newerVersionAvailable(installed, cachedLatestVersion(pkg, repos, cacheDir))
 }
 
 # Shown at package attach time when a newer version is available.

--- a/R/version-check.R
+++ b/R/version-check.R
@@ -1,0 +1,102 @@
+# rsconnect checks whether a newer version of itself is available from the
+# user's configured repositories, and surfaces that information in two places:
+#
+#   * a startup message when the package is attached interactively, since
+#     that's the moment a user is most likely to notice it (see `.onAttach()`
+#     in `zzz.R`)
+#   * a hint appended to HTTP errors, since push-button deployment from the
+#     IDE loads rsconnect without attaching it, so the startup message never
+#     fires (see `reportError()` in `http.R`)
+#
+# The check never blocks deployment or throws: any failure (offline,
+# air-gapped repositories, timeout, etc.) is swallowed and simply results in
+# no notifiication.
+
+# Returns the newest version of `pkg` available from `repos`, or NULL if it
+# can't be determined.
+latestAvailableVersion <- function(
+  pkg = "rsconnect",
+  repos = getOption("repos")
+) {
+  repos <- repos[repos != "@CRAN@"]
+  if (length(repos) == 0) {
+    return(NULL)
+  }
+
+  old_timeout <- options(
+    timeout = getOption("rsconnect.update_check_timeout", 5)
+  )
+  on.exit(options(old_timeout), add = TRUE)
+
+  tryCatch(
+    suppressWarnings({
+      db <- availablePackages(repos)
+      idx <- match(pkg, db[, "Package"])
+      if (is.na(idx)) {
+        NULL
+      } else {
+        unname(db[idx, "Version"])
+      }
+    }),
+    error = function(e) NULL
+  )
+}
+
+# Returns `latest` if it represents a version newer than `installed`,
+# otherwise NULL. A locally-built dev version (e.g. 1.10.0.9000) is never
+# considered outdated.
+newerVersionAvailable <- function(installed, latest) {
+  if (is.null(latest)) {
+    return(NULL)
+  }
+
+  if (package_version(latest) > package_version(installed)) {
+    latest
+  } else {
+    NULL
+  }
+}
+
+checkUpdatesEnabled <- function() {
+  isTRUE(getOption("rsconnect.check_updates", TRUE)) &&
+    !identical(tolower(Sys.getenv("RSCONNECT_CHECK_UPDATES", "true")), "false")
+}
+
+# The single entry point: returns the newer version of `pkg` available from
+# `repos`, if any, or NULL. Always checks live (no caching), respecting
+# `rsconnect.check_updates`/`RSCONNECT_CHECK_UPDATES` as an opt-out.
+checkForNewerVersion <- function(
+  pkg = "rsconnect",
+  repos = getOption("repos")
+) {
+  if (!checkUpdatesEnabled()) {
+    return(NULL)
+  }
+
+  installed <- utils::packageVersion(pkg)
+  newerVersionAvailable(installed, latestAvailableVersion(pkg, repos))
+}
+
+# Shown at package attach time when a newer version is available.
+updateStartupMessage <- function(installed, latest) {
+  paste0(
+    "A newer version of rsconnect (",
+    latest,
+    ") is available from your repositories. You have ",
+    installed,
+    "."
+  )
+}
+
+# A neutral bullet appended to HTTP error messages. Deliberately avoids
+# implying that updating will resolve the error -- rsconnect has no way of
+# knowing whether an outdated version caused the failure.
+updateErrorHint <- function(installed, latest) {
+  c(
+    i = sprintf(
+      "rsconnect %s is available from your repositories (you have %s).",
+      latest,
+      installed
+    )
+  )
+}

--- a/R/version-check.R
+++ b/R/version-check.R
@@ -51,14 +51,22 @@ parsePackagesVersion <- function(packagesText, pkg) {
 
 # Returns the newest version of `pkg` available from `repos`, or NULL if it
 # can't be determined.
-latestAvailableVersion <- function(pkg = "rsconnect", repos = getOption("repos")) {
+latestAvailableVersion <- function(
+  pkg = "rsconnect",
+  repos = getOption("repos")
+) {
   repos <- repos[repos != "@CRAN@"]
   if (length(repos) == 0) {
     return(NULL)
   }
 
   timeout <- getOption("rsconnect.update_check_timeout", 2)
-  versions <- unlist(lapply(repos, latestVersionInRepo, pkg = pkg, timeout = timeout))
+  versions <- unlist(lapply(
+    repos,
+    latestVersionInRepo,
+    pkg = pkg,
+    timeout = timeout
+  ))
   versions <- versions[vapply(versions, isValidVersion, logical(1))]
   if (length(versions) == 0) {
     NULL
@@ -125,7 +133,11 @@ readVersionCheckCache <- function(pkg, cacheDir) {
       dcf <- read.dcf(path)
       list(
         checked = as.numeric(dcf[1, "Checked"]),
-        latest = if (nzchar(dcf[1, "Latest"])) unname(dcf[1, "Latest"]) else NULL,
+        latest = if (nzchar(dcf[1, "Latest"])) {
+          unname(dcf[1, "Latest"])
+        } else {
+          NULL
+        },
         repos = unname(dcf[1, "Repos"])
       )
     },

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -21,7 +21,8 @@ setOptionDefaults <- function(...) {
     rsconnect.max.bundle.size = defaultMaxBundleSize,
     rsconnect.max.bundle.files = defaultMaxBundleFiles,
     rsconnect.check_updates = TRUE,
-    rsconnect.update_check_timeout = 5
+    rsconnect.update_check_timeout = 2,
+    rsconnect.update_check_interval = 60 * 60 * 24
   )
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -19,6 +19,21 @@ setOptionDefaults <- function(...) {
 .onLoad <- function(libname, pkgname) {
   setOptionDefaults(
     rsconnect.max.bundle.size = defaultMaxBundleSize,
-    rsconnect.max.bundle.files = defaultMaxBundleFiles
+    rsconnect.max.bundle.files = defaultMaxBundleFiles,
+    rsconnect.check_updates = TRUE,
+    rsconnect.update_check_timeout = 5
   )
+}
+
+.onAttach <- function(libname, pkgname) {
+  if (!is_interactive()) {
+    return(invisible())
+  }
+
+  newer <- tryCatch(checkForNewerVersion(pkgname), error = function(e) NULL)
+  if (!is.null(newer)) {
+    packageStartupMessage(
+      updateStartupMessage(utils::packageVersion(pkgname), newer)
+    )
+  }
 }

--- a/tests/testthat/_snaps/http.md
+++ b/tests/testthat/_snaps/http.md
@@ -68,3 +68,21 @@
       Error in `POST()`:
       ! <http://127.0.0.1:{port}/status/403> failed with HTTP status 403
 
+# http errors mention a newer rsconnect version when one is known
+
+    Code
+      GET(service, list(), path = "status/404")
+    Condition
+      Error in `GET()`:
+      ! <http://127.0.0.1:{port}/status/404> failed with HTTP status 404
+      
+      i rsconnect 99.0.0 is available from your repositories (you have 1.10.0.9000).
+
+# http errors don't mention a version hint when none is known
+
+    Code
+      GET(service, list(), path = "status/404")
+    Condition
+      Error in `GET()`:
+      ! <http://127.0.0.1:{port}/status/404> failed with HTTP status 404
+

--- a/tests/testthat/_snaps/version-check.md
+++ b/tests/testthat/_snaps/version-check.md
@@ -1,0 +1,12 @@
+# update messages are informative but don't overclaim
+
+    Code
+      updateStartupMessage("1.10.0", "1.11.0")
+    Output
+      [1] "A newer version of rsconnect (1.11.0) is available from your repositories. You have 1.10.0."
+    Code
+      updateErrorHint("1.10.0", "1.11.0")
+    Output
+                                                                              i 
+      "rsconnect 1.11.0 is available from your repositories (you have 1.10.0)." 
+

--- a/tests/testthat/_snaps/version-check.md
+++ b/tests/testthat/_snaps/version-check.md
@@ -10,3 +10,14 @@
                                                                               i 
       "rsconnect 1.11.0 is available from your repositories (you have 1.10.0)." 
 
+# deploy version message mentions latest version only when known
+
+    Code
+      deployVersionMessage("1.10.0")
+    Output
+      [1] "This is rsconnect 1.10.0"
+    Code
+      deployVersionMessage("1.10.0", "1.11.0")
+    Output
+      [1] "This is rsconnect 1.10.0 (1.11.0 is latest available)"
+

--- a/tests/testthat/helper-http.R
+++ b/tests/testthat/helper-http.R
@@ -87,7 +87,11 @@ service_redirect <- function(target) {
 # A CRAN-like repo serving a PACKAGES index at /src/contrib/PACKAGES, with
 # an optional artificial delay -- used to test that update-check requests
 # are bounded by rsconnect.update_check_timeout instead of hanging.
-service_repo <- function(packages = character(), delay = 0, env = parent.frame()) {
+service_repo <- function(
+  packages = character(),
+  delay = 0,
+  env = parent.frame()
+) {
   body <- paste(packages, collapse = "\n\n")
   app <- webfakes::new_app()
   app$get("/src/contrib/PACKAGES", function(req, res) {

--- a/tests/testthat/helper-http.R
+++ b/tests/testthat/helper-http.R
@@ -84,6 +84,21 @@ service_redirect <- function(target) {
   parseHttpUrl(app$url())
 }
 
+# A CRAN-like repo serving a PACKAGES index at /src/contrib/PACKAGES, with
+# an optional artificial delay -- used to test that update-check requests
+# are bounded by rsconnect.update_check_timeout instead of hanging.
+service_repo <- function(packages = character(), delay = 0) {
+  body <- paste(packages, collapse = "\n\n")
+  app <- webfakes::new_app()
+  app$get("/src/contrib/PACKAGES", function(req, res) {
+    if (delay > 0) {
+      Sys.sleep(delay)
+    }
+    res$set_type("text/plain")$send(body)
+  })
+  proc <- webfakes::new_app_process(app)
+  proc$url()
+}
 
 # Generic tests of various http methods -----------------------------------
 

--- a/tests/testthat/helper-http.R
+++ b/tests/testthat/helper-http.R
@@ -87,7 +87,7 @@ service_redirect <- function(target) {
 # A CRAN-like repo serving a PACKAGES index at /src/contrib/PACKAGES, with
 # an optional artificial delay -- used to test that update-check requests
 # are bounded by rsconnect.update_check_timeout instead of hanging.
-service_repo <- function(packages = character(), delay = 0) {
+service_repo <- function(packages = character(), delay = 0, env = parent.frame()) {
   body <- paste(packages, collapse = "\n\n")
   app <- webfakes::new_app()
   app$get("/src/contrib/PACKAGES", function(req, res) {
@@ -96,7 +96,10 @@ service_repo <- function(packages = character(), delay = 0) {
     }
     res$set_type("text/plain")$send(body)
   })
-  proc <- webfakes::new_app_process(app)
+  # The process handle must outlive this function: the server subprocess is
+  # killed as soon as the handle is garbage collected, which made repos
+  # vanish mid-test. Tie its lifetime to the calling test instead.
+  proc <- webfakes::local_app_process(app, .local_envir = env)
   proc$url()
 }
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -3,6 +3,14 @@ showDcf <- function(df) {
   invisible()
 }
 
+fakeAvailablePackages <- function(pkg = "rsconnect", version = "1.11.0") {
+  matrix(
+    c(pkg, version),
+    nrow = 1,
+    dimnames = list(NULL, c("Package", "Version"))
+  )
+}
+
 # Create and use a directory as temporary replacement for R_USER_CONFIG_DIR to
 # avoid having tests overwrite the "official" configuration locations.
 local_temp_config <- function(env = caller_env()) {

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -3,14 +3,6 @@ showDcf <- function(df) {
   invisible()
 }
 
-fakeAvailablePackages <- function(pkg = "rsconnect", version = "1.11.0") {
-  matrix(
-    c(pkg, version),
-    nrow = 1,
-    dimnames = list(NULL, c("Package", "Version"))
-  )
-}
-
 # Create and use a directory as temporary replacement for R_USER_CONFIG_DIR to
 # avoid having tests overwrite the "official" configuration locations.
 local_temp_config <- function(env = caller_env()) {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,5 @@
+# Disable the update-check feature (version-check.R) for the whole test suite by
+# default. Tests that want to exercise the feature turn it back on locally (see
+# test-version-check.R) or mock checkForNewerVersion() directly (see
+# test-http.R).
+options(rsconnect.check_updates = FALSE)

--- a/tests/testthat/test-http.R
+++ b/tests/testthat/test-http.R
@@ -198,6 +198,36 @@ test_that("http error includes status in error class", {
   )
 })
 
+test_that("http errors mention a newer rsconnect version when one is known", {
+  skip_if_not_installed("webfakes")
+
+  service <- httpbin_service()
+  local_mocked_bindings(checkForNewerVersion = function(...) "99.0.0")
+  local_mocked_bindings(
+    packageVersion = function(...) package_version("1.10.0.9000"),
+    .package = "utils"
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    GET(service, list(), path = "status/404"),
+    transform = strip_port(service)
+  )
+})
+
+test_that("http errors don't mention a version hint when none is known", {
+  skip_if_not_installed("webfakes")
+
+  service <- httpbin_service()
+  local_mocked_bindings(checkForNewerVersion = function(...) NULL)
+
+  expect_snapshot(
+    error = TRUE,
+    GET(service, list(), path = "status/404"),
+    transform = strip_port(service)
+  )
+})
+
 test_that("handles redirects", {
   skip_if_not_installed("webfakes")
 

--- a/tests/testthat/test-version-check.R
+++ b/tests/testthat/test-version-check.R
@@ -1,0 +1,123 @@
+# newerVersionAvailable() --------------------------------------------------
+
+test_that("newerVersionAvailable() detects a newer version", {
+  expect_equal(newerVersionAvailable("1.10.0", "1.11.0"), "1.11.0")
+})
+
+test_that("newerVersionAvailable() returns NULL when not newer", {
+  expect_null(newerVersionAvailable("1.10.0", "1.10.0"))
+  expect_null(newerVersionAvailable("1.10.0", "1.9.0"))
+})
+
+test_that("newerVersionAvailable() treats a local dev version as up to date", {
+  expect_null(newerVersionAvailable("1.10.0.9000", "1.10.0"))
+})
+
+test_that("newerVersionAvailable() returns NULL when latest is unknown", {
+  expect_null(newerVersionAvailable("1.10.0", NULL))
+})
+
+# latestAvailableVersion() --------------------------------------------------
+
+test_that("latestAvailableVersion() reads the version out of available.packages()", {
+  local_mocked_bindings(availablePackages = function(repos) {
+    fakeAvailablePackages()
+  })
+
+  expect_equal(
+    latestAvailableVersion(
+      "rsconnect",
+      repos = c(CRAN = "https://cran.example")
+    ),
+    "1.11.0"
+  )
+})
+
+test_that("latestAvailableVersion() returns NULL when the package isn't listed", {
+  local_mocked_bindings(
+    availablePackages = function(repos) fakeAvailablePackages("some-other-pkg")
+  )
+
+  expect_null(latestAvailableVersion(
+    "rsconnect",
+    repos = c(CRAN = "https://cran.example")
+  ))
+})
+
+test_that("latestAvailableVersion() returns NULL for the unresolved @CRAN@ placeholder", {
+  # No mock: if this fell through to available.packages() it would attempt a
+  # real network request and this test would hang/fail depending on network.
+  expect_null(latestAvailableVersion("rsconnect", repos = c(CRAN = "@CRAN@")))
+})
+
+test_that("latestAvailableVersion() returns NULL rather than erroring", {
+  local_mocked_bindings(availablePackages = function(repos) {
+    stop("network is down")
+  })
+
+  expect_null(latestAvailableVersion(
+    "rsconnect",
+    repos = c(CRAN = "https://cran.example")
+  ))
+})
+
+# checkForNewerVersion() ----------------------------------------------------
+
+test_that("checkForNewerVersion() checks live every call (no caching)", {
+  repos <- c(CRAN = "https://cran.example")
+
+  calls <- 0
+  local_mocked_bindings(latestAvailableVersion = function(...) {
+    calls <<- calls + 1
+    "999.0.0"
+  })
+
+  checkForNewerVersion("rsconnect", repos = repos)
+  checkForNewerVersion("rsconnect", repos = repos)
+  expect_equal(calls, 2)
+})
+
+test_that("checkForNewerVersion() returns NULL when not outdated", {
+  local_mocked_bindings(latestAvailableVersion = function(...) "0.0.1")
+  expect_null(checkForNewerVersion(
+    "rsconnect",
+    repos = c(CRAN = "https://cran.example")
+  ))
+})
+
+test_that("checkForNewerVersion() can be disabled via option", {
+  withr::local_options(rsconnect.check_updates = FALSE)
+  local_mocked_bindings(
+    latestAvailableVersion = function(...) {
+      testthat::fail("should not be called")
+    }
+  )
+
+  expect_null(checkForNewerVersion(
+    "rsconnect",
+    repos = c(CRAN = "https://cran.example")
+  ))
+})
+
+test_that("checkForNewerVersion() can be disabled via environment variable", {
+  withr::local_envvar(RSCONNECT_CHECK_UPDATES = "false")
+  local_mocked_bindings(
+    latestAvailableVersion = function(...) {
+      testthat::fail("should not be called")
+    }
+  )
+
+  expect_null(checkForNewerVersion(
+    "rsconnect",
+    repos = c(CRAN = "https://cran.example")
+  ))
+})
+
+# messages -------------------------------------------------------------
+
+test_that("update messages are informative but don't overclaim", {
+  expect_snapshot({
+    updateStartupMessage("1.10.0", "1.11.0")
+    updateErrorHint("1.10.0", "1.11.0")
+  })
+})

--- a/tests/testthat/test-version-check.R
+++ b/tests/testthat/test-version-check.R
@@ -44,6 +44,8 @@ test_that("parsePackagesVersion() returns NULL rather than erroring on garbage i
 test_that("latestAvailableVersion() reads the version out of a repo's PACKAGES index", {
   skip_if_not_installed("webfakes")
 
+  # The default 2s timeout can be exceeded by a slow CI runner
+  withr::local_options(rsconnect.update_check_timeout = 10)
   repo <- service_repo(c("Package: rsconnect\nVersion: 1.11.0"))
   expect_equal(
     latestAvailableVersion("rsconnect", repos = c(CRAN = repo)),
@@ -61,6 +63,8 @@ test_that("latestAvailableVersion() returns NULL when the package isn't listed",
 test_that("latestAvailableVersion() takes the highest version across multiple repos", {
   skip_if_not_installed("webfakes")
 
+  # The default 2s timeout can be exceeded by a slow CI runner
+  withr::local_options(rsconnect.update_check_timeout = 10)
   old_repo <- service_repo(c("Package: rsconnect\nVersion: 1.9.0"))
   new_repo <- service_repo(c("Package: rsconnect\nVersion: 1.11.0"))
 
@@ -98,6 +102,8 @@ test_that("latestAvailableVersion() returns NULL rather than erroring on a malfo
 test_that("latestAvailableVersion() ignores a malformed version from one repo among several", {
   skip_if_not_installed("webfakes")
 
+  # The default 2s timeout can be exceeded by a slow CI runner
+  withr::local_options(rsconnect.update_check_timeout = 10)
   broken <- service_repo(c("Package: rsconnect\nVersion: not-a-version!!"))
   ok <- service_repo(c("Package: rsconnect\nVersion: 5.0.0"))
 

--- a/tests/testthat/test-version-check.R
+++ b/tests/testthat/test-version-check.R
@@ -45,7 +45,10 @@ test_that("latestAvailableVersion() reads the version out of a repo's PACKAGES i
   skip_if_not_installed("webfakes")
 
   repo <- service_repo(c("Package: rsconnect\nVersion: 1.11.0"))
-  expect_equal(latestAvailableVersion("rsconnect", repos = c(CRAN = repo)), "1.11.0")
+  expect_equal(
+    latestAvailableVersion("rsconnect", repos = c(CRAN = repo)),
+    "1.11.0"
+  )
 })
 
 test_that("latestAvailableVersion() returns NULL when the package isn't listed", {
@@ -62,7 +65,10 @@ test_that("latestAvailableVersion() takes the highest version across multiple re
   new_repo <- service_repo(c("Package: rsconnect\nVersion: 1.11.0"))
 
   expect_equal(
-    latestAvailableVersion("rsconnect", repos = c(old = old_repo, new = new_repo)),
+    latestAvailableVersion(
+      "rsconnect",
+      repos = c(old = old_repo, new = new_repo)
+    ),
     "1.11.0"
   )
 })
@@ -201,7 +207,12 @@ test_that("cachedLatestVersion() refreshes a stale cache", {
 test_that("cachedLatestVersion() refreshes when repos change", {
   cacheDir <- withr::local_tempdir()
   oldRepos <- c(CRAN = "https://old.example")
-  writeVersionCheckCache("rsconnect", "1.9.0", reposCacheKey(oldRepos), cacheDir)
+  writeVersionCheckCache(
+    "rsconnect",
+    "1.9.0",
+    reposCacheKey(oldRepos),
+    cacheDir
+  )
 
   local_mocked_bindings(latestAvailableVersion = function(...) "1.11.0")
 

--- a/tests/testthat/test-version-check.R
+++ b/tests/testthat/test-version-check.R
@@ -17,71 +17,211 @@ test_that("newerVersionAvailable() returns NULL when latest is unknown", {
   expect_null(newerVersionAvailable("1.10.0", NULL))
 })
 
+test_that("newerVersionAvailable() returns NULL rather than erroring on a malformed version", {
+  # `latest` may come from an untrusted repo or a hand-edited/corrupted
+  # cache file, so package_version() failing to parse it shouldn't throw.
+  expect_null(newerVersionAvailable("1.10.0", "not-a-version!!"))
+})
+
+# parsePackagesVersion() ----------------------------------------------------
+
+test_that("parsePackagesVersion() reads the version for a listed package", {
+  packages <- "Package: rsconnect\nVersion: 1.11.0\n\nPackage: other\nVersion: 2.0.0\n"
+  expect_equal(parsePackagesVersion(packages, "rsconnect"), "1.11.0")
+})
+
+test_that("parsePackagesVersion() returns NULL when the package isn't listed", {
+  packages <- "Package: other\nVersion: 2.0.0\n"
+  expect_null(parsePackagesVersion(packages, "rsconnect"))
+})
+
+test_that("parsePackagesVersion() returns NULL rather than erroring on garbage input", {
+  expect_null(parsePackagesVersion("not a PACKAGES file at all", "rsconnect"))
+})
+
 # latestAvailableVersion() --------------------------------------------------
 
-test_that("latestAvailableVersion() reads the version out of available.packages()", {
-  local_mocked_bindings(availablePackages = function(repos) {
-    fakeAvailablePackages()
-  })
+test_that("latestAvailableVersion() reads the version out of a repo's PACKAGES index", {
+  skip_if_not_installed("webfakes")
+
+  repo <- service_repo(c("Package: rsconnect\nVersion: 1.11.0"))
+  expect_equal(latestAvailableVersion("rsconnect", repos = c(CRAN = repo)), "1.11.0")
+})
+
+test_that("latestAvailableVersion() returns NULL when the package isn't listed", {
+  skip_if_not_installed("webfakes")
+
+  repo <- service_repo(c("Package: other\nVersion: 2.0.0"))
+  expect_null(latestAvailableVersion("rsconnect", repos = c(CRAN = repo)))
+})
+
+test_that("latestAvailableVersion() takes the highest version across multiple repos", {
+  skip_if_not_installed("webfakes")
+
+  old_repo <- service_repo(c("Package: rsconnect\nVersion: 1.9.0"))
+  new_repo <- service_repo(c("Package: rsconnect\nVersion: 1.11.0"))
 
   expect_equal(
-    latestAvailableVersion(
-      "rsconnect",
-      repos = c(CRAN = "https://cran.example")
-    ),
+    latestAvailableVersion("rsconnect", repos = c(old = old_repo, new = new_repo)),
     "1.11.0"
   )
 })
 
-test_that("latestAvailableVersion() returns NULL when the package isn't listed", {
-  local_mocked_bindings(
-    availablePackages = function(repos) fakeAvailablePackages("some-other-pkg")
-  )
-
-  expect_null(latestAvailableVersion(
-    "rsconnect",
-    repos = c(CRAN = "https://cran.example")
-  ))
-})
-
 test_that("latestAvailableVersion() returns NULL for the unresolved @CRAN@ placeholder", {
-  # No mock: if this fell through to available.packages() it would attempt a
-  # real network request and this test would hang/fail depending on network.
   expect_null(latestAvailableVersion("rsconnect", repos = c(CRAN = "@CRAN@")))
 })
 
-test_that("latestAvailableVersion() returns NULL rather than erroring", {
-  local_mocked_bindings(availablePackages = function(repos) {
-    stop("network is down")
-  })
+test_that("latestAvailableVersion() returns NULL rather than erroring when a repo 404s", {
+  skip_if_not_installed("webfakes")
 
-  expect_null(latestAvailableVersion(
-    "rsconnect",
-    repos = c(CRAN = "https://cran.example")
-  ))
+  # service_repo() only serves /src/contrib/PACKAGES, so any other path 404s.
+  app <- webfakes::new_app_process(webfakes::new_app())
+  expect_null(latestAvailableVersion("rsconnect", repos = c(CRAN = app$url())))
 })
 
-# checkForNewerVersion() ----------------------------------------------------
+test_that("latestAvailableVersion() returns NULL rather than erroring on a malformed version", {
+  skip_if_not_installed("webfakes")
 
-test_that("checkForNewerVersion() checks live every call (no caching)", {
+  # A broken or hand-rolled internal mirror -- exactly the kind of repo
+  # this feature needs to tolerate -- could list a Version field
+  # package_version() can't parse.
+  repo <- service_repo(c("Package: rsconnect\nVersion: not-a-version!!"))
+  expect_null(latestAvailableVersion("rsconnect", repos = c(CRAN = repo)))
+})
+
+test_that("latestAvailableVersion() ignores a malformed version from one repo among several", {
+  skip_if_not_installed("webfakes")
+
+  broken <- service_repo(c("Package: rsconnect\nVersion: not-a-version!!"))
+  ok <- service_repo(c("Package: rsconnect\nVersion: 5.0.0"))
+
+  expect_equal(
+    latestAvailableVersion("rsconnect", repos = c(broken = broken, ok = ok)),
+    "5.0.0"
+  )
+})
+
+test_that("latestAvailableVersion() is bounded by rsconnect.update_check_timeout", {
+  skip_if_not_installed("webfakes")
+  skip_on_cran() # timing-sensitive
+
+  withr::local_options(rsconnect.update_check_timeout = 1)
+  # Repo takes 10s to respond -- if the timeout isn't honored, this test
+  # itself would take 10+ seconds instead of ~1.
+  repo <- service_repo(c("Package: rsconnect\nVersion: 1.11.0"), delay = 10)
+
+  elapsed <- system.time(
+    result <- latestAvailableVersion("rsconnect", repos = c(CRAN = repo))
+  )
+  expect_null(result)
+  expect_lt(elapsed[["elapsed"]], 5)
+})
+
+# reposCacheKey() / disk cache round trip ------------------------------------
+
+test_that("reposCacheKey() survives a write.dcf()/read.dcf() round trip", {
+  repos <- c(
+    PPM = "https://packagemanager.posit.co/cran/latest",
+    RSPM = "https://packagemanager.posit.co/cran/latest",
+    CRAN = "https://packagemanager.posit.co/cran/latest"
+  )
+
+  cacheDir <- withr::local_tempdir()
+  writeVersionCheckCache("rsconnect", "1.11.0", reposCacheKey(repos), cacheDir)
+  cached <- readVersionCheckCache("rsconnect", cacheDir)
+
+  expect_identical(cached$repos, reposCacheKey(repos))
+})
+
+test_that("reposCacheKey() differs for different repos", {
+  a <- reposCacheKey(c(CRAN = "https://cran.example"))
+  b <- reposCacheKey(c(CRAN = "https://other.example"))
+  expect_false(identical(a, b))
+})
+
+# cachedLatestVersion() ------------------------------------------------------
+
+test_that("cachedLatestVersion() caches on disk and throttles refreshes", {
+  cacheDir <- withr::local_tempdir()
   repos <- c(CRAN = "https://cran.example")
 
   calls <- 0
   local_mocked_bindings(latestAvailableVersion = function(...) {
     calls <<- calls + 1
-    "999.0.0"
+    "1.11.0"
   })
 
-  checkForNewerVersion("rsconnect", repos = repos)
-  checkForNewerVersion("rsconnect", repos = repos)
-  expect_equal(calls, 2)
+  expect_equal(cachedLatestVersion("rsconnect", repos, cacheDir), "1.11.0")
+  expect_equal(calls, 1)
+
+  # Clear the session-level cache so the second call is forced through the
+  # disk-read path -- otherwise this test would pass even if the on-disk
+  # cache were broken (e.g. never actually recognized as fresh on read).
+  rm(list = ls(versionCheckCache), envir = versionCheckCache)
+
+  # Within the throttle interval, a second call should read the disk cache
+  # instead of checking again.
+  expect_equal(cachedLatestVersion("rsconnect", repos, cacheDir), "1.11.0")
+  expect_equal(calls, 1)
 })
 
+test_that("cachedLatestVersion() caches a failed/unknown lookup too", {
+  cacheDir <- withr::local_tempdir()
+  repos <- c(CRAN = "https://cran.example")
+
+  calls <- 0
+  local_mocked_bindings(latestAvailableVersion = function(...) {
+    calls <<- calls + 1
+    NULL
+  })
+
+  expect_null(cachedLatestVersion("rsconnect", repos, cacheDir))
+  expect_null(cachedLatestVersion("rsconnect", repos, cacheDir))
+  # An unreachable/unknown result should still only be checked once per
+  # interval, not retried on every call.
+  expect_equal(calls, 1)
+})
+
+test_that("cachedLatestVersion() refreshes a stale cache", {
+  cacheDir <- withr::local_tempdir()
+  repos <- c(CRAN = "https://cran.example")
+
+  dcf <- cbind(
+    Checked = as.character(as.numeric(Sys.time()) - 999999),
+    Latest = "1.9.0",
+    Repos = reposCacheKey(repos)
+  )
+  write.dcf(dcf, versionCheckCacheFile("rsconnect", cacheDir))
+
+  local_mocked_bindings(latestAvailableVersion = function(...) "1.11.0")
+
+  expect_equal(cachedLatestVersion("rsconnect", repos, cacheDir), "1.11.0")
+})
+
+test_that("cachedLatestVersion() refreshes when repos change", {
+  cacheDir <- withr::local_tempdir()
+  oldRepos <- c(CRAN = "https://old.example")
+  writeVersionCheckCache("rsconnect", "1.9.0", reposCacheKey(oldRepos), cacheDir)
+
+  local_mocked_bindings(latestAvailableVersion = function(...) "1.11.0")
+
+  expect_equal(
+    cachedLatestVersion("rsconnect", c(CRAN = "https://new.example"), cacheDir),
+    "1.11.0"
+  )
+})
+
+# checkForNewerVersion() ----------------------------------------------------
+
 test_that("checkForNewerVersion() returns NULL when not outdated", {
+  withr::local_options(rsconnect.check_updates = TRUE)
+  cacheDir <- withr::local_tempdir()
   local_mocked_bindings(latestAvailableVersion = function(...) "0.0.1")
+
   expect_null(checkForNewerVersion(
     "rsconnect",
-    repos = c(CRAN = "https://cran.example")
+    repos = c(CRAN = "https://cran.example"),
+    cacheDir = cacheDir
   ))
 })
 
@@ -95,7 +235,8 @@ test_that("checkForNewerVersion() can be disabled via option", {
 
   expect_null(checkForNewerVersion(
     "rsconnect",
-    repos = c(CRAN = "https://cran.example")
+    repos = c(CRAN = "https://cran.example"),
+    cacheDir = withr::local_tempdir()
   ))
 })
 
@@ -109,8 +250,42 @@ test_that("checkForNewerVersion() can be disabled via environment variable", {
 
   expect_null(checkForNewerVersion(
     "rsconnect",
-    repos = c(CRAN = "https://cran.example")
+    repos = c(CRAN = "https://cran.example"),
+    cacheDir = withr::local_tempdir()
   ))
+})
+
+test_that("checkForNewerVersion() env var disable is not case-sensitive", {
+  # RSCONNECT_PACKRAT and friends accept "TRUE"/"True"/"1" etc. via truthy();
+  # RSCONNECT_CHECK_UPDATES should behave the same way, not just react to the
+  # exact lowercase string "false".
+  withr::local_envvar(RSCONNECT_CHECK_UPDATES = "FALSE")
+  local_mocked_bindings(
+    latestAvailableVersion = function(...) {
+      testthat::fail("should not be called")
+    }
+  )
+
+  expect_null(checkForNewerVersion(
+    "rsconnect",
+    repos = c(CRAN = "https://cran.example"),
+    cacheDir = withr::local_tempdir()
+  ))
+})
+
+test_that("checkForNewerVersion() environment variable takes precedence over the option", {
+  withr::local_options(rsconnect.check_updates = FALSE)
+  withr::local_envvar(RSCONNECT_CHECK_UPDATES = "true")
+  local_mocked_bindings(latestAvailableVersion = function(...) "999.0.0")
+
+  expect_equal(
+    checkForNewerVersion(
+      "rsconnect",
+      repos = c(CRAN = "https://cran.example"),
+      cacheDir = withr::local_tempdir()
+    ),
+    "999.0.0"
+  )
 })
 
 # messages -------------------------------------------------------------

--- a/tests/testthat/test-version-check.R
+++ b/tests/testthat/test-version-check.R
@@ -307,3 +307,10 @@ test_that("update messages are informative but don't overclaim", {
     updateErrorHint("1.10.0", "1.11.0")
   })
 })
+
+test_that("deploy version message mentions latest version only when known", {
+  expect_snapshot({
+    deployVersionMessage("1.10.0")
+    deployVersionMessage("1.10.0", "1.11.0")
+  })
+})


### PR DESCRIPTION
Fixes #1342 

This checks for newer versions of rsconnect in the user's configured repositories at two times:
* when the package is attached (in an interactive session)
* on an HTTP error

The latter is arguably sort of a weird place to check and report a newer version, but it is the only case that would have saved @zackverham in #1342 because he was using push-button deployment in RStudio, not deploying from the R console. We intentionally do not imply that upgrading rsconnect will fix whatever error the user hit since we have no way of knowing whether that's true.

The check looks at the user's configured repositories and does not error if it can't determine the latest version. Requests are limited to `rsconnect.update_check_timeout` (default 2s) so we don't delay `library(rsconnect)` or error reporting excessively. Results are also cached (default 1 day). The whole feature can be turned off with `options(rsconnect.check_updates = FALSE)` or `RSCONNECT_CHECK_UPDATES=false`.
