### PR TITLE
Reconstruct migration record from contentId when no local record exists

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,9 @@
   existing Posit Connect Cloud content item instead, so the next deploy
   (including the RStudio IDE's Publish button) routes to Connect Cloud. If no
   Connect Cloud account is registered yet, it guides you through setting one
-  up first. (#1353)
+  up first. When the local deployment record has been lost, it reconstructs
+  the record from `contentId` alone, taking the name from `appName` or the
+  content's title. (#1353)
   
 # rsconnect 1.10.1
 

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -362,6 +362,7 @@ migrateToConnectCloud <- function(
   server = NULL
 ) {
   check_string(contentId)
+  check_string(appName, allow_empty = FALSE, allow_null = TRUE)
 
   # Ensure a Connect Cloud account exists; prompt to register one if not.
   ensureConnectCloudAccount()
@@ -370,17 +371,35 @@ migrateToConnectCloud <- function(
   # Resolve the source deployment record if one exists. It is optional: when
   # the local record has been lost, the Connect Cloud record is reconstructed
   # from the content alone.
+  #
+  # `appName` is not applied as a filter here: it doubles as the name for a
+  # reconstructed record, so filtering by it could hide an existing record and
+  # silently leave it behind. `account`/`server` are genuine source selectors
+  # and still apply. When records exist, `appName` disambiguates among them --
+  # and a value that matches none is an error, not a silent reconstruction.
   sourceDeps <- deployments(
     appPath,
-    nameFilter = appName,
     accountFilter = account,
     serverFilter = server,
     excludeOrphaned = FALSE
   )
-  sourceRecord <- if (nrow(sourceDeps) > 0) {
-    disambiguateDeployments(sourceDeps)
+  if (nrow(sourceDeps) == 0) {
+    sourceRecord <- NULL
   } else {
-    NULL
+    if (!is.null(appName)) {
+      matched <- sourceDeps[sourceDeps$name == appName, , drop = FALSE]
+      if (nrow(matched) == 0) {
+        cli::cli_abort(
+          c(
+            "No deployment record named {.val {appName}} for {.path {appPath}}.",
+            i = "Existing record{?s}: {.val {sourceDeps$name}}.",
+            i = "Omit {.arg appName} to migrate an existing record, or remove the old record first."
+          )
+        )
+      }
+      sourceDeps <- matched
+    }
+    sourceRecord <- disambiguateDeployments(sourceDeps)
   }
 
   if (

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -331,6 +331,12 @@ forgetDeployment <- function(
 #' server. The target content must already exist in Connect Cloud — this
 #' function updates only the local `.dcf` file on disk.
 #'
+#' The source deployment record is optional. When `appPath` has no local
+#' record (for example, the `rsconnect/` directory was never checked in or has
+#' been lost), the Connect Cloud record is reconstructed from `contentId`
+#' alone. In that case the record name is taken from `appName`, or derived from
+#' the content's title when `appName` is not supplied.
+#'
 #' Supported servers: all (source) -> Posit Connect Cloud (target)
 #'
 #' @param appPath Path to the content directory. Defaults to the current
@@ -342,6 +348,8 @@ forgetDeployment <- function(
 #'   registered, it is used automatically.
 #' @param appName,account,server Filters to disambiguate the source
 #'   deployment record when `appPath` has records for multiple deployments.
+#'   When no source record exists, `appName` names the reconstructed record;
+#'   if omitted, the name is derived from the content title.
 #'
 #' @return The path to the new deployment record file, invisibly.
 #' @export
@@ -359,7 +367,9 @@ migrateToConnectCloud <- function(
   ensureConnectCloudAccount()
   ccInfo <- findAccountInfo(cloudAccount, "connect.posit.cloud")
 
-  # Resolve and validate the source deployment record before touching the network.
+  # Resolve the source deployment record if one exists. It is optional: when
+  # the local record has been lost, the Connect Cloud record is reconstructed
+  # from the content alone.
   sourceDeps <- deployments(
     appPath,
     nameFilter = appName,
@@ -367,47 +377,32 @@ migrateToConnectCloud <- function(
     serverFilter = server,
     excludeOrphaned = FALSE
   )
-  if (nrow(sourceDeps) == 0) {
-    cli::cli_abort(
-      c(
-        "No deployment records found for {.path {appPath}}.",
-        i = "Deploy the app first, then call {.fun migrateToConnectCloud}."
-      )
-    )
+  sourceRecord <- if (nrow(sourceDeps) > 0) {
+    disambiguateDeployments(sourceDeps)
+  } else {
+    NULL
   }
-  sourceRecord <- disambiguateDeployments(sourceDeps)
 
-  if (isPositConnectCloudServer(sourceRecord$server)) {
+  if (!is.null(sourceRecord) && isPositConnectCloudServer(sourceRecord$server)) {
     cli::cli_abort(
       "The selected deployment already targets Connect Cloud. Nothing to migrate."
     )
   }
 
-  # Check for a collision at the target path before doing any Connect Cloud
-  # API work -- the path only depends on the source record and ccInfo, not
-  # on the content being migrated.
-  newPath <- deploymentConfigFile(
-    appPath,
-    sourceRecord$name,
-    ccInfo$name,
-    "connect.posit.cloud"
-  )
-
-  if (file.exists(newPath)) {
-    idx <- cli_menu(
-      "A Connect Cloud deployment record already exists at {.path {newPath}}.",
-      "What do you want to do?",
-      choices = c(
-        "Overwrite the existing record",
-        "Abort"
-      ),
-      not_interactive = c(
-        i = "Remove the existing record, or pass a different {.arg appName}/{.arg cloudAccount}, then retry."
-      )
+  # The record name comes from the source record when we have one, otherwise
+  # from `appName`. Both are known without a network call, so we can check for
+  # a target-path collision before doing any Connect Cloud API work. Without
+  # either, the name is derived from the content title after it is fetched.
+  recordName <- if (!is.null(sourceRecord)) sourceRecord$name else appName
+  newPath <- NULL
+  if (!is.null(recordName)) {
+    newPath <- deploymentConfigFile(
+      appPath,
+      recordName,
+      ccInfo$name,
+      "connect.posit.cloud"
     )
-    if (idx != 1L) {
-      cli::cli_abort("Migration cancelled.", call = NULL)
-    }
+    confirmMigrationOverwrite(newPath)
   }
 
   # Verify the target content exists and collect its metadata.
@@ -427,9 +422,34 @@ migrateToConnectCloud <- function(
     contentId
   )
 
+  # No source record and no `appName`: derive the record name from the content
+  # title (Connect Cloud content has no server-side name to reuse), then check
+  # for a collision as above.
+  if (is.null(recordName)) {
+    recordName <- tryCatch(
+      generateAppName(content$title, appPath, ccInfo$name, unique = FALSE),
+      error = function(e) {
+        cli::cli_abort(
+          c(
+            "Could not derive an application name from the content title.",
+            i = "Pass an {.arg appName} to name the migrated deployment record."
+          ),
+          parent = e
+        )
+      }
+    )
+    newPath <- deploymentConfigFile(
+      appPath,
+      recordName,
+      ccInfo$name,
+      "connect.posit.cloud"
+    )
+    confirmMigrationOverwrite(newPath)
+  }
+
   # Build and write the new Connect Cloud record.
   newRecord <- deploymentRecord(
-    name = sourceRecord$name,
+    name = recordName,
     title = content$title %||% sourceRecord$title,
     username = ccInfo$name,
     account = ccInfo$name,
@@ -438,13 +458,13 @@ migrateToConnectCloud <- function(
     appId = contentId,
     bundleId = NULL, # Connect Cloud does not use bundle IDs
     url = contentUrl,
-    envVars = sourceRecord$envVars[[1L]]
+    envVars = if (!is.null(sourceRecord)) sourceRecord$envVars[[1L]] else NULL
   )
 
   writeDeploymentRecord(newRecord, newPath)
 
-  # Remove the superseded source record.
-  if (unlink(sourceRecord$deploymentFile) != 0L) {
+  # Remove the superseded source record, when there was one.
+  if (!is.null(sourceRecord) && unlink(sourceRecord$deploymentFile) != 0L) {
     cli::cli_abort(
       c(
         "Failed to remove source deployment record {.path {sourceRecord$deploymentFile}}.",
@@ -457,6 +477,29 @@ migrateToConnectCloud <- function(
     "Migration complete: next deploy of {.path {appPath}} targets Connect Cloud content {.val {contentId}}."
   )
   invisible(newPath)
+}
+
+# Internal: prompt to overwrite (or abort) when a Connect Cloud record already
+# exists at the target path. A no-op when the path is free.
+confirmMigrationOverwrite <- function(newPath) {
+  if (!file.exists(newPath)) {
+    return(invisible())
+  }
+  idx <- cli_menu(
+    "A Connect Cloud deployment record already exists at {.path {newPath}}.",
+    "What do you want to do?",
+    choices = c(
+      "Overwrite the existing record",
+      "Abort"
+    ),
+    not_interactive = c(
+      i = "Remove the existing record, or pass a different {.arg appName}/{.arg cloudAccount}, then retry."
+    )
+  )
+  if (idx != 1L) {
+    cli::cli_abort("Migration cancelled.", call = NULL)
+  }
+  invisible()
 }
 
 # Internal: abort or prompt to register a Connect Cloud account when none exists.

--- a/R/deployments.R
+++ b/R/deployments.R
@@ -383,7 +383,9 @@ migrateToConnectCloud <- function(
     NULL
   }
 
-  if (!is.null(sourceRecord) && isPositConnectCloudServer(sourceRecord$server)) {
+  if (
+    !is.null(sourceRecord) && isPositConnectCloudServer(sourceRecord$server)
+  ) {
     cli::cli_abort(
       "The selected deployment already targets Connect Cloud. Nothing to migrate."
     )

--- a/man/migrateToConnectCloud.Rd
+++ b/man/migrateToConnectCloud.Rd
@@ -25,7 +25,9 @@ new record under. When \code{NULL} and exactly one Connect Cloud account is
 registered, it is used automatically.}
 
 \item{appName, account, server}{Filters to disambiguate the source
-deployment record when \code{appPath} has records for multiple deployments.}
+deployment record when \code{appPath} has records for multiple deployments.
+When no source record exists, \code{appName} names the reconstructed record;
+if omitted, the name is derived from the content title.}
 }
 \value{
 The path to the new deployment record file, invisibly.
@@ -38,5 +40,11 @@ server. The target content must already exist in Connect Cloud — this
 function updates only the local \code{.dcf} file on disk.
 }
 \details{
+The source deployment record is optional. When \code{appPath} has no local
+record (for example, the \verb{rsconnect/} directory was never checked in or has
+been lost), the Connect Cloud record is reconstructed from \code{contentId}
+alone. In that case the record name is taken from \code{appName}, or derived from
+the content's title when \code{appName} is not supplied.
+
 Supported servers: all (source) -> Posit Connect Cloud (target)
 }

--- a/tests/testthat/test-migrateToConnectCloud.R
+++ b/tests/testthat/test-migrateToConnectCloud.R
@@ -26,41 +26,65 @@ write_shinyapps_dcf <- function(
   dcfPath
 }
 
-test_that("migrateToConnectCloud() rewrites DCF and removes source record", {
-  appDir <- withr::local_tempdir()
-  srcPath <- write_shinyapps_dcf(appDir)
+# An accounts() frame with both a shinyapps.io and a Connect Cloud account.
+shinyapps_and_cc_accounts <- data.frame(
+  name = c("myaccount", "cc-account"),
+  server = c("shinyapps.io", "connect.posit.cloud"),
+  stringsAsFactors = FALSE
+)
 
-  local_mocked_bindings(
-    accounts = function(...) {
-      data.frame(
-        name = c("myaccount", "cc-account"),
-        server = c("shinyapps.io", "connect.posit.cloud"),
-        stringsAsFactors = FALSE
+# Helper: install the Connect Cloud mocks migrateToConnectCloud() relies on.
+# Every knob has a sensible default; tests override only what they exercise.
+#   - accounts:       the accounts() frame (defaults to a single CC account)
+#   - title:          content title returned by getContent()
+#   - account_id:     owning account id returned by getContent()
+#   - owned_accounts: the accounts getAccounts() reports a role on
+#   - get_content:    override the whole getContent() function (e.g. to error)
+#   - client:         override the whole clientForAccount() function
+local_migrate_mocks <- function(
+  accounts = data.frame(
+    name = "cc-account",
+    server = "connect.posit.cloud",
+    stringsAsFactors = FALSE
+  ),
+  title = "My App",
+  account_id = "acct-1",
+  owned_accounts = list(list(id = "acct-1", name = "cc-account")),
+  get_content = NULL,
+  client = NULL,
+  .env = parent.frame()
+) {
+  get_content <- get_content %||%
+    function(id) {
+      list(id = id, title = title, account_id = account_id, state = "active")
+    }
+  client <- client %||%
+    function(...) {
+      list(
+        getContent = get_content,
+        getAccounts = function() list(data = owned_accounts)
       )
-    },
-    findAccountInfo = function(name, server, ...) {
+    }
+  local_mocked_bindings(
+    accounts = function(...) accounts,
+    findAccountInfo = function(...) {
       list(
         name = "cc-account",
         server = "connect.posit.cloud",
         accessToken = "tok"
       )
     },
-    clientForAccount = function(info) {
-      list(
-        getContent = function(contentId) {
-          list(
-            id = contentId,
-            title = "My App",
-            account_id = "acct-1",
-            state = "active"
-          )
-        },
-        getAccounts = function() {
-          list(data = list(list(id = "acct-1", name = "cc-account")))
-        }
-      )
-    }
+    clientForAccount = client,
+    .package = "rsconnect",
+    .env = .env
   )
+}
+
+test_that("migrateToConnectCloud() rewrites DCF and removes source record", {
+  appDir <- withr::local_tempdir()
+  srcPath <- write_shinyapps_dcf(appDir)
+
+  local_migrate_mocks(accounts = shinyapps_and_cc_accounts)
 
   newPath <- migrateToConnectCloud(
     appDir,
@@ -94,41 +118,13 @@ test_that("migrateToConnectCloud() builds the URL from the content's owning acco
   appDir <- withr::local_tempdir()
   write_shinyapps_dcf(appDir)
 
-  local_mocked_bindings(
-    accounts = function(...) {
-      data.frame(
-        name = c("myaccount", "cc-account"),
-        server = c("shinyapps.io", "connect.posit.cloud"),
-        stringsAsFactors = FALSE
-      )
-    },
-    findAccountInfo = function(...) {
-      list(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        accessToken = "tok"
-      )
-    },
-    clientForAccount = function(...) {
-      list(
-        getContent = function(contentId) {
-          list(
-            id = contentId,
-            title = "My App",
-            account_id = "acct-2",
-            state = "active"
-          )
-        },
-        getAccounts = function() {
-          list(
-            data = list(
-              list(id = "acct-1", name = "cc-account"),
-              list(id = "acct-2", name = "team-account")
-            )
-          )
-        }
-      )
-    }
+  local_migrate_mocks(
+    accounts = shinyapps_and_cc_accounts,
+    account_id = "acct-2",
+    owned_accounts = list(
+      list(id = "acct-1", name = "cc-account"),
+      list(id = "acct-2", name = "team-account")
+    )
   )
 
   newPath <- migrateToConnectCloud(
@@ -151,36 +147,9 @@ test_that("migrateToConnectCloud() aborts when the content's account can't be re
   appDir <- withr::local_tempdir()
   srcPath <- write_shinyapps_dcf(appDir)
 
-  local_mocked_bindings(
-    accounts = function(...) {
-      data.frame(
-        name = c("myaccount", "cc-account"),
-        server = c("shinyapps.io", "connect.posit.cloud"),
-        stringsAsFactors = FALSE
-      )
-    },
-    findAccountInfo = function(...) {
-      list(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        accessToken = "tok"
-      )
-    },
-    clientForAccount = function(...) {
-      list(
-        getContent = function(id) {
-          list(
-            id = id,
-            title = "My App",
-            account_id = "acct-unknown",
-            state = "active"
-          )
-        },
-        getAccounts = function() {
-          list(data = list(list(id = "acct-1", name = "cc-account")))
-        }
-      )
-    }
+  local_migrate_mocks(
+    accounts = shinyapps_and_cc_accounts,
+    account_id = "acct-unknown"
   )
 
   expect_error(
@@ -212,27 +181,7 @@ test_that("migrateToConnectCloud() aborts when source already targets Connect Cl
     width = 4096
   )
 
-  local_mocked_bindings(
-    accounts = function(...) {
-      data.frame(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        stringsAsFactors = FALSE
-      )
-    },
-    findAccountInfo = function(...) {
-      list(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        accessToken = "tok"
-      )
-    },
-    clientForAccount = function(...) {
-      list(getContent = function(id) {
-        list(id = id, title = "", url = "", state = "active")
-      })
-    }
-  )
+  local_migrate_mocks()
 
   expect_error(
     migrateToConnectCloud(appDir, contentId = "abc123"),
@@ -260,24 +209,11 @@ test_that("migrateToConnectCloud() aborts when a record already exists at the ta
     width = 4096
   )
 
-  local_mocked_bindings(
-    accounts = function(...) {
-      data.frame(
-        name = c("myaccount", "cc-account"),
-        server = c("shinyapps.io", "connect.posit.cloud"),
-        stringsAsFactors = FALSE
-      )
-    },
-    findAccountInfo = function(...) {
-      list(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        accessToken = "tok"
-      )
-    },
-    # The path collision check happens before any Connect Cloud API calls,
-    # so clientForAccount() should never even be invoked here.
-    clientForAccount = function(...) {
+  # The path collision check happens before any Connect Cloud API calls, so
+  # clientForAccount() should never even be invoked here.
+  local_migrate_mocks(
+    accounts = shinyapps_and_cc_accounts,
+    client = function(...) {
       stop("clientForAccount() should not be called before the collision check")
     }
   )
@@ -296,6 +232,40 @@ test_that("migrateToConnectCloud() aborts when a record already exists at the ta
   expect_true(file.exists(srcPath))
   newRec <- as.list(as.data.frame(read.dcf(file.path(ccDir, "myapp.dcf"))))
   expect_equal(newRec$appId, "existing123")
+})
+
+test_that("migrateToConnectCloud() aborts with an unmatched appName instead of orphaning the source record", {
+  # An appName that matches no existing record must not fall through to
+  # reconstruction -- that would write a new Connect Cloud record while
+  # leaving the original (differently named) record behind.
+  appDir <- withr::local_tempdir()
+  srcPath <- write_shinyapps_dcf(appDir, appName = "oldname")
+
+  local_migrate_mocks(
+    accounts = shinyapps_and_cc_accounts,
+    client = function(...) stop("network should not be reached")
+  )
+
+  expect_error(
+    migrateToConnectCloud(
+      appDir,
+      contentId = "abc123",
+      cloudAccount = "cc-account",
+      appName = "newname"
+    ),
+    "No deployment record named"
+  )
+
+  # Source untouched, and no Connect Cloud record was written.
+  expect_true(file.exists(srcPath))
+  ccPath <- file.path(
+    appDir,
+    "rsconnect",
+    "connect.posit.cloud",
+    "cc-account",
+    "newname.dcf"
+  )
+  expect_false(file.exists(ccPath))
 })
 
 test_that("ensureConnectCloudAccount() aborts in non-interactive session with no CC accounts", {
@@ -324,37 +294,7 @@ test_that("migrateToConnectCloud() aborts when source record cannot be deleted",
   Sys.chmod(srcDir, mode = "555")
   withr::defer(Sys.chmod(srcDir, mode = "755"))
 
-  local_mocked_bindings(
-    accounts = function(...) {
-      data.frame(
-        name = c("myaccount", "cc-account"),
-        server = c("shinyapps.io", "connect.posit.cloud"),
-        stringsAsFactors = FALSE
-      )
-    },
-    findAccountInfo = function(...) {
-      list(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        accessToken = "tok"
-      )
-    },
-    clientForAccount = function(...) {
-      list(
-        getContent = function(id) {
-          list(
-            id = id,
-            title = "My App",
-            account_id = "acct-1",
-            state = "active"
-          )
-        },
-        getAccounts = function() {
-          list(data = list(list(id = "acct-1", name = "cc-account")))
-        }
-      )
-    }
-  )
+  local_migrate_mocks(accounts = shinyapps_and_cc_accounts)
 
   expect_error(
     migrateToConnectCloud(
@@ -371,37 +311,7 @@ test_that("migrateToConnectCloud() reconstructs a record from contentId when no 
   # already on Connect Cloud. The record is rebuilt from contentId + appName.
   appDir <- withr::local_tempdir()
 
-  local_mocked_bindings(
-    accounts = function(...) {
-      data.frame(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        stringsAsFactors = FALSE
-      )
-    },
-    findAccountInfo = function(...) {
-      list(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        accessToken = "tok"
-      )
-    },
-    clientForAccount = function(...) {
-      list(
-        getContent = function(id) {
-          list(
-            id = id,
-            title = "My App",
-            account_id = "acct-1",
-            state = "active"
-          )
-        },
-        getAccounts = function() {
-          list(data = list(list(id = "acct-1", name = "cc-account")))
-        }
-      )
-    }
-  )
+  local_migrate_mocks()
 
   newPath <- migrateToConnectCloud(
     appDir,
@@ -422,37 +332,7 @@ test_that("migrateToConnectCloud() reconstructs a record from contentId when no 
 test_that("migrateToConnectCloud() derives the record name from the content title when no source and no appName", {
   appDir <- withr::local_tempdir()
 
-  local_mocked_bindings(
-    accounts = function(...) {
-      data.frame(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        stringsAsFactors = FALSE
-      )
-    },
-    findAccountInfo = function(...) {
-      list(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        accessToken = "tok"
-      )
-    },
-    clientForAccount = function(...) {
-      list(
-        getContent = function(id) {
-          list(
-            id = id,
-            title = "My Great App",
-            account_id = "acct-1",
-            state = "active"
-          )
-        },
-        getAccounts = function() {
-          list(data = list(list(id = "acct-1", name = "cc-account")))
-        }
-      )
-    }
-  )
+  local_migrate_mocks(title = "My Great App")
 
   newPath <- migrateToConnectCloud(appDir, contentId = "abc123")
 
@@ -469,32 +349,7 @@ test_that("migrateToConnectCloud() errors with guidance when the name can't be d
   appDir <- file.path(root, "a")
   dir.create(appDir)
 
-  local_mocked_bindings(
-    accounts = function(...) {
-      data.frame(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        stringsAsFactors = FALSE
-      )
-    },
-    findAccountInfo = function(...) {
-      list(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        accessToken = "tok"
-      )
-    },
-    clientForAccount = function(...) {
-      list(
-        getContent = function(id) {
-          list(id = id, title = "", account_id = "acct-1", state = "active")
-        },
-        getAccounts = function() {
-          list(data = list(list(id = "acct-1", name = "cc-account")))
-        }
-      )
-    }
-  )
+  local_migrate_mocks(title = "")
 
   expect_error(
     migrateToConnectCloud(
@@ -511,32 +366,7 @@ test_that("migrateToConnectCloud() derives the record name from the directory wh
   appDir <- file.path(root, "coolapp")
   dir.create(appDir)
 
-  local_mocked_bindings(
-    accounts = function(...) {
-      data.frame(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        stringsAsFactors = FALSE
-      )
-    },
-    findAccountInfo = function(...) {
-      list(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        accessToken = "tok"
-      )
-    },
-    clientForAccount = function(...) {
-      list(
-        getContent = function(id) {
-          list(id = id, title = "", account_id = "acct-1", state = "active")
-        },
-        getAccounts = function() {
-          list(data = list(list(id = "acct-1", name = "cc-account")))
-        }
-      )
-    }
-  )
+  local_migrate_mocks(title = "")
 
   newPath <- migrateToConnectCloud(appDir, contentId = "abc123")
 
@@ -547,37 +377,7 @@ test_that("migrateToConnectCloud() derives the record name from the directory wh
 test_that("migrateToConnectCloud() reconstructs a record with empty envVars when there is no source", {
   appDir <- withr::local_tempdir()
 
-  local_mocked_bindings(
-    accounts = function(...) {
-      data.frame(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        stringsAsFactors = FALSE
-      )
-    },
-    findAccountInfo = function(...) {
-      list(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        accessToken = "tok"
-      )
-    },
-    clientForAccount = function(...) {
-      list(
-        getContent = function(id) {
-          list(
-            id = id,
-            title = "My App",
-            account_id = "acct-1",
-            state = "active"
-          )
-        },
-        getAccounts = function() {
-          list(data = list(list(id = "acct-1", name = "cc-account")))
-        }
-      )
-    }
-  )
+  local_migrate_mocks()
 
   newPath <- migrateToConnectCloud(
     appDir,
@@ -594,32 +394,11 @@ test_that("migrateToConnectCloud() reconstructs a record with empty envVars when
 test_that("migrateToConnectCloud() aborts when the target content is missing (no source record)", {
   appDir <- withr::local_tempdir()
 
-  local_mocked_bindings(
-    accounts = function(...) {
-      data.frame(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        stringsAsFactors = FALSE
-      )
-    },
-    findAccountInfo = function(...) {
-      list(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        accessToken = "tok"
-      )
-    },
-    clientForAccount = function(...) {
-      list(
-        getContent = function(id) {
-          cli::cli_abort(
-            "Content is pending deletion.",
-            class = c("rsconnect_http_404", "rsconnect_http")
-          )
-        },
-        getAccounts = function() {
-          list(data = list(list(id = "acct-1", name = "cc-account")))
-        }
+  local_migrate_mocks(
+    get_content = function(id) {
+      cli::cli_abort(
+        "Content is pending deletion.",
+        class = c("rsconnect_http_404", "rsconnect_http")
       )
     }
   )
@@ -638,4 +417,11 @@ test_that("migrateToConnectCloud() requires a string contentId", {
   appDir <- withr::local_tempdir()
   expect_error(migrateToConnectCloud(appDir))
   expect_error(migrateToConnectCloud(appDir, contentId = 123))
+})
+
+test_that("migrateToConnectCloud() rejects a blank appName", {
+  appDir <- withr::local_tempdir()
+  expect_error(
+    migrateToConnectCloud(appDir, contentId = "abc123", appName = "")
+  )
 })

--- a/tests/testthat/test-migrateToConnectCloud.R
+++ b/tests/testthat/test-migrateToConnectCloud.R
@@ -505,3 +505,137 @@ test_that("migrateToConnectCloud() errors with guidance when the name can't be d
     "Could not derive an application name"
   )
 })
+
+test_that("migrateToConnectCloud() derives the record name from the directory when the content has no title", {
+  root <- withr::local_tempdir()
+  appDir <- file.path(root, "coolapp")
+  dir.create(appDir)
+
+  local_mocked_bindings(
+    accounts = function(...) {
+      data.frame(
+        name = "cc-account",
+        server = "connect.posit.cloud",
+        stringsAsFactors = FALSE
+      )
+    },
+    findAccountInfo = function(...) {
+      list(
+        name = "cc-account",
+        server = "connect.posit.cloud",
+        accessToken = "tok"
+      )
+    },
+    clientForAccount = function(...) {
+      list(
+        getContent = function(id) {
+          list(id = id, title = "", account_id = "acct-1", state = "active")
+        },
+        getAccounts = function() {
+          list(data = list(list(id = "acct-1", name = "cc-account")))
+        }
+      )
+    }
+  )
+
+  newPath <- migrateToConnectCloud(appDir, contentId = "abc123")
+
+  rec <- as.list(as.data.frame(read.dcf(newPath)))
+  expect_equal(rec$name, "coolapp")
+})
+
+test_that("migrateToConnectCloud() reconstructs a record with empty envVars when there is no source", {
+  appDir <- withr::local_tempdir()
+
+  local_mocked_bindings(
+    accounts = function(...) {
+      data.frame(
+        name = "cc-account",
+        server = "connect.posit.cloud",
+        stringsAsFactors = FALSE
+      )
+    },
+    findAccountInfo = function(...) {
+      list(
+        name = "cc-account",
+        server = "connect.posit.cloud",
+        accessToken = "tok"
+      )
+    },
+    clientForAccount = function(...) {
+      list(
+        getContent = function(id) {
+          list(
+            id = id,
+            title = "My App",
+            account_id = "acct-1",
+            state = "active"
+          )
+        },
+        getAccounts = function() {
+          list(data = list(list(id = "acct-1", name = "cc-account")))
+        }
+      )
+    }
+  )
+
+  newPath <- migrateToConnectCloud(
+    appDir,
+    contentId = "abc123",
+    appName = "myapp"
+  )
+
+  # No source record means no envVars to carry over; deploymentRecord() writes
+  # NA, which read.dcf() surfaces as absent or "NA".
+  rec <- as.list(as.data.frame(read.dcf(newPath)))
+  expect_true(is.null(rec$envVars) || rec$envVars %in% c("", "NA"))
+})
+
+test_that("migrateToConnectCloud() aborts when the target content is missing (no source record)", {
+  appDir <- withr::local_tempdir()
+
+  local_mocked_bindings(
+    accounts = function(...) {
+      data.frame(
+        name = "cc-account",
+        server = "connect.posit.cloud",
+        stringsAsFactors = FALSE
+      )
+    },
+    findAccountInfo = function(...) {
+      list(
+        name = "cc-account",
+        server = "connect.posit.cloud",
+        accessToken = "tok"
+      )
+    },
+    clientForAccount = function(...) {
+      list(
+        getContent = function(id) {
+          cli::cli_abort(
+            "Content is pending deletion.",
+            class = c("rsconnect_http_404", "rsconnect_http")
+          )
+        },
+        getAccounts = function() {
+          list(data = list(list(id = "acct-1", name = "cc-account")))
+        }
+      )
+    }
+  )
+
+  expect_error(
+    migrateToConnectCloud(
+      appDir,
+      contentId = "abc123",
+      appName = "myapp"
+    ),
+    "pending deletion"
+  )
+})
+
+test_that("migrateToConnectCloud() requires a string contentId", {
+  appDir <- withr::local_tempdir()
+  expect_error(migrateToConnectCloud(appDir))
+  expect_error(migrateToConnectCloud(appDir, contentId = 123))
+})

--- a/tests/testthat/test-migrateToConnectCloud.R
+++ b/tests/testthat/test-migrateToConnectCloud.R
@@ -366,7 +366,9 @@ test_that("migrateToConnectCloud() aborts when source record cannot be deleted",
   )
 })
 
-test_that("migrateToConnectCloud() aborts with no deployment records", {
+test_that("migrateToConnectCloud() reconstructs a record from contentId when no source exists (appName supplied)", {
+  # Lost rsconnect directory: no source record on disk, but the content is
+  # already on Connect Cloud. The record is rebuilt from contentId + appName.
   appDir <- withr::local_tempdir()
 
   local_mocked_bindings(
@@ -378,21 +380,102 @@ test_that("migrateToConnectCloud() aborts with no deployment records", {
       )
     },
     findAccountInfo = function(...) {
-      list(
-        name = "cc-account",
-        server = "connect.posit.cloud",
-        accessToken = "tok"
-      )
+      list(name = "cc-account", server = "connect.posit.cloud", accessToken = "tok")
     },
     clientForAccount = function(...) {
-      list(getContent = function(id) {
-        list(id = id, title = "", url = "", state = "active")
-      })
+      list(
+        getContent = function(id) {
+          list(id = id, title = "My App", account_id = "acct-1", state = "active")
+        },
+        getAccounts = function() {
+          list(data = list(list(id = "acct-1", name = "cc-account")))
+        }
+      )
+    }
+  )
+
+  newPath <- migrateToConnectCloud(
+    appDir,
+    contentId = "abc123",
+    cloudAccount = "cc-account",
+    appName = "myapp"
+  )
+
+  expect_true(file.exists(newPath))
+  rec <- as.list(as.data.frame(read.dcf(newPath)))
+  expect_equal(rec$server, "connect.posit.cloud")
+  expect_equal(rec$appId, "abc123")
+  expect_equal(rec$name, "myapp")
+  expect_equal(rec$title, "My App")
+  expect_equal(rec$url, "https://connect.posit.cloud/cc-account/content/abc123")
+})
+
+test_that("migrateToConnectCloud() derives the record name from the content title when no source and no appName", {
+  appDir <- withr::local_tempdir()
+
+  local_mocked_bindings(
+    accounts = function(...) {
+      data.frame(
+        name = "cc-account",
+        server = "connect.posit.cloud",
+        stringsAsFactors = FALSE
+      )
+    },
+    findAccountInfo = function(...) {
+      list(name = "cc-account", server = "connect.posit.cloud", accessToken = "tok")
+    },
+    clientForAccount = function(...) {
+      list(
+        getContent = function(id) {
+          list(id = id, title = "My Great App", account_id = "acct-1", state = "active")
+        },
+        getAccounts = function() {
+          list(data = list(list(id = "acct-1", name = "cc-account")))
+        }
+      )
+    }
+  )
+
+  newPath <- migrateToConnectCloud(appDir, contentId = "abc123")
+
+  rec <- as.list(as.data.frame(read.dcf(newPath)))
+  # generateAppName() munges "My Great App" -> "my_great_app".
+  expect_equal(rec$name, "my_great_app")
+  expect_equal(rec$appId, "abc123")
+})
+
+test_that("migrateToConnectCloud() errors with guidance when the name can't be derived", {
+  # Empty content title and a directory whose basename ("a") is too short to
+  # form a valid app name -- the caller must supply appName.
+  root <- withr::local_tempdir()
+  appDir <- file.path(root, "a")
+  dir.create(appDir)
+
+  local_mocked_bindings(
+    accounts = function(...) {
+      data.frame(
+        name = "cc-account",
+        server = "connect.posit.cloud",
+        stringsAsFactors = FALSE
+      )
+    },
+    findAccountInfo = function(...) {
+      list(name = "cc-account", server = "connect.posit.cloud", accessToken = "tok")
+    },
+    clientForAccount = function(...) {
+      list(
+        getContent = function(id) {
+          list(id = id, title = "", account_id = "acct-1", state = "active")
+        },
+        getAccounts = function() {
+          list(data = list(list(id = "acct-1", name = "cc-account")))
+        }
+      )
     }
   )
 
   expect_error(
-    migrateToConnectCloud(appDir, contentId = "abc123"),
-    "No deployment records found"
+    migrateToConnectCloud(appDir, contentId = "abc123", cloudAccount = "cc-account"),
+    "Could not derive an application name"
   )
 })

--- a/tests/testthat/test-migrateToConnectCloud.R
+++ b/tests/testthat/test-migrateToConnectCloud.R
@@ -380,12 +380,21 @@ test_that("migrateToConnectCloud() reconstructs a record from contentId when no 
       )
     },
     findAccountInfo = function(...) {
-      list(name = "cc-account", server = "connect.posit.cloud", accessToken = "tok")
+      list(
+        name = "cc-account",
+        server = "connect.posit.cloud",
+        accessToken = "tok"
+      )
     },
     clientForAccount = function(...) {
       list(
         getContent = function(id) {
-          list(id = id, title = "My App", account_id = "acct-1", state = "active")
+          list(
+            id = id,
+            title = "My App",
+            account_id = "acct-1",
+            state = "active"
+          )
         },
         getAccounts = function() {
           list(data = list(list(id = "acct-1", name = "cc-account")))
@@ -422,12 +431,21 @@ test_that("migrateToConnectCloud() derives the record name from the content titl
       )
     },
     findAccountInfo = function(...) {
-      list(name = "cc-account", server = "connect.posit.cloud", accessToken = "tok")
+      list(
+        name = "cc-account",
+        server = "connect.posit.cloud",
+        accessToken = "tok"
+      )
     },
     clientForAccount = function(...) {
       list(
         getContent = function(id) {
-          list(id = id, title = "My Great App", account_id = "acct-1", state = "active")
+          list(
+            id = id,
+            title = "My Great App",
+            account_id = "acct-1",
+            state = "active"
+          )
         },
         getAccounts = function() {
           list(data = list(list(id = "acct-1", name = "cc-account")))
@@ -460,7 +478,11 @@ test_that("migrateToConnectCloud() errors with guidance when the name can't be d
       )
     },
     findAccountInfo = function(...) {
-      list(name = "cc-account", server = "connect.posit.cloud", accessToken = "tok")
+      list(
+        name = "cc-account",
+        server = "connect.posit.cloud",
+        accessToken = "tok"
+      )
     },
     clientForAccount = function(...) {
       list(
@@ -475,7 +497,11 @@ test_that("migrateToConnectCloud() errors with guidance when the name can't be d
   )
 
   expect_error(
-    migrateToConnectCloud(appDir, contentId = "abc123", cloudAccount = "cc-account"),
+    migrateToConnectCloud(
+      appDir,
+      contentId = "abc123",
+      cloudAccount = "cc-account"
+    ),
     "Could not derive an application name"
   )
 })


### PR DESCRIPTION
Follow-up to #1353. Closes https://github.com/rstudio/lucid-server/issues/5706

For users whose local record is gone, the merged version had no recovery path - this closes that gap without requiring the shinyapps source bundle or `appId`. When no source record is found:

- The Connect Cloud record is reconstructed from `contentId` alone (which `getContent()` already verifies exists).
- The record `name` comes from `appName`, or is derived from the content's title via `generateAppName()` when `appName` is omitted - Connect Cloud content has no server-side name to reuse, only a title.
- The source-removal step is skipped (there is nothing to remove).

### Testing
1. Run `migrateToConnectCloud(appDir, contentId)` from a working directory where there is no deployment record.
2. It should create a Connect Cloud record from `contentId`.
3. `deployApp(appDir)` should send deployments to connect.posit.cloud.