### PR TITLE
Add Posit Connect Cloud support to applications() and collaborator management functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ tests/**/*.quarto_ipynb
 # license files should not be commited to this repository
 *.lic
 .positai
+
+# pylon build worktrees
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,3 @@ tests/**/*.quarto_ipynb
 # license files should not be commited to this repository
 *.lic
 .positai
-
-# pylon build worktrees
-.worktrees/

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,8 @@
   (Posit Connect Cloud or shinyapps.io) for managing collaborators directly.
   These functions continue to work on both ShinyApps and Posit Connect Cloud
   accounts. On Posit Connect Cloud, the `sendEmail` argument to
-  `addAuthorizedUser()` is silently honored by the API (PCC always emails
-  invitees) and a warning is emitted when it is explicitly set to `FALSE`.
+  `addAuthorizedUser()` is ignored because PCC always emails invitees;
+  a warning is emitted when it is explicitly set to `FALSE`.
 
 * `applications()` now supports Posit Connect Cloud accounts, returning a
   data frame with the same columns as for ShinyApps and Posit Connect accounts.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # rsconnect (development version)
 
+* `showUsers()` and `showInvited()` now return data frames with atomic
+  `character` and `logical` columns on all backends. Previously the
+  shinyapps.io path used `do.call(rbind, list_of_lists)` on list-of-lists,
+  which produced list-matrix columns. User ids are now always `character`
+  (previously numeric on shinyapps.io); an empty result is a typed 0-row data
+  frame with named columns rather than `NULL`.
+
 * `addAuthorizedUser()`, `removeAuthorizedUser()`, `showUsers()`,
   `showInvited()`, and `resendInvitation()` are now soft-deprecated. Callers
   will see a deprecation warning with a link to the appropriate web interface

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # rsconnect (development version)
 
+* `addAuthorizedUser()`, `removeAuthorizedUser()`, `showUsers()`,
+  `showInvited()`, and `resendInvitation()` are now soft-deprecated. Callers
+  will see a deprecation warning with a link to the appropriate web interface
+  (Posit Connect Cloud or shinyapps.io) for managing collaborators directly.
+  These functions continue to work on both ShinyApps and Posit Connect Cloud
+  accounts. On Posit Connect Cloud, the `sendEmail` argument to
+  `addAuthorizedUser()` is silently honored by the API (PCC always emails
+  invitees) and a warning is emitted when it is explicitly set to `FALSE`.
+
+* `applications()` now supports Posit Connect Cloud accounts, returning a
+  data frame with the same columns as for ShinyApps and Posit Connect accounts.
+
 * rsconnect checks whether a newer version of itself is available from your
   configured repositories, and lets you know: as a startup message when the
   package is attached interactively, and as a note appended to deployment errors

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,10 @@
   shinyapps.io path used `do.call(rbind, list_of_lists)` on list-of-lists,
   which produced list-matrix columns. User ids are now always `character`
   (previously numeric on shinyapps.io); an empty result is a typed 0-row data
-  frame with named columns rather than `NULL`.
+  frame with named columns rather than `NULL`. On Posit Connect Cloud,
+  `showUsers()` additionally returns `display_name` and `role` columns from
+  the API response; the `account` column is `NA` on PCC (it is only populated
+  on shinyapps.io).
 
 * `addAuthorizedUser()`, `removeAuthorizedUser()`, `showUsers()`,
   `showInvited()`, and `resendInvitation()` are now soft-deprecated. Callers

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,12 @@
 # rsconnect (development version)
 
-* `showUsers()` and `showInvited()` now return data frames with atomic
-  `character` and `logical` columns on all backends. Previously the
-  shinyapps.io path used `do.call(rbind, list_of_lists)` on list-of-lists,
-  which produced list-matrix columns. User ids are now always `character`
-  (previously numeric on shinyapps.io); an empty result is a typed 0-row data
-  frame with named columns rather than `NULL`. On Posit Connect Cloud,
-  `showUsers()` additionally returns `display_name` and `role` columns from
-  the API response; the `account` column is `NA` on PCC (it is only populated
-  on shinyapps.io).
+* `showUsers()` and `showInvited()` now always return a data frame with
+  atomic `character`/`logical` columns, including a typed 0-row data frame
+  (rather than `NULL`) when there are no results. User ids are now always
+  `character` (previously numeric on shinyapps.io). On Posit Connect Cloud,
+  `showUsers()` also includes `display_name` and `role` columns; the
+  `account` column is populated only on shinyapps.io and is `NA` on Connect
+  Cloud.
 
 * `addAuthorizedUser()`, `removeAuthorizedUser()`, `showUsers()`,
   `showInvited()`, and `resendInvitation()` are now soft-deprecated. Callers

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,13 +9,10 @@
   Cloud.
 
 * `addAuthorizedUser()`, `removeAuthorizedUser()`, `showUsers()`,
-  `showInvited()`, and `resendInvitation()` are now soft-deprecated. Callers
-  will see a deprecation warning with a link to the appropriate web interface
-  (Posit Connect Cloud or shinyapps.io) for managing collaborators directly.
-  These functions continue to work on both ShinyApps and Posit Connect Cloud
-  accounts. On Posit Connect Cloud, the `sendEmail` argument to
-  `addAuthorizedUser()` is ignored because PCC always emails invitees;
-  a warning is emitted when it is explicitly set to `FALSE`.
+  `showInvited()`, and `resendInvitation()` now work with Posit Connect Cloud
+  accounts in addition to ShinyApps. On Posit Connect Cloud, the `sendEmail`
+  argument to `addAuthorizedUser()` is ignored because PCC always emails
+  invitees; a warning is emitted when it is explicitly set to `FALSE`.
 
 * `applications()` now supports Posit Connect Cloud accounts, returning a
   data frame with the same columns as for ShinyApps and Posit Connect accounts.

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,17 +12,14 @@
   `showInvited()`, and `resendInvitation()` now work with Posit Connect Cloud
   accounts in addition to ShinyApps. On Posit Connect Cloud, the `sendEmail`
   argument to `addAuthorizedUser()` is ignored because PCC always emails
-  invitees; a warning is emitted when it is explicitly set to `FALSE`.
+  invitees; a warning is emitted when it is explicitly set to `FALSE`. On Posit
+  Connect Cloud these functions also accept a `contentId` argument that targets
+  the content directly (the id is shown in the content URL and returned by
+  `applications()`), so a local deployment record is not required; `contentId`
+  is not supported on shinyapps.io.
 
 * `applications()` now supports Posit Connect Cloud accounts, returning a
   data frame with the same columns as for ShinyApps and Posit Connect accounts.
-
-* `addAuthorizedUser()`, `removeAuthorizedUser()`, `showUsers()`,
-  `showInvited()`, and `resendInvitation()` gain a `contentId` argument. On
-  Posit Connect Cloud, passing `contentId` targets the content directly, so a
-  local deployment record is no longer required; the id is shown in the content
-  URL and returned by `applications()`. `contentId` is not supported on
-  shinyapps.io.
 
 # rsconnect 1.11.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,13 @@
 * `applications()` now supports Posit Connect Cloud accounts, returning a
   data frame with the same columns as for ShinyApps and Posit Connect accounts.
 
+* `addAuthorizedUser()`, `removeAuthorizedUser()`, `showUsers()`,
+  `showInvited()`, and `resendInvitation()` gain a `contentId` argument. On
+  Posit Connect Cloud, passing `contentId` targets the content directly, so a
+  local deployment record is no longer required; the id is shown in the content
+  URL and returned by `applications()`. `contentId` is not supported on
+  shinyapps.io.
+
 # rsconnect 1.11.0
 
 * rsconnect checks whether a newer version of itself is available from your

--- a/R/applications.R
+++ b/R/applications.R
@@ -93,8 +93,8 @@ applications <- function(account = NULL, server = NULL) {
     )
     res <- lapply(apps, function(x) {
       # On PCC the content list response does not expose a separately served-app
-      # URL; the browsable content URL is the best available and is used for both
-      # url and config_url.
+      # URL. url = the browsable content view page; config_url = the settings
+      # page for that content item.
       contentUrl <- paste0(contentUrlBase, x$id %||% "")
       data.frame(
         id = x$id %||% NA_character_,
@@ -104,7 +104,7 @@ applications <- function(account = NULL, server = NULL) {
         status = NA_character_,
         size = NA_character_,
         instances = NA_integer_,
-        config_url = contentUrl,
+        config_url = paste0(contentUrl, "/settings/info"),
         created_time = x$created_time %||% NA_character_,
         updated_time = x$updated_time %||% NA_character_,
         guid = NA_character_,

--- a/R/applications.R
+++ b/R/applications.R
@@ -59,21 +59,36 @@ applications <- function(account = NULL, server = NULL) {
       stringsAsFactors = FALSE
     )
     if (length(apps) == 0) return(empty)
+    # Resolve the owning account's real server-side slug once. All items belong
+    # to accountDetails$accountId (listApplications filters by it), so one
+    # getAccounts() call covers every row. Using the resolved slug rather than
+    # accountDetails$name (the local alias) prevents wrong-account URLs when the
+    # remote slug differs from the alias stored in the local config.
+    pccAccts <- client$getAccounts()$data
+    pccOwner <- Find(function(a) identical(a$id, accountDetails$accountId), pccAccts)
+    if (is.null(pccOwner)) {
+      cli::cli_abort(
+        c(
+          "Unable to determine the Connect Cloud account for content listing.",
+          i = "You may not have access to the account this content belongs to."
+        )
+      )
+    }
+    contentUrlBase <- paste0(connectCloudUrls()$ui, "/", pccOwner$name, "/content/")
     res <- lapply(apps, function(x) {
+      # On PCC the content list response does not expose a separately served-app
+      # URL; the browsable content URL is the best available and is used for both
+      # url and config_url.
+      contentUrl <- paste0(contentUrlBase, x$id %||% "")
       data.frame(
         id = x$id %||% NA_character_,
         name = x$title %||% NA_character_,
         title = x$title %||% NA_character_,
-        url = x$current_revision$url %||% NA_character_,
+        url = contentUrl,
         status = NA_character_,
         size = NA_character_,
         instances = NA_integer_,
-        # accountDetails$name is the authenticated caller's account, which matches
-        # the account_id filter passed to listApplications — content listed here
-        # always belongs to this account, so this URL is correct.
-        config_url = paste0(
-          connectCloudUrls()$ui, "/", accountDetails$name, "/content/", x$id %||% ""
-        ),
+        config_url = contentUrl,
         created_time = x$created_time %||% NA_character_,
         updated_time = x$updated_time %||% NA_character_,
         guid = NA_character_,

--- a/R/applications.R
+++ b/R/applications.R
@@ -327,6 +327,7 @@ getLogs <- function(
     server = server,
     account = account
   )
+  checkShinyappsServer(deployment$server)
   accountDetails <- accountInfo(deployment$account, deployment$server)
   client <- clientForAccount(accountDetails)
   application <- getAppByName(client, accountDetails, deployment$name)

--- a/R/applications.R
+++ b/R/applications.R
@@ -51,21 +51,32 @@ applications <- function(account = NULL, server = NULL) {
 
   if (isPCC) {
     empty <- data.frame(
-      id = character(), name = character(), title = character(),
-      url = character(), status = character(), size = character(),
-      instances = integer(), config_url = character(),
-      created_time = character(), updated_time = character(),
+      id = character(),
+      name = character(),
+      title = character(),
+      url = character(),
+      status = character(),
+      size = character(),
+      instances = integer(),
+      config_url = character(),
+      created_time = character(),
+      updated_time = character(),
       guid = character(),
       stringsAsFactors = FALSE
     )
-    if (length(apps) == 0) return(empty)
+    if (length(apps) == 0) {
+      return(empty)
+    }
     # Resolve the owning account's real server-side slug once. All items belong
     # to accountDetails$accountId (listApplications filters by it), so one
     # getAccounts() call covers every row. Using the resolved slug rather than
     # accountDetails$name (the local alias) prevents wrong-account URLs when the
     # remote slug differs from the alias stored in the local config.
     pccAccts <- client$getAccounts()$data
-    pccOwner <- Find(function(a) identical(a$id, accountDetails$accountId), pccAccts)
+    pccOwner <- Find(
+      function(a) identical(a$id, accountDetails$accountId),
+      pccAccts
+    )
     if (is.null(pccOwner)) {
       cli::cli_abort(
         c(
@@ -74,7 +85,12 @@ applications <- function(account = NULL, server = NULL) {
         )
       )
     }
-    contentUrlBase <- paste0(connectCloudUrls()$ui, "/", pccOwner$name, "/content/")
+    contentUrlBase <- paste0(
+      connectCloudUrls()$ui,
+      "/",
+      pccOwner$name,
+      "/content/"
+    )
     res <- lapply(apps, function(x) {
       # On PCC the content list response does not expose a separately served-app
       # URL; the browsable content URL is the best available and is used for both

--- a/R/applications.R
+++ b/R/applications.R
@@ -92,19 +92,22 @@ applications <- function(account = NULL, server = NULL) {
       "/content/"
     )
     res <- lapply(apps, function(x) {
-      # On PCC the content list response does not expose a separately served-app
-      # URL. url = the browsable content view page; config_url = the settings
-      # page for that content item.
-      contentUrl <- paste0(contentUrlBase, x$id %||% "")
+      # url = the standalone served URL handed to app consumers (consistent with
+      # shinyapps.io/Connect); config_url = the dashboard settings page.
+      # Prefer the revision's served URL (the vanity/custom URL when set); fall
+      # back to the constructed content-id URL for content not yet published,
+      # where current_revision (or its url) is absent.
+      contentId <- x$id %||% ""
+      dashboardUrl <- paste0(contentUrlBase, contentId)
       data.frame(
         id = x$id %||% NA_character_,
         name = x$title %||% NA_character_,
         title = x$title %||% NA_character_,
-        url = contentUrl,
+        url = x$current_revision$url %||% connectCloudStandaloneUrl(contentId),
         status = NA_character_,
         size = NA_character_,
         instances = NA_integer_,
-        config_url = paste0(contentUrl, "/settings/info"),
+        config_url = paste0(dashboardUrl, "/settings/info"),
         created_time = x$created_time %||% NA_character_,
         updated_time = x$updated_time %||% NA_character_,
         guid = NA_character_,

--- a/R/applications.R
+++ b/R/applications.R
@@ -61,15 +61,18 @@ applications <- function(account = NULL, server = NULL) {
     if (length(apps) == 0) return(empty)
     res <- lapply(apps, function(x) {
       data.frame(
-        id = x$id,
-        name = x$title,
-        title = x$title,
+        id = x$id %||% NA_character_,
+        name = x$title %||% NA_character_,
+        title = x$title %||% NA_character_,
         url = x$current_revision$url %||% NA_character_,
         status = NA_character_,
         size = NA_character_,
         instances = NA_integer_,
+        # accountDetails$name is the authenticated caller's account, which matches
+        # the account_id filter passed to listApplications — content listed here
+        # always belongs to this account, so this URL is correct.
         config_url = paste0(
-          connectCloudUrls()$ui, "/", accountDetails$name, "/content/", x$id
+          connectCloudUrls()$ui, "/", accountDetails$name, "/content/", x$id %||% ""
         ),
         created_time = x$created_time %||% NA_character_,
         updated_time = x$updated_time %||% NA_character_,

--- a/R/applications.R
+++ b/R/applications.R
@@ -43,16 +43,42 @@ applications <- function(account = NULL, server = NULL) {
   serverDetails <- serverInfo(accountDetails$server)
   client <- clientForAccount(accountDetails)
 
-  if (isPositConnectCloudServer(accountDetails$server)) {
-    cli::cli_abort(
-      "The applications() function is not supported for Posit Connect Cloud accounts."
-    )
-  }
-
   isConnect <- isConnectServer(accountDetails$server)
+  isPCC <- isPositConnectCloudServer(accountDetails$server)
 
   # retrieve applications
   apps <- client$listApplications(accountDetails$accountId)
+
+  if (isPCC) {
+    empty <- data.frame(
+      id = character(), name = character(), title = character(),
+      url = character(), status = character(), size = character(),
+      instances = integer(), config_url = character(),
+      created_time = character(), updated_time = character(),
+      guid = character(),
+      stringsAsFactors = FALSE
+    )
+    if (length(apps) == 0) return(empty)
+    res <- lapply(apps, function(x) {
+      data.frame(
+        id = x$id,
+        name = x$title,
+        title = x$title,
+        url = x$current_revision$url %||% NA_character_,
+        status = NA_character_,
+        size = NA_character_,
+        instances = NA_integer_,
+        config_url = paste0(
+          connectCloudUrls()$ui, "/", accountDetails$name, "/content/", x$id
+        ),
+        created_time = x$created_time %||% NA_character_,
+        updated_time = x$updated_time %||% NA_character_,
+        guid = NA_character_,
+        stringsAsFactors = FALSE
+      )
+    })
+    return(do.call("rbind", res))
+  }
 
   # extract the subset of fields we're interested in
   keep <- if (isConnect) {

--- a/R/auth.R
+++ b/R/auth.R
@@ -9,6 +9,56 @@ collaboratorDeprecationDetails <- function(server) {
   }
 }
 
+# Internal: fetch authorized users for an already-resolved application id.
+# Does NOT call resolveContentTarget() or emit deprecate_warn(); callers are
+# responsible for resolving content exactly once before invoking this.
+showUsers_impl <- function(api, applicationId) {
+  res <- api$listApplicationAuthorization(applicationId)
+  rows <- lapply(res, function(x) {
+    data.frame(
+      id      = as.character(x$user$id %||% NA_character_),
+      email   = as.character(x$user$email %||% NA_character_),
+      account = if (!is.null(x$account)) as.character(x$account) else NA_character_,
+      stringsAsFactors = FALSE
+    )
+  })
+  if (length(rows) == 0L) {
+    return(data.frame(
+      id      = character(),
+      email   = character(),
+      account = character(),
+      stringsAsFactors = FALSE
+    ))
+  }
+  do.call(rbind, rows)
+}
+
+# Internal: fetch pending invitations for an already-resolved application id.
+# Does NOT call resolveContentTarget() or emit deprecate_warn().
+showInvited_impl <- function(api, applicationId) {
+  res <- api$listApplicationInvitations(applicationId)
+  # PCC uses email_address / is_expired; shinyapps.io uses email / expired.
+  rows <- lapply(res, function(x) {
+    data.frame(
+      id      = as.character(x$id %||% NA_character_),
+      email   = as.character(x$email_address %||% x$email %||% NA_character_),
+      link    = as.character(x$link %||% NA_character_),
+      expired = as.logical(x$is_expired %||% x$expired %||% NA),
+      stringsAsFactors = FALSE
+    )
+  })
+  if (length(rows) == 0L) {
+    return(data.frame(
+      id      = character(),
+      email   = character(),
+      link    = character(),
+      expired = logical(),
+      stringsAsFactors = FALSE
+    ))
+  }
+  do.call(rbind, rows)
+}
+
 cleanupPasswordFile <- function(appDir) {
   check_directory(appDir)
   appDir <- normalizePath(appDir)
@@ -190,8 +240,13 @@ removeAuthorizedUser <- function(
   # check and remove password file
   cleanupPasswordFile(appDir)
 
-  # get users
-  users <- showUsers(appDir, appName, account, server)
+  # resolve content exactly once: use impl so showUsers() does not call
+  # resolveContentTarget() a second time (a second interactive prompt could
+  # return a different record, causing removeApplicationUser to act on the
+  # wrong content). This supersedes the plan's accepted double-deprecation
+  # note — the root issue is a correctness bug, not just warning noise.
+  api <- clientForAccount(accountDetails)
+  users <- showUsers_impl(api, application$id)
 
   if (is.numeric(user)) {
     # lookup by id
@@ -209,8 +264,7 @@ removeAuthorizedUser <- function(
     }
   }
 
-  # remove user
-  api <- clientForAccount(accountDetails)
+  # remove user (api already built above)
   api$removeApplicationUser(application$id, user$id)
 
   message(paste("Removed:", user$email, "from application", sep = " "))
@@ -257,30 +311,8 @@ showUsers <- function(
 
   application <- resolveContentTarget(accountDetails, appDir, appName)
 
-  # fetch authorization list
   api <- clientForAccount(accountDetails)
-  res <- api$listApplicationAuthorization(application$id)
-
-  # get interesting fields; build rows as data.frames so rbind yields atomic
-  # columns (do.call(rbind, list_of_lists) produces list-matrix columns).
-  rows <- lapply(res, function(x) {
-    data.frame(
-      id      = as.character(x$user$id %||% NA_character_),
-      email   = as.character(x$user$email %||% NA_character_),
-      account = if (!is.null(x$account)) as.character(x$account) else NA_character_,
-      stringsAsFactors = FALSE
-    )
-  })
-
-  if (length(rows) == 0L) {
-    return(data.frame(
-      id      = character(),
-      email   = character(),
-      account = character(),
-      stringsAsFactors = FALSE
-    ))
-  }
-  do.call(rbind, rows)
+  showUsers_impl(api, application$id)
 }
 
 #' List invited users for an application
@@ -325,33 +357,8 @@ showInvited <- function(
 
   application <- resolveContentTarget(accountDetails, appDir, appName)
 
-  # fetch invitation list
   api <- clientForAccount(accountDetails)
-  res <- api$listApplicationInvitations(application$id)
-
-  # get interesting fields; PCC uses email_address / is_expired; shinyapps uses email / expired.
-  # Build rows as data.frames so rbind yields atomic columns (do.call(rbind, list_of_lists)
-  # produces list-matrix columns).
-  rows <- lapply(res, function(x) {
-    data.frame(
-      id      = as.character(x$id %||% NA_character_),
-      email   = as.character(x$email_address %||% x$email %||% NA_character_),
-      link    = as.character(x$link %||% NA_character_),
-      expired = as.logical(x$is_expired %||% x$expired %||% NA),
-      stringsAsFactors = FALSE
-    )
-  })
-
-  if (length(rows) == 0L) {
-    return(data.frame(
-      id      = character(),
-      email   = character(),
-      link    = character(),
-      expired = logical(),
-      stringsAsFactors = FALSE
-    ))
-  }
-  do.call(rbind, rows)
+  showInvited_impl(api, application$id)
 }
 
 #' Resend invitation for invited users of an application
@@ -393,8 +400,11 @@ resendInvitation <- function(
     details = collaboratorDeprecationDetails(accountDetails$server)
   )
 
-  # get invitations
-  invited <- showInvited(appDir, appName, account, server)
+  # resolve content exactly once, then fetch invitations via impl (avoids a
+  # second resolveContentTarget() call and a second deprecate_warn()).
+  application <- resolveContentTarget(accountDetails, appDir, appName)
+  api <- clientForAccount(accountDetails)
+  invited <- showInvited_impl(api, application$id)
 
   if (is.numeric(invite)) {
     # lookup by id
@@ -412,8 +422,7 @@ resendInvitation <- function(
     }
   }
 
-  # resend invitation
-  api <- clientForAccount(accountDetails)
+  # resend invitation (api already built above)
   api$resendApplicationInvitation(invite$id, regenerate)
 
   message(paste("Sent invitation to", invite$email, "", sep = " "))

--- a/R/auth.R
+++ b/R/auth.R
@@ -307,12 +307,17 @@ removeAuthorizedUser <- function(
   } else if (user %in% users$email) {
     user <- users[users$email == user, ]
   } else {
-    cli::cli_abort(
-      c(
-        "User {.val {user}} not found.",
-        i = "Pass the user id from {.fn showUsers} instead of the email: on Posit Connect Cloud an email can be redacted and won't match."
-      )
-    )
+    # Only PCC redacts emails, and the hint only helps someone who searched by
+    # email (an id-based lookup already avoids the problem).
+    redactionHint <-
+      isPositConnectCloudServer(accountDetails$server) &&
+      grepl("@", user, fixed = TRUE)
+    cli::cli_abort(c(
+      "User {.val {user}} not found.",
+      i = if (redactionHint) {
+        "On Posit Connect Cloud an email can be redacted and won't match; pass the user id from {.fn showUsers} instead."
+      }
+    ))
   }
 
   if (is.na(user$id)) {

--- a/R/auth.R
+++ b/R/auth.R
@@ -119,11 +119,19 @@ cleanupPasswordFile <- function(appDir) {
 }
 
 # Internal: resolve the target content for collaborator management functions.
-# On PCC, reads the local deployment record to get the content id (appId)
-# rather than matching by title (mutable, non-unique on PCC).
-# On shinyapps.io, delegates to resolveApplication() unchanged.
-resolveContentTarget <- function(accountDetails, appDir, appName) {
+# On PCC, an explicit contentId targets the content directly; otherwise reads
+# the local deployment record to get the content id (appId) rather than matching
+# by title (mutable, non-unique on PCC).
+# On shinyapps.io, delegates to resolveApplication() unchanged; contentId is
+# not supported there.
+resolveContentTarget <- function(accountDetails, appDir, appName, contentId = NULL) {
   if (isPositConnectCloudServer(accountDetails$server)) {
+    # An explicit content id targets PCC content directly, with no local
+    # deployment record required.
+    if (!is.null(contentId)) {
+      check_string(contentId)
+      return(list(id = contentId))
+    }
     recs <- deployments(
       appPath = appDir,
       accountFilter = accountDetails$name,
@@ -145,6 +153,12 @@ resolveContentTarget <- function(accountDetails, appDir, appName) {
     }
     list(id = recs$appId[[1L]])
   } else {
+    if (!is.null(contentId)) {
+      cli::cli_abort(c(
+        "{.arg contentId} is only supported on Posit Connect Cloud.",
+        i = "On shinyapps.io, identify the application with {.arg appName}."
+      ))
+    }
     resolveApplication(accountDetails, appName %||% basename(appDir))
   }
 }
@@ -160,6 +174,11 @@ resolveContentTarget <- function(accountDetails, appDir, appName) {
 #' @param appDir Directory containing application. Defaults to
 #'   current working directory.
 #' @param appName Name of application.
+#' @param contentId On Posit Connect Cloud, the content ID to manage, taken from
+#'   the content URL
+#'   (\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+#'   supplied, \code{appDir} and \code{appName} are ignored and no local
+#'   deployment record is required. Not supported on shinyapps.io.
 #' @inheritParams deployApp
 #' @param sendEmail Send an email letting the user know the application
 #'   has been shared with them.
@@ -176,12 +195,14 @@ resolveContentTarget <- function(accountDetails, appDir, appName) {
 #'   record under \code{appDir}, which defaults to the working directory. Pass
 #'   \code{appDir} to point at the project directory that contains the
 #'   \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-#'   the same directory.
+#'   the same directory. Alternatively, pass \code{contentId} to target the
+#'   content directly, without a local deployment record.
 #' @export
 addAuthorizedUser <- function(
   email,
   appDir = getwd(),
   appName = NULL,
+  contentId = NULL,
   account = NULL,
   server = NULL,
   sendEmail = NULL,
@@ -192,7 +213,7 @@ addAuthorizedUser <- function(
     checkShinyappsServer(accountDetails$server)
   }
 
-  application <- resolveContentTarget(accountDetails, appDir, appName)
+  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
 
   # check for and remove password file (shinyapps.io only; PCC has no password file)
   if (!isPositConnectCloudServer(accountDetails$server)) {
@@ -234,6 +255,11 @@ addAuthorizedUser <- function(
 #' @param appDir Directory containing application. Defaults to
 #' current working directory.
 #' @param appName Name of application.
+#' @param contentId On Posit Connect Cloud, the content ID to manage, taken from
+#'   the content URL
+#'   (\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+#'   supplied, \code{appDir} and \code{appName} are ignored and no local
+#'   deployment record is required. Not supported on shinyapps.io.
 #' @inheritParams deployApp
 #' @seealso [addAuthorizedUser()] and [showUsers()]
 #' @note This function works for ShinyApps and Posit Connect Cloud.
@@ -242,12 +268,14 @@ addAuthorizedUser <- function(
 #'   record under \code{appDir}, which defaults to the working directory. Pass
 #'   \code{appDir} to point at the project directory that contains the
 #'   \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-#'   the same directory.
+#'   the same directory. Alternatively, pass \code{contentId} to target the
+#'   content directly, without a local deployment record.
 #' @export
 removeAuthorizedUser <- function(
   user,
   appDir = getwd(),
   appName = NULL,
+  contentId = NULL,
   account = NULL,
   server = NULL
 ) {
@@ -256,7 +284,7 @@ removeAuthorizedUser <- function(
     checkShinyappsServer(accountDetails$server)
   }
 
-  application <- resolveContentTarget(accountDetails, appDir, appName)
+  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
 
   # check and remove password file (shinyapps.io only; PCC has no password file)
   if (!isPositConnectCloudServer(accountDetails$server)) {
@@ -320,6 +348,11 @@ removeAuthorizedUser <- function(
 #' @param appDir Directory containing application. Defaults to
 #'   current working directory.
 #' @param appName Name of application.
+#' @param contentId On Posit Connect Cloud, the content ID to manage, taken from
+#'   the content URL
+#'   (\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+#'   supplied, \code{appDir} and \code{appName} are ignored and no local
+#'   deployment record is required. Not supported on shinyapps.io.
 #' @inheritParams deployApp
 #' @seealso [addAuthorizedUser()] and [showInvited()]
 #' @return A data frame with one row per authorized user. Columns always
@@ -334,11 +367,13 @@ removeAuthorizedUser <- function(
 #'   record under \code{appDir}, which defaults to the working directory. Pass
 #'   \code{appDir} to point at the project directory that contains the
 #'   \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-#'   the same directory.
+#'   the same directory. Alternatively, pass \code{contentId} to target the
+#'   content directly, without a local deployment record.
 #' @export
 showUsers <- function(
   appDir = getwd(),
   appName = NULL,
+  contentId = NULL,
   account = NULL,
   server = NULL
 ) {
@@ -347,7 +382,7 @@ showUsers <- function(
     checkShinyappsServer(accountDetails$server)
   }
 
-  application <- resolveContentTarget(accountDetails, appDir, appName)
+  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
 
   api <- clientForAccount(accountDetails)
   showUsers_impl(
@@ -367,6 +402,11 @@ showUsers <- function(
 #' @param appDir Directory containing application. Defaults to
 #'   current working directory.
 #' @param appName Name of application.
+#' @param contentId On Posit Connect Cloud, the content ID to manage, taken from
+#'   the content URL
+#'   (\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+#'   supplied, \code{appDir} and \code{appName} are ignored and no local
+#'   deployment record is required. Not supported on shinyapps.io.
 #' @inheritParams deployApp
 #' @seealso [addAuthorizedUser()] and [showUsers()]
 #' @note This function works for ShinyApps and Posit Connect Cloud. On Posit
@@ -378,11 +418,13 @@ showUsers <- function(
 #'   record under \code{appDir}, which defaults to the working directory. Pass
 #'   \code{appDir} to point at the project directory that contains the
 #'   \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-#'   the same directory.
+#'   the same directory. Alternatively, pass \code{contentId} to target the
+#'   content directly, without a local deployment record.
 #' @export
 showInvited <- function(
   appDir = getwd(),
   appName = NULL,
+  contentId = NULL,
   account = NULL,
   server = NULL
 ) {
@@ -391,7 +433,7 @@ showInvited <- function(
     checkShinyappsServer(accountDetails$server)
   }
 
-  application <- resolveContentTarget(accountDetails, appDir, appName)
+  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
 
   api <- clientForAccount(accountDetails)
   showInvited_impl(api, application$id)
@@ -410,6 +452,11 @@ showInvited <- function(
 #' @param appDir Directory containing application. Defaults to
 #'   current working directory.
 #' @param appName Name of application.
+#' @param contentId On Posit Connect Cloud, the content ID to manage, taken from
+#'   the content URL
+#'   (\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+#'   supplied, \code{appDir} and \code{appName} are ignored and no local
+#'   deployment record is required. Not supported on shinyapps.io.
 #' @inheritParams deployApp
 #' @seealso [showInvited()]
 #' @note This function works for ShinyApps and Posit Connect Cloud. The
@@ -420,13 +467,15 @@ showInvited <- function(
 #'   record under \code{appDir}, which defaults to the working directory. Pass
 #'   \code{appDir} to point at the project directory that contains the
 #'   \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-#'   the same directory.
+#'   the same directory. Alternatively, pass \code{contentId} to target the
+#'   content directly, without a local deployment record.
 #' @export
 resendInvitation <- function(
   invite,
   regenerate = FALSE,
   appDir = getwd(),
   appName = NULL,
+  contentId = NULL,
   account = NULL,
   server = NULL
 ) {
@@ -437,7 +486,7 @@ resendInvitation <- function(
 
   # resolve content exactly once, then fetch invitations via impl (avoids a
   # second resolveContentTarget() call).
-  application <- resolveContentTarget(accountDetails, appDir, appName)
+  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
   api <- clientForAccount(accountDetails)
   invited <- showInvited_impl(api, application$id)
 

--- a/R/auth.R
+++ b/R/auth.R
@@ -307,7 +307,12 @@ removeAuthorizedUser <- function(
   } else if (user %in% users$email) {
     user <- users[users$email == user, ]
   } else {
-    stop("User \"", user, "\" not found", call. = FALSE)
+    cli::cli_abort(
+      c(
+        "User {.val {user}} not found.",
+        i = "Pass the user id from {.fn showUsers} instead of the email: on Posit Connect Cloud an email can be redacted and won't match."
+      )
+    )
   }
 
   if (is.na(user$id)) {

--- a/R/auth.R
+++ b/R/auth.R
@@ -209,7 +209,7 @@ addAuthorizedUser <- function(
     checkShinyappsServer(accountDetails$server)
   }
   lifecycle::deprecate_warn(
-    "1.10.1.9000",
+    "1.11.0",
     "addAuthorizedUser()",
     details = collaboratorDeprecationDetails(accountDetails$server)
   )
@@ -279,7 +279,7 @@ removeAuthorizedUser <- function(
     checkShinyappsServer(accountDetails$server)
   }
   lifecycle::deprecate_warn(
-    "1.10.1.9000",
+    "1.11.0",
     "removeAuthorizedUser()",
     details = collaboratorDeprecationDetails(accountDetails$server)
   )
@@ -363,7 +363,7 @@ showUsers <- function(
     checkShinyappsServer(accountDetails$server)
   }
   lifecycle::deprecate_warn(
-    "1.10.1.9000",
+    "1.11.0",
     "showUsers()",
     details = collaboratorDeprecationDetails(accountDetails$server)
   )
@@ -413,7 +413,7 @@ showInvited <- function(
     checkShinyappsServer(accountDetails$server)
   }
   lifecycle::deprecate_warn(
-    "1.10.1.9000",
+    "1.11.0",
     "showInvited()",
     details = collaboratorDeprecationDetails(accountDetails$server)
   )
@@ -463,7 +463,7 @@ resendInvitation <- function(
     checkShinyappsServer(accountDetails$server)
   }
   lifecycle::deprecate_warn(
-    "1.10.1.9000",
+    "1.11.0",
     "resendInvitation()",
     details = collaboratorDeprecationDetails(accountDetails$server)
   )

--- a/R/auth.R
+++ b/R/auth.R
@@ -87,9 +87,11 @@ addAuthorizedUser <- function(
 #' Remove authorized user from an application
 #'
 #' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' Remove authorized user from an application
 #'
-#' Supported servers: ShinyApps servers
+#' Supported servers: ShinyApps, Posit Connect Cloud
 #'
 #' @param user The user to remove. Can be id or email address.
 #' @param appDir Directory containing application. Defaults to
@@ -97,7 +99,7 @@ addAuthorizedUser <- function(
 #' @param appName Name of application.
 #' @inheritParams deployApp
 #' @seealso [addAuthorizedUser()] and [showUsers()]
-#' @note This function works only for ShinyApps servers.
+#' @note This function works for ShinyApps and Posit Connect Cloud.
 #' @export
 removeAuthorizedUser <- function(
   user,
@@ -106,8 +108,18 @@ removeAuthorizedUser <- function(
   account = NULL,
   server = NULL
 ) {
+  lifecycle::deprecate_warn(
+    "1.10.1.9000",
+    "removeAuthorizedUser()",
+    details = paste0(
+      "Manage collaborators directly in Posit Connect Cloud at ",
+      "<https://connect.posit.cloud>."
+    )
+  )
   accountDetails <- accountInfo(account, server)
-  checkShinyappsServer(accountDetails$server)
+  if (!isPositConnectCloudServer(accountDetails$server)) {
+    checkShinyappsServer(accountDetails$server)
+  }
 
   # resolve application
   if (is.null(appName)) {
@@ -149,16 +161,18 @@ removeAuthorizedUser <- function(
 #' List authorized users for an application
 #'
 #' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' List authorized users for an application
 #'
-#' Supported servers: ShinyApps servers
+#' Supported servers: ShinyApps, Posit Connect Cloud
 #'
 #' @param appDir Directory containing application. Defaults to
 #'   current working directory.
 #' @param appName Name of application.
 #' @inheritParams deployApp
 #' @seealso [addAuthorizedUser()] and [showInvited()]
-#' @note This function works only for ShinyApps servers.
+#' @note This function works for ShinyApps and Posit Connect Cloud.
 #' @export
 showUsers <- function(
   appDir = getwd(),
@@ -166,8 +180,18 @@ showUsers <- function(
   account = NULL,
   server = NULL
 ) {
+  lifecycle::deprecate_warn(
+    "1.10.1.9000",
+    "showUsers()",
+    details = paste0(
+      "Manage collaborators directly in Posit Connect Cloud at ",
+      "<https://connect.posit.cloud>."
+    )
+  )
   accountDetails <- accountInfo(account, server)
-  checkShinyappsServer(accountDetails$server)
+  if (!isPositConnectCloudServer(accountDetails$server)) {
+    checkShinyappsServer(accountDetails$server)
+  }
 
   # resolve application
   if (is.null(appName)) {
@@ -179,23 +203,18 @@ showUsers <- function(
   api <- clientForAccount(accountDetails)
   res <- api$listApplicationAuthorization(application$id)
 
-  # get interesting fields
-  users <- lapply(res, function(x) {
-    a <- list()
-    a$id <- x$user$id
-    a$email <- x$user$email
-    if (!is.null(x$account)) {
-      a$account <- x$account
-    } else {
-      a$account <- NA
-    }
-    return(a)
+  # get interesting fields; build rows as data.frames so rbind yields atomic
+  # columns (do.call(rbind, list_of_lists) produces list-matrix columns).
+  rows <- lapply(res, function(x) {
+    data.frame(
+      id      = as.character(x$user$id),
+      email   = as.character(x$user$email),
+      account = if (!is.null(x$account)) as.character(x$account) else NA_character_,
+      stringsAsFactors = FALSE
+    )
   })
 
-  # convert to data frame
-  users <- do.call(rbind, users)
-  df <- as.data.frame(users, stringsAsFactors = FALSE)
-  return(df)
+  do.call(rbind, rows)
 }
 
 #' List invited users for an application

--- a/R/auth.R
+++ b/R/auth.R
@@ -268,7 +268,11 @@ removeAuthorizedUser <- function(
   # return a different record, causing removeApplicationUser to act on the
   # wrong content).
   api <- clientForAccount(accountDetails)
-  users <- showUsers_impl(api, application$id)
+  users <- showUsers_impl(
+    api,
+    application$id,
+    isPCC = isPositConnectCloudServer(accountDetails$server)
+  )
 
   user <- as.character(user)
   # Match id first (UUID strings on PCC, numeric-as-character on shinyapps.io),

--- a/R/auth.R
+++ b/R/auth.R
@@ -2,7 +2,7 @@
 collaboratorDeprecationDetails <- function(server) {
   if (isPositConnectCloudServer(server)) {
     paste0("Manage collaborators directly in Posit Connect Cloud at ",
-           "<https://connect.posit.cloud>.")
+           "<", connectCloudUrls()$ui, ">.")
   } else {
     paste0("Manage collaborators directly in shinyapps.io at ",
            "<https://www.shinyapps.io>.")

--- a/R/auth.R
+++ b/R/auth.R
@@ -1,11 +1,17 @@
 # Internal: deprecation remediation text varies by backend.
 collaboratorDeprecationDetails <- function(server) {
   if (isPositConnectCloudServer(server)) {
-    paste0("Manage collaborators directly in Posit Connect Cloud at ",
-           "<", connectCloudUrls()$ui, ">.")
+    paste0(
+      "Manage collaborators directly in Posit Connect Cloud at ",
+      "<",
+      connectCloudUrls()$ui,
+      ">."
+    )
   } else {
-    paste0("Manage collaborators directly in shinyapps.io at ",
-           "<https://www.shinyapps.io>.")
+    paste0(
+      "Manage collaborators directly in shinyapps.io at ",
+      "<https://www.shinyapps.io>."
+    )
   }
 }
 
@@ -15,7 +21,7 @@ collaboratorDeprecationDetails <- function(server) {
 showUsers_impl <- function(api, applicationId) {
   res <- api$listApplicationAuthorization(applicationId)
   rows <- lapply(res, function(x) {
-    id    <- as.character(x$user$id    %||% NA_character_)
+    id <- as.character(x$user$id %||% NA_character_)
     email <- as.character(x$user$email %||% NA_character_)
     if (is.na(id) && is.na(email)) {
       cli::cli_abort(
@@ -26,16 +32,20 @@ showUsers_impl <- function(api, applicationId) {
       )
     }
     data.frame(
-      id      = id,
-      email   = email,
-      account = if (!is.null(x$account)) as.character(x$account) else NA_character_,
+      id = id,
+      email = email,
+      account = if (!is.null(x$account)) {
+        as.character(x$account)
+      } else {
+        NA_character_
+      },
       stringsAsFactors = FALSE
     )
   })
   if (length(rows) == 0L) {
     return(data.frame(
-      id      = character(),
-      email   = character(),
+      id = character(),
+      email = character(),
       account = character(),
       stringsAsFactors = FALSE
     ))
@@ -50,18 +60,18 @@ showInvited_impl <- function(api, applicationId) {
   # PCC uses email_address / is_expired; shinyapps.io uses email / expired.
   rows <- lapply(res, function(x) {
     data.frame(
-      id      = as.character(x$id %||% NA_character_),
-      email   = as.character(x$email_address %||% x$email %||% NA_character_),
-      link    = as.character(x$link %||% NA_character_),
+      id = as.character(x$id %||% NA_character_),
+      email = as.character(x$email_address %||% x$email %||% NA_character_),
+      link = as.character(x$link %||% NA_character_),
       expired = as.logical(x$is_expired %||% x$expired %||% NA),
       stringsAsFactors = FALSE
     )
   })
   if (length(rows) == 0L) {
     return(data.frame(
-      id      = character(),
-      email   = character(),
-      link    = character(),
+      id = character(),
+      email = character(),
+      link = character(),
       expired = logical(),
       stringsAsFactors = FALSE
     ))
@@ -188,7 +198,10 @@ addAuthorizedUser <- function(
   }
 
   # PCC always emails invitees; warn only when caller explicitly opts out
-  if (isPositConnectCloudServer(accountDetails$server) && identical(sendEmail, FALSE)) {
+  if (
+    isPositConnectCloudServer(accountDetails$server) &&
+      identical(sendEmail, FALSE)
+  ) {
     cli::cli_warn(
       "{.arg sendEmail} is ignored on Posit Connect Cloud; PCC always sends an invitation email."
     )

--- a/R/auth.R
+++ b/R/auth.R
@@ -40,6 +40,38 @@ cleanupPasswordFile <- function(appDir) {
   invisible(TRUE)
 }
 
+# Internal: resolve the target content for collaborator management functions.
+# On PCC, reads the local deployment record to get the content id (appId)
+# rather than matching by title (mutable, non-unique on PCC).
+# On shinyapps.io, delegates to resolveApplication() unchanged.
+resolveContentTarget <- function(accountDetails, appDir, appName) {
+  if (isPositConnectCloudServer(accountDetails$server)) {
+    recs <- deployments(
+      appPath = appDir,
+      accountFilter = accountDetails$name,
+      serverFilter = accountDetails$server
+    )
+    if (nrow(recs) == 0L) {
+      cli::cli_abort(c(
+        "Can't identify the Posit Connect Cloud content for {.file {appDir}}.",
+        i = paste0(
+          "No deployment record found. Deploy the content first, or run from ",
+          "the project directory that contains its {.path rsconnect/} record."
+        )
+      ))
+    }
+    if (nrow(recs) > 1L) {
+      cli::cli_abort(c(
+        "Found {nrow(recs)} deployment records for {.file {appDir}}.",
+        i = "Narrow the target by supplying {.arg account} and/or {.arg server}."
+      ))
+    }
+    list(id = recs$appId[[1L]])
+  } else {
+    resolveApplication(accountDetails, appName %||% basename(appDir))
+  }
+}
+
 #' Add authorized user to application
 #'
 #' @description
@@ -84,11 +116,7 @@ addAuthorizedUser <- function(
     details = collaboratorDeprecationDetails(accountDetails$server)
   )
 
-  # resolve application
-  if (is.null(appName)) {
-    appName <- basename(appDir)
-  }
-  application <- resolveApplication(accountDetails, appName)
+  application <- resolveContentTarget(accountDetails, appDir, appName)
 
   # check for and remove password file
   cleanupPasswordFile(appDir)
@@ -148,11 +176,7 @@ removeAuthorizedUser <- function(
     details = collaboratorDeprecationDetails(accountDetails$server)
   )
 
-  # resolve application
-  if (is.null(appName)) {
-    appName <- basename(appDir)
-  }
-  application <- resolveApplication(accountDetails, appName)
+  application <- resolveContentTarget(accountDetails, appDir, appName)
 
   # check and remove password file
   cleanupPasswordFile(appDir)
@@ -217,11 +241,7 @@ showUsers <- function(
     details = collaboratorDeprecationDetails(accountDetails$server)
   )
 
-  # resolve application
-  if (is.null(appName)) {
-    appName <- basename(appDir)
-  }
-  application <- resolveApplication(accountDetails, appName)
+  application <- resolveContentTarget(accountDetails, appDir, appName)
 
   # fetch authorization list
   api <- clientForAccount(accountDetails)
@@ -284,11 +304,7 @@ showInvited <- function(
     details = collaboratorDeprecationDetails(accountDetails$server)
   )
 
-  # resolve application
-  if (is.null(appName)) {
-    appName <- basename(appDir)
-  }
-  application <- resolveApplication(accountDetails, appName)
+  application <- resolveContentTarget(accountDetails, appDir, appName)
 
   # fetch invitation list
   api <- clientForAccount(accountDetails)

--- a/R/auth.R
+++ b/R/auth.R
@@ -49,7 +49,8 @@ resolveContentTarget <- function(accountDetails, appDir, appName) {
     recs <- deployments(
       appPath = appDir,
       accountFilter = accountDetails$name,
-      serverFilter = accountDetails$server
+      serverFilter = accountDetails$server,
+      nameFilter = appName
     )
     if (nrow(recs) == 0L) {
       cli::cli_abort(c(
@@ -61,10 +62,8 @@ resolveContentTarget <- function(accountDetails, appDir, appName) {
       ))
     }
     if (nrow(recs) > 1L) {
-      cli::cli_abort(c(
-        "Found {nrow(recs)} deployment records for {.file {appDir}}.",
-        i = "Narrow the target by supplying {.arg account} and/or {.arg server}."
-      ))
+      dep <- disambiguateDeployments(recs)
+      return(list(id = dep$appId))
     }
     list(id = recs$appId[[1L]])
   } else {
@@ -96,6 +95,11 @@ resolveContentTarget <- function(accountDetails, appDir, appName) {
 #'   Connect Cloud, the content's account must be an organization account.
 #'   The \code{sendEmail} argument is ignored on Posit Connect Cloud;
 #'   PCC always sends an invitation email.
+#'
+#'   On Posit Connect Cloud, the content is resolved from the local deployment
+#'   record in \code{appDir}; the call must run from the directory that contains
+#'   the \code{rsconnect/} deployment record. \code{appName} selects among
+#'   multiple records in the same directory.
 #' @export
 addAuthorizedUser <- function(
   email,
@@ -158,6 +162,11 @@ addAuthorizedUser <- function(
 #' @inheritParams deployApp
 #' @seealso [addAuthorizedUser()] and [showUsers()]
 #' @note This function works for ShinyApps and Posit Connect Cloud.
+#'
+#'   On Posit Connect Cloud, the content is resolved from the local deployment
+#'   record in \code{appDir}; the call must run from the directory that contains
+#'   the \code{rsconnect/} deployment record. \code{appName} selects among
+#'   multiple records in the same directory.
 #' @export
 removeAuthorizedUser <- function(
   user,
@@ -224,6 +233,11 @@ removeAuthorizedUser <- function(
 #' @inheritParams deployApp
 #' @seealso [addAuthorizedUser()] and [showInvited()]
 #' @note This function works for ShinyApps and Posit Connect Cloud.
+#'
+#'   On Posit Connect Cloud, the content is resolved from the local deployment
+#'   record in \code{appDir}; the call must run from the directory that contains
+#'   the \code{rsconnect/} deployment record. \code{appName} selects among
+#'   multiple records in the same directory.
 #' @export
 showUsers <- function(
   appDir = getwd(),
@@ -287,6 +301,11 @@ showUsers <- function(
 #'   Connect Cloud, the \code{link} column is always \code{NA} because the
 #'   accept link is only emailed to the recipient and is never returned by
 #'   the API.
+#'
+#'   On Posit Connect Cloud, the content is resolved from the local deployment
+#'   record in \code{appDir}; the call must run from the directory that contains
+#'   the \code{rsconnect/} deployment record. \code{appName} selects among
+#'   multiple records in the same directory.
 #' @export
 showInvited <- function(
   appDir = getwd(),

--- a/R/auth.R
+++ b/R/auth.R
@@ -124,7 +124,12 @@ cleanupPasswordFile <- function(appDir) {
 # by title (mutable, non-unique on PCC).
 # On shinyapps.io, delegates to resolveApplication() unchanged; contentId is
 # not supported there.
-resolveContentTarget <- function(accountDetails, appDir, appName, contentId = NULL) {
+resolveContentTarget <- function(
+  accountDetails,
+  appDir,
+  appName,
+  contentId = NULL
+) {
   if (isPositConnectCloudServer(accountDetails$server)) {
     # An explicit content id targets PCC content directly, with no local
     # deployment record required.
@@ -213,7 +218,12 @@ addAuthorizedUser <- function(
     checkShinyappsServer(accountDetails$server)
   }
 
-  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
+  application <- resolveContentTarget(
+    accountDetails,
+    appDir,
+    appName,
+    contentId
+  )
 
   # check for and remove password file (shinyapps.io only; PCC has no password file)
   if (!isPositConnectCloudServer(accountDetails$server)) {
@@ -284,7 +294,12 @@ removeAuthorizedUser <- function(
     checkShinyappsServer(accountDetails$server)
   }
 
-  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
+  application <- resolveContentTarget(
+    accountDetails,
+    appDir,
+    appName,
+    contentId
+  )
 
   # check and remove password file (shinyapps.io only; PCC has no password file)
   if (!isPositConnectCloudServer(accountDetails$server)) {
@@ -382,7 +397,12 @@ showUsers <- function(
     checkShinyappsServer(accountDetails$server)
   }
 
-  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
+  application <- resolveContentTarget(
+    accountDetails,
+    appDir,
+    appName,
+    contentId
+  )
 
   api <- clientForAccount(accountDetails)
   showUsers_impl(
@@ -433,7 +453,12 @@ showInvited <- function(
     checkShinyappsServer(accountDetails$server)
   }
 
-  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
+  application <- resolveContentTarget(
+    accountDetails,
+    appDir,
+    appName,
+    contentId
+  )
 
   api <- clientForAccount(accountDetails)
   showInvited_impl(api, application$id)
@@ -486,7 +511,12 @@ resendInvitation <- function(
 
   # resolve content exactly once, then fetch invitations via impl (avoids a
   # second resolveContentTarget() call).
-  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
+  application <- resolveContentTarget(
+    accountDetails,
+    appDir,
+    appName,
+    contentId
+  )
   api <- clientForAccount(accountDetails)
   invited <- showInvited_impl(api, application$id)
 

--- a/R/auth.R
+++ b/R/auth.R
@@ -1,3 +1,14 @@
+# Internal: deprecation remediation text varies by backend.
+collaboratorDeprecationDetails <- function(server) {
+  if (isPositConnectCloudServer(server)) {
+    paste0("Manage collaborators directly in Posit Connect Cloud at ",
+           "<https://connect.posit.cloud>.")
+  } else {
+    paste0("Manage collaborators directly in shinyapps.io at ",
+           "<https://www.shinyapps.io>.")
+  }
+}
+
 cleanupPasswordFile <- function(appDir) {
   check_directory(appDir)
   appDir <- normalizePath(appDir)
@@ -64,20 +75,14 @@ addAuthorizedUser <- function(
   emailMessage = NULL
 ) {
   accountDetails <- accountInfo(account, server)
-  lifecycle::deprecate_warn(
-    "1.10.1.9000",
-    "addAuthorizedUser()",
-    details = if (isPositConnectCloudServer(accountDetails$server)) {
-      paste0("Manage collaborators directly in Posit Connect Cloud at ",
-             "<https://connect.posit.cloud>.")
-    } else {
-      paste0("Manage collaborators directly in shinyapps.io at ",
-             "<https://www.shinyapps.io>.")
-    }
-  )
   if (!isPositConnectCloudServer(accountDetails$server)) {
     checkShinyappsServer(accountDetails$server)
   }
+  lifecycle::deprecate_warn(
+    "1.10.1.9000",
+    "addAuthorizedUser()",
+    details = collaboratorDeprecationDetails(accountDetails$server)
+  )
 
   # resolve application
   if (is.null(appName)) {
@@ -88,8 +93,8 @@ addAuthorizedUser <- function(
   # check for and remove password file
   cleanupPasswordFile(appDir)
 
-  # PCC always emails invitees; warn if caller explicitly passed sendEmail
-  if (isPositConnectCloudServer(accountDetails$server) && !is.null(sendEmail)) {
+  # PCC always emails invitees; warn only when caller explicitly opts out
+  if (isPositConnectCloudServer(accountDetails$server) && identical(sendEmail, FALSE)) {
     cli::cli_warn(
       "{.arg sendEmail} is ignored on Posit Connect Cloud; PCC always sends an invitation email."
     )
@@ -134,20 +139,14 @@ removeAuthorizedUser <- function(
   server = NULL
 ) {
   accountDetails <- accountInfo(account, server)
-  lifecycle::deprecate_warn(
-    "1.10.1.9000",
-    "removeAuthorizedUser()",
-    details = if (isPositConnectCloudServer(accountDetails$server)) {
-      paste0("Manage collaborators directly in Posit Connect Cloud at ",
-             "<https://connect.posit.cloud>.")
-    } else {
-      paste0("Manage collaborators directly in shinyapps.io at ",
-             "<https://www.shinyapps.io>.")
-    }
-  )
   if (!isPositConnectCloudServer(accountDetails$server)) {
     checkShinyappsServer(accountDetails$server)
   }
+  lifecycle::deprecate_warn(
+    "1.10.1.9000",
+    "removeAuthorizedUser()",
+    details = collaboratorDeprecationDetails(accountDetails$server)
+  )
 
   # resolve application
   if (is.null(appName)) {
@@ -209,20 +208,14 @@ showUsers <- function(
   server = NULL
 ) {
   accountDetails <- accountInfo(account, server)
-  lifecycle::deprecate_warn(
-    "1.10.1.9000",
-    "showUsers()",
-    details = if (isPositConnectCloudServer(accountDetails$server)) {
-      paste0("Manage collaborators directly in Posit Connect Cloud at ",
-             "<https://connect.posit.cloud>.")
-    } else {
-      paste0("Manage collaborators directly in shinyapps.io at ",
-             "<https://www.shinyapps.io>.")
-    }
-  )
   if (!isPositConnectCloudServer(accountDetails$server)) {
     checkShinyappsServer(accountDetails$server)
   }
+  lifecycle::deprecate_warn(
+    "1.10.1.9000",
+    "showUsers()",
+    details = collaboratorDeprecationDetails(accountDetails$server)
+  )
 
   # resolve application
   if (is.null(appName)) {
@@ -238,8 +231,8 @@ showUsers <- function(
   # columns (do.call(rbind, list_of_lists) produces list-matrix columns).
   rows <- lapply(res, function(x) {
     data.frame(
-      id      = as.character(x$user$id),
-      email   = as.character(x$user$email),
+      id      = as.character(x$user$id %||% NA_character_),
+      email   = as.character(x$user$email %||% NA_character_),
       account = if (!is.null(x$account)) as.character(x$account) else NA_character_,
       stringsAsFactors = FALSE
     )
@@ -282,20 +275,14 @@ showInvited <- function(
   server = NULL
 ) {
   accountDetails <- accountInfo(account, server)
-  lifecycle::deprecate_warn(
-    "1.10.1.9000",
-    "showInvited()",
-    details = if (isPositConnectCloudServer(accountDetails$server)) {
-      paste0("Manage collaborators directly in Posit Connect Cloud at ",
-             "<https://connect.posit.cloud>.")
-    } else {
-      paste0("Manage collaborators directly in shinyapps.io at ",
-             "<https://www.shinyapps.io>.")
-    }
-  )
   if (!isPositConnectCloudServer(accountDetails$server)) {
     checkShinyappsServer(accountDetails$server)
   }
+  lifecycle::deprecate_warn(
+    "1.10.1.9000",
+    "showInvited()",
+    details = collaboratorDeprecationDetails(accountDetails$server)
+  )
 
   # resolve application
   if (is.null(appName)) {
@@ -312,7 +299,7 @@ showInvited <- function(
   # produces list-matrix columns).
   rows <- lapply(res, function(x) {
     data.frame(
-      id      = as.character(x$id),
+      id      = as.character(x$id %||% NA_character_),
       email   = as.character(x$email_address %||% x$email %||% NA_character_),
       link    = as.character(x$link %||% NA_character_),
       expired = as.logical(x$is_expired %||% x$expired %||% NA),
@@ -362,20 +349,14 @@ resendInvitation <- function(
   server = NULL
 ) {
   accountDetails <- accountInfo(account, server)
-  lifecycle::deprecate_warn(
-    "1.10.1.9000",
-    "resendInvitation()",
-    details = if (isPositConnectCloudServer(accountDetails$server)) {
-      paste0("Manage collaborators directly in Posit Connect Cloud at ",
-             "<https://connect.posit.cloud>.")
-    } else {
-      paste0("Manage collaborators directly in shinyapps.io at ",
-             "<https://www.shinyapps.io>.")
-    }
-  )
   if (!isPositConnectCloudServer(accountDetails$server)) {
     checkShinyappsServer(accountDetails$server)
   }
+  lifecycle::deprecate_warn(
+    "1.10.1.9000",
+    "resendInvitation()",
+    details = collaboratorDeprecationDetails(accountDetails$server)
+  )
 
   # get invitations
   invited <- showInvited(appDir, appName, account, server)

--- a/R/auth.R
+++ b/R/auth.R
@@ -51,6 +51,8 @@ cleanupPasswordFile <- function(appDir) {
 #' @seealso [removeAuthorizedUser()] and [showUsers()]
 #' @note This function works for ShinyApps and Posit Connect Cloud. On Posit
 #'   Connect Cloud, the content's account must be an organization account.
+#'   The \code{sendEmail} argument is ignored on Posit Connect Cloud;
+#'   PCC always sends an invitation email.
 #' @export
 addAuthorizedUser <- function(
   email,
@@ -61,15 +63,18 @@ addAuthorizedUser <- function(
   sendEmail = NULL,
   emailMessage = NULL
 ) {
+  accountDetails <- accountInfo(account, server)
   lifecycle::deprecate_warn(
     "1.10.1.9000",
     "addAuthorizedUser()",
-    details = paste0(
-      "Manage collaborators directly in Posit Connect Cloud at ",
-      "<https://connect.posit.cloud>."
-    )
+    details = if (isPositConnectCloudServer(accountDetails$server)) {
+      paste0("Manage collaborators directly in Posit Connect Cloud at ",
+             "<https://connect.posit.cloud>.")
+    } else {
+      paste0("Manage collaborators directly in shinyapps.io at ",
+             "<https://www.shinyapps.io>.")
+    }
   )
-  accountDetails <- accountInfo(account, server)
   if (!isPositConnectCloudServer(accountDetails$server)) {
     checkShinyappsServer(accountDetails$server)
   }
@@ -82,6 +87,13 @@ addAuthorizedUser <- function(
 
   # check for and remove password file
   cleanupPasswordFile(appDir)
+
+  # PCC always emails invitees; warn if caller explicitly passed sendEmail
+  if (isPositConnectCloudServer(accountDetails$server) && !is.null(sendEmail)) {
+    cli::cli_warn(
+      "{.arg sendEmail} is ignored on Posit Connect Cloud; PCC always sends an invitation email."
+    )
+  }
 
   # fetch authorization list
   api <- clientForAccount(accountDetails)
@@ -121,15 +133,18 @@ removeAuthorizedUser <- function(
   account = NULL,
   server = NULL
 ) {
+  accountDetails <- accountInfo(account, server)
   lifecycle::deprecate_warn(
     "1.10.1.9000",
     "removeAuthorizedUser()",
-    details = paste0(
-      "Manage collaborators directly in Posit Connect Cloud at ",
-      "<https://connect.posit.cloud>."
-    )
+    details = if (isPositConnectCloudServer(accountDetails$server)) {
+      paste0("Manage collaborators directly in Posit Connect Cloud at ",
+             "<https://connect.posit.cloud>.")
+    } else {
+      paste0("Manage collaborators directly in shinyapps.io at ",
+             "<https://www.shinyapps.io>.")
+    }
   )
-  accountDetails <- accountInfo(account, server)
   if (!isPositConnectCloudServer(accountDetails$server)) {
     checkShinyappsServer(accountDetails$server)
   }
@@ -193,15 +208,18 @@ showUsers <- function(
   account = NULL,
   server = NULL
 ) {
+  accountDetails <- accountInfo(account, server)
   lifecycle::deprecate_warn(
     "1.10.1.9000",
     "showUsers()",
-    details = paste0(
-      "Manage collaborators directly in Posit Connect Cloud at ",
-      "<https://connect.posit.cloud>."
-    )
+    details = if (isPositConnectCloudServer(accountDetails$server)) {
+      paste0("Manage collaborators directly in Posit Connect Cloud at ",
+             "<https://connect.posit.cloud>.")
+    } else {
+      paste0("Manage collaborators directly in shinyapps.io at ",
+             "<https://www.shinyapps.io>.")
+    }
   )
-  accountDetails <- accountInfo(account, server)
   if (!isPositConnectCloudServer(accountDetails$server)) {
     checkShinyappsServer(accountDetails$server)
   }
@@ -263,15 +281,18 @@ showInvited <- function(
   account = NULL,
   server = NULL
 ) {
+  accountDetails <- accountInfo(account, server)
   lifecycle::deprecate_warn(
     "1.10.1.9000",
     "showInvited()",
-    details = paste0(
-      "Manage collaborators directly in Posit Connect Cloud at ",
-      "<https://connect.posit.cloud>."
-    )
+    details = if (isPositConnectCloudServer(accountDetails$server)) {
+      paste0("Manage collaborators directly in Posit Connect Cloud at ",
+             "<https://connect.posit.cloud>.")
+    } else {
+      paste0("Manage collaborators directly in shinyapps.io at ",
+             "<https://www.shinyapps.io>.")
+    }
   )
-  accountDetails <- accountInfo(account, server)
   if (!isPositConnectCloudServer(accountDetails$server)) {
     checkShinyappsServer(accountDetails$server)
   }
@@ -292,9 +313,9 @@ showInvited <- function(
   rows <- lapply(res, function(x) {
     data.frame(
       id      = as.character(x$id),
-      email   = as.character(x$email_address %||% x$email),
+      email   = as.character(x$email_address %||% x$email %||% NA_character_),
       link    = as.character(x$link %||% NA_character_),
-      expired = as.logical(x$is_expired %||% x$expired),
+      expired = as.logical(x$is_expired %||% x$expired %||% NA),
       stringsAsFactors = FALSE
     )
   })
@@ -340,15 +361,18 @@ resendInvitation <- function(
   account = NULL,
   server = NULL
 ) {
+  accountDetails <- accountInfo(account, server)
   lifecycle::deprecate_warn(
     "1.10.1.9000",
     "resendInvitation()",
-    details = paste0(
-      "Manage collaborators directly in Posit Connect Cloud at ",
-      "<https://connect.posit.cloud>."
-    )
+    details = if (isPositConnectCloudServer(accountDetails$server)) {
+      paste0("Manage collaborators directly in Posit Connect Cloud at ",
+             "<https://connect.posit.cloud>.")
+    } else {
+      paste0("Manage collaborators directly in shinyapps.io at ",
+             "<https://www.shinyapps.io>.")
+    }
   )
-  accountDetails <- accountInfo(account, server)
   if (!isPositConnectCloudServer(accountDetails$server)) {
     checkShinyappsServer(accountDetails$server)
   }

--- a/R/auth.R
+++ b/R/auth.R
@@ -135,7 +135,7 @@ resolveContentTarget <- function(accountDetails, appDir, appName) {
         "Can't identify the Posit Connect Cloud content for {.file {appDir}}.",
         i = paste0(
           "No deployment record found. Deploy the content first, or run from ",
-          "the project directory that contains its {.path rsconnect/} record."
+          "the project directory that contains its {.path rsconnect/} deployment record."
         )
       ))
     }
@@ -149,6 +149,9 @@ resolveContentTarget <- function(accountDetails, appDir, appName) {
   }
 }
 
+#' Add authorized user to application
+#'
+#' @description
 #' Add authorized user to application
 #'
 #' Supported servers: ShinyApps, Posit Connect Cloud
@@ -172,7 +175,7 @@ resolveContentTarget <- function(accountDetails, appDir, appName) {
 #'   On Posit Connect Cloud, the content is resolved from the local deployment
 #'   record under \code{appDir}, which defaults to the working directory. Pass
 #'   \code{appDir} to point at the project directory that contains the
-#'   \code{rsconnect/} record. \code{appName} selects among multiple records in
+#'   \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
 #'   the same directory.
 #' @export
 addAuthorizedUser <- function(
@@ -222,6 +225,9 @@ addAuthorizedUser <- function(
 
 #' Remove authorized user from an application
 #'
+#' @description
+#' Remove authorized user from an application
+#'
 #' Supported servers: ShinyApps, Posit Connect Cloud
 #'
 #' @param user The user to remove. Can be id or email address.
@@ -235,7 +241,7 @@ addAuthorizedUser <- function(
 #'   On Posit Connect Cloud, the content is resolved from the local deployment
 #'   record under \code{appDir}, which defaults to the working directory. Pass
 #'   \code{appDir} to point at the project directory that contains the
-#'   \code{rsconnect/} record. \code{appName} selects among multiple records in
+#'   \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
 #'   the same directory.
 #' @export
 removeAuthorizedUser <- function(
@@ -302,6 +308,9 @@ removeAuthorizedUser <- function(
 
 #' List authorized users for an application
 #'
+#' @description
+#' List authorized users for an application
+#'
 #' Supported servers: ShinyApps, Posit Connect Cloud
 #'
 #' @param appDir Directory containing application. Defaults to
@@ -320,7 +329,7 @@ removeAuthorizedUser <- function(
 #'   On Posit Connect Cloud, the content is resolved from the local deployment
 #'   record under \code{appDir}, which defaults to the working directory. Pass
 #'   \code{appDir} to point at the project directory that contains the
-#'   \code{rsconnect/} record. \code{appName} selects among multiple records in
+#'   \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
 #'   the same directory.
 #' @export
 showUsers <- function(
@@ -346,6 +355,9 @@ showUsers <- function(
 
 #' List invited users for an application
 #'
+#' @description
+#' List invited users for an application
+#'
 #' Supported servers: ShinyApps, Posit Connect Cloud
 #'
 #' @param appDir Directory containing application. Defaults to
@@ -361,7 +373,7 @@ showUsers <- function(
 #'   On Posit Connect Cloud, the content is resolved from the local deployment
 #'   record under \code{appDir}, which defaults to the working directory. Pass
 #'   \code{appDir} to point at the project directory that contains the
-#'   \code{rsconnect/} record. \code{appName} selects among multiple records in
+#'   \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
 #'   the same directory.
 #' @export
 showInvited <- function(
@@ -383,6 +395,9 @@ showInvited <- function(
 
 #' Resend invitation for invited users of an application
 #'
+#' @description
+#' Resend invitation for invited users of an application
+#'
 #' Supported servers: ShinyApps, Posit Connect Cloud
 #'
 #' @param invite The invitation to resend. Can be id or email address.
@@ -400,7 +415,7 @@ showInvited <- function(
 #'   On Posit Connect Cloud, the content is resolved from the local deployment
 #'   record under \code{appDir}, which defaults to the working directory. Pass
 #'   \code{appDir} to point at the project directory that contains the
-#'   \code{rsconnect/} record. \code{appName} selects among multiple records in
+#'   \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
 #'   the same directory.
 #' @export
 resendInvitation <- function(

--- a/R/auth.R
+++ b/R/auth.R
@@ -214,6 +214,14 @@ showUsers <- function(
     )
   })
 
+  if (length(rows) == 0L) {
+    return(data.frame(
+      id      = character(),
+      email   = character(),
+      account = character(),
+      stringsAsFactors = FALSE
+    ))
+  }
   do.call(rbind, rows)
 }
 

--- a/R/auth.R
+++ b/R/auth.R
@@ -1,23 +1,6 @@
-# Internal: deprecation remediation text varies by backend.
-collaboratorDeprecationDetails <- function(server) {
-  if (isPositConnectCloudServer(server)) {
-    paste0(
-      "Manage collaborators directly in Posit Connect Cloud at ",
-      "<",
-      connectCloudUrls()$ui,
-      ">."
-    )
-  } else {
-    paste0(
-      "Manage collaborators directly in shinyapps.io at ",
-      "<https://www.shinyapps.io>."
-    )
-  }
-}
-
 # Internal: fetch authorized users for an already-resolved application id.
-# Does NOT call resolveContentTarget() or emit deprecate_warn(); callers are
-# responsible for resolving content exactly once before invoking this.
+# Does NOT call resolveContentTarget(); callers are responsible for resolving
+# content exactly once before invoking this.
 # isPCC = TRUE adds display_name and role columns from the PCC response shape
 # ({user: {id, email, display_name, ...}, role}); shinyapps.io keeps the
 # original three-column shape (id, email, account).
@@ -79,7 +62,7 @@ showUsers_impl <- function(api, applicationId, isPCC = FALSE) {
 }
 
 # Internal: fetch pending invitations for an already-resolved application id.
-# Does NOT call resolveContentTarget() or emit deprecate_warn().
+# Does NOT call resolveContentTarget().
 showInvited_impl <- function(api, applicationId) {
   res <- api$listApplicationInvitations(applicationId)
   # PCC uses email_address / is_expired; shinyapps.io uses email / expired.
@@ -168,11 +151,6 @@ resolveContentTarget <- function(accountDetails, appDir, appName) {
 
 #' Add authorized user to application
 #'
-#' @description
-#' `r lifecycle::badge("deprecated")`
-#'
-#' Add authorized user to application
-#'
 #' Supported servers: ShinyApps, Posit Connect Cloud
 #'
 #' @param email Email address of user to add.
@@ -210,11 +188,6 @@ addAuthorizedUser <- function(
   if (!isPositConnectCloudServer(accountDetails$server)) {
     checkShinyappsServer(accountDetails$server)
   }
-  lifecycle::deprecate_warn(
-    "1.11.0",
-    "addAuthorizedUser()",
-    details = collaboratorDeprecationDetails(accountDetails$server)
-  )
 
   application <- resolveContentTarget(accountDetails, appDir, appName)
 
@@ -249,11 +222,6 @@ addAuthorizedUser <- function(
 
 #' Remove authorized user from an application
 #'
-#' @description
-#' `r lifecycle::badge("deprecated")`
-#'
-#' Remove authorized user from an application
-#'
 #' Supported servers: ShinyApps, Posit Connect Cloud
 #'
 #' @param user The user to remove. Can be id or email address.
@@ -281,11 +249,6 @@ removeAuthorizedUser <- function(
   if (!isPositConnectCloudServer(accountDetails$server)) {
     checkShinyappsServer(accountDetails$server)
   }
-  lifecycle::deprecate_warn(
-    "1.11.0",
-    "removeAuthorizedUser()",
-    details = collaboratorDeprecationDetails(accountDetails$server)
-  )
 
   application <- resolveContentTarget(accountDetails, appDir, appName)
 
@@ -297,8 +260,7 @@ removeAuthorizedUser <- function(
   # resolve content exactly once: use impl so showUsers() does not call
   # resolveContentTarget() a second time (a second interactive prompt could
   # return a different record, causing removeApplicationUser to act on the
-  # wrong content). This supersedes the plan's accepted double-deprecation
-  # note — the root issue is a correctness bug, not just warning noise.
+  # wrong content).
   api <- clientForAccount(accountDetails)
   users <- showUsers_impl(api, application$id)
 
@@ -340,11 +302,6 @@ removeAuthorizedUser <- function(
 
 #' List authorized users for an application
 #'
-#' @description
-#' `r lifecycle::badge("deprecated")`
-#'
-#' List authorized users for an application
-#'
 #' Supported servers: ShinyApps, Posit Connect Cloud
 #'
 #' @param appDir Directory containing application. Defaults to
@@ -376,11 +333,6 @@ showUsers <- function(
   if (!isPositConnectCloudServer(accountDetails$server)) {
     checkShinyappsServer(accountDetails$server)
   }
-  lifecycle::deprecate_warn(
-    "1.11.0",
-    "showUsers()",
-    details = collaboratorDeprecationDetails(accountDetails$server)
-  )
 
   application <- resolveContentTarget(accountDetails, appDir, appName)
 
@@ -392,11 +344,6 @@ showUsers <- function(
   )
 }
 
-#' List invited users for an application
-#'
-#' @description
-#' `r lifecycle::badge("deprecated")`
-#'
 #' List invited users for an application
 #'
 #' Supported servers: ShinyApps, Posit Connect Cloud
@@ -427,11 +374,6 @@ showInvited <- function(
   if (!isPositConnectCloudServer(accountDetails$server)) {
     checkShinyappsServer(accountDetails$server)
   }
-  lifecycle::deprecate_warn(
-    "1.11.0",
-    "showInvited()",
-    details = collaboratorDeprecationDetails(accountDetails$server)
-  )
 
   application <- resolveContentTarget(accountDetails, appDir, appName)
 
@@ -439,11 +381,6 @@ showInvited <- function(
   showInvited_impl(api, application$id)
 }
 
-#' Resend invitation for invited users of an application
-#'
-#' @description
-#' `r lifecycle::badge("deprecated")`
-#'
 #' Resend invitation for invited users of an application
 #'
 #' Supported servers: ShinyApps, Posit Connect Cloud
@@ -478,14 +415,9 @@ resendInvitation <- function(
   if (!isPositConnectCloudServer(accountDetails$server)) {
     checkShinyappsServer(accountDetails$server)
   }
-  lifecycle::deprecate_warn(
-    "1.11.0",
-    "resendInvitation()",
-    details = collaboratorDeprecationDetails(accountDetails$server)
-  )
 
   # resolve content exactly once, then fetch invitations via impl (avoids a
-  # second resolveContentTarget() call and a second deprecate_warn()).
+  # second resolveContentTarget() call).
   application <- resolveContentTarget(accountDetails, appDir, appName)
   api <- clientForAccount(accountDetails)
   invited <- showInvited_impl(api, application$id)

--- a/R/auth.R
+++ b/R/auth.R
@@ -18,7 +18,10 @@ collaboratorDeprecationDetails <- function(server) {
 # Internal: fetch authorized users for an already-resolved application id.
 # Does NOT call resolveContentTarget() or emit deprecate_warn(); callers are
 # responsible for resolving content exactly once before invoking this.
-showUsers_impl <- function(api, applicationId) {
+# isPCC = TRUE adds display_name and role columns from the PCC response shape
+# ({user: {id, email, display_name, ...}, role}); shinyapps.io keeps the
+# original three-column shape (id, email, account).
+showUsers_impl <- function(api, applicationId, isPCC = FALSE) {
   res <- api$listApplicationAuthorization(applicationId)
   rows <- lapply(res, function(x) {
     id <- as.character(x$user$id %||% NA_character_)
@@ -31,18 +34,39 @@ showUsers_impl <- function(api, applicationId) {
         )
       )
     }
-    data.frame(
-      id = id,
-      email = email,
-      account = if (!is.null(x$account)) {
-        as.character(x$account)
-      } else {
-        NA_character_
-      },
-      stringsAsFactors = FALSE
-    )
+    if (isPCC) {
+      data.frame(
+        id = id,
+        email = email,
+        account = NA_character_,
+        display_name = as.character(x$user$display_name %||% NA_character_),
+        role = as.character(x$role %||% NA_character_),
+        stringsAsFactors = FALSE
+      )
+    } else {
+      data.frame(
+        id = id,
+        email = email,
+        account = if (!is.null(x$account)) {
+          as.character(x$account)
+        } else {
+          NA_character_
+        },
+        stringsAsFactors = FALSE
+      )
+    }
   })
   if (length(rows) == 0L) {
+    if (isPCC) {
+      return(data.frame(
+        id = character(),
+        email = character(),
+        account = character(),
+        display_name = character(),
+        role = character(),
+        stringsAsFactors = FALSE
+      ))
+    }
     return(data.frame(
       id = character(),
       email = character(),
@@ -315,6 +339,12 @@ removeAuthorizedUser <- function(
 #' @param appName Name of application.
 #' @inheritParams deployApp
 #' @seealso [addAuthorizedUser()] and [showInvited()]
+#' @return A data frame with one row per authorized user. Columns always
+#'   present: \code{id}, \code{email}, \code{account}. The \code{account}
+#'   column is populated on shinyapps.io only and is \code{NA} on Posit Connect
+#'   Cloud. On Posit Connect Cloud the data frame additionally includes
+#'   \code{display_name} and \code{role} (e.g. \code{"viewer"} or
+#'   \code{"collaborator"}) from the API response.
 #' @note This function works for ShinyApps and Posit Connect Cloud.
 #'
 #'   On Posit Connect Cloud, the content is resolved from the local deployment
@@ -341,7 +371,11 @@ showUsers <- function(
   application <- resolveContentTarget(accountDetails, appDir, appName)
 
   api <- clientForAccount(accountDetails)
-  showUsers_impl(api, application$id)
+  showUsers_impl(
+    api,
+    application$id,
+    isPCC = isPositConnectCloudServer(accountDetails$server)
+  )
 }
 
 #' List invited users for an application

--- a/R/auth.R
+++ b/R/auth.R
@@ -32,9 +32,11 @@ cleanupPasswordFile <- function(appDir) {
 #' Add authorized user to application
 #'
 #' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' Add authorized user to application
 #'
-#' Supported servers: ShinyApps servers
+#' Supported servers: ShinyApps, Posit Connect Cloud
 #'
 #' @param email Email address of user to add.
 #' @param appDir Directory containing application. Defaults to
@@ -47,7 +49,8 @@ cleanupPasswordFile <- function(appDir) {
 #'   custom message to send in email invitation. Defaults to NULL, which
 #'   will use default invitation message.
 #' @seealso [removeAuthorizedUser()] and [showUsers()]
-#' @note This function works only for ShinyApps servers.
+#' @note This function works for ShinyApps and Posit Connect Cloud. On Posit
+#'   Connect Cloud, the content's account must be an organization account.
 #' @export
 addAuthorizedUser <- function(
   email,
@@ -58,8 +61,18 @@ addAuthorizedUser <- function(
   sendEmail = NULL,
   emailMessage = NULL
 ) {
+  lifecycle::deprecate_warn(
+    "1.10.1.9000",
+    "addAuthorizedUser()",
+    details = paste0(
+      "Manage collaborators directly in Posit Connect Cloud at ",
+      "<https://connect.posit.cloud>."
+    )
+  )
   accountDetails <- accountInfo(account, server)
-  checkShinyappsServer(accountDetails$server)
+  if (!isPositConnectCloudServer(accountDetails$server)) {
+    checkShinyappsServer(accountDetails$server)
+  }
 
   # resolve application
   if (is.null(appName)) {
@@ -228,16 +241,21 @@ showUsers <- function(
 #' List invited users for an application
 #'
 #' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' List invited users for an application
 #'
-#' Supported servers: ShinyApps servers
+#' Supported servers: ShinyApps, Posit Connect Cloud
 #'
 #' @param appDir Directory containing application. Defaults to
 #'   current working directory.
 #' @param appName Name of application.
 #' @inheritParams deployApp
 #' @seealso [addAuthorizedUser()] and [showUsers()]
-#' @note This function works only for ShinyApps servers.
+#' @note This function works for ShinyApps and Posit Connect Cloud. On Posit
+#'   Connect Cloud, the \code{link} column is always \code{NA} because the
+#'   accept link is only emailed to the recipient and is never returned by
+#'   the API.
 #' @export
 showInvited <- function(
   appDir = getwd(),
@@ -245,8 +263,18 @@ showInvited <- function(
   account = NULL,
   server = NULL
 ) {
+  lifecycle::deprecate_warn(
+    "1.10.1.9000",
+    "showInvited()",
+    details = paste0(
+      "Manage collaborators directly in Posit Connect Cloud at ",
+      "<https://connect.posit.cloud>."
+    )
+  )
   accountDetails <- accountInfo(account, server)
-  checkShinyappsServer(accountDetails$server)
+  if (!isPositConnectCloudServer(accountDetails$server)) {
+    checkShinyappsServer(accountDetails$server)
+  }
 
   # resolve application
   if (is.null(appName)) {
@@ -258,28 +286,39 @@ showInvited <- function(
   api <- clientForAccount(accountDetails)
   res <- api$listApplicationInvitations(application$id)
 
-  # get interesting fields
-  users <- lapply(res, function(x) {
-    a <- list()
-    a$id <- x$id
-    a$email <- x$email
-    a$link <- x$link
-    a$expired <- x$expired
-    return(a)
+  # get interesting fields; PCC uses email_address / is_expired; shinyapps uses email / expired.
+  # Build rows as data.frames so rbind yields atomic columns (do.call(rbind, list_of_lists)
+  # produces list-matrix columns).
+  rows <- lapply(res, function(x) {
+    data.frame(
+      id      = as.character(x$id),
+      email   = as.character(x$email_address %||% x$email),
+      link    = as.character(x$link %||% NA_character_),
+      expired = as.logical(x$is_expired %||% x$expired),
+      stringsAsFactors = FALSE
+    )
   })
 
-  # convert to data frame
-  users <- do.call(rbind, users)
-  df <- as.data.frame(users, stringsAsFactors = FALSE)
-  return(df)
+  if (length(rows) == 0L) {
+    return(data.frame(
+      id      = character(),
+      email   = character(),
+      link    = character(),
+      expired = logical(),
+      stringsAsFactors = FALSE
+    ))
+  }
+  do.call(rbind, rows)
 }
 
 #' Resend invitation for invited users of an application
 #'
 #' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' Resend invitation for invited users of an application
 #'
-#' Supported servers: ShinyApps servers
+#' Supported servers: ShinyApps, Posit Connect Cloud
 #'
 #' @param invite The invitation to resend. Can be id or email address.
 #' @param regenerate Regenerate the invite code. Can be helpful is the
@@ -289,7 +328,9 @@ showInvited <- function(
 #' @param appName Name of application.
 #' @inheritParams deployApp
 #' @seealso [showInvited()]
-#' @note This function works only for ShinyApps servers.
+#' @note This function works for ShinyApps and Posit Connect Cloud. On Posit
+#'   Connect Cloud, look up the invitation by email address; the
+#'   \code{regenerate} argument has no effect.
 #' @export
 resendInvitation <- function(
   invite,
@@ -299,8 +340,18 @@ resendInvitation <- function(
   account = NULL,
   server = NULL
 ) {
+  lifecycle::deprecate_warn(
+    "1.10.1.9000",
+    "resendInvitation()",
+    details = paste0(
+      "Manage collaborators directly in Posit Connect Cloud at ",
+      "<https://connect.posit.cloud>."
+    )
+  )
   accountDetails <- accountInfo(account, server)
-  checkShinyappsServer(accountDetails$server)
+  if (!isPositConnectCloudServer(accountDetails$server)) {
+    checkShinyappsServer(accountDetails$server)
+  }
 
   # get invitations
   invited <- showInvited(appDir, appName, account, server)

--- a/R/auth.R
+++ b/R/auth.R
@@ -273,6 +273,13 @@ removeAuthorizedUser <- function(
     stop("User \"", user, "\" not found", call. = FALSE)
   }
 
+  if (is.na(user$id)) {
+    cli::cli_abort(c(
+      "Cannot remove user {.val {user$email}}: the matched record has no id.",
+      i = "This is unexpected; contact Posit support if this persists."
+    ))
+  }
+
   # remove user (api already built above)
   api$removeApplicationUser(application$id, user$id)
 
@@ -387,9 +394,14 @@ showInvited <- function(
 #' @param appName Name of application.
 #' @inheritParams deployApp
 #' @seealso [showInvited()]
-#' @note This function works for ShinyApps and Posit Connect Cloud. On Posit
-#'   Connect Cloud, look up the invitation by email address; the
-#'   \code{regenerate} argument has no effect.
+#' @note This function works for ShinyApps and Posit Connect Cloud. The
+#'   invitation can be selected by id or email address. On Posit Connect Cloud,
+#'   the \code{regenerate} argument has no effect.
+#'
+#'   On Posit Connect Cloud, the content is resolved from the local deployment
+#'   record in \code{appDir}; the call must run from the directory that contains
+#'   the \code{rsconnect/} deployment record. \code{appName} selects among
+#'   multiple records in the same directory.
 #' @export
 resendInvitation <- function(
   invite,
@@ -424,6 +436,13 @@ resendInvitation <- function(
     invite <- invited[invited$email == invite, ]
   } else {
     stop("Invitation for \"", invite, "\" not found", call. = FALSE)
+  }
+
+  if (is.na(invite$id)) {
+    cli::cli_abort(c(
+      "Cannot resend invitation for {.val {invite$email}}: the matched record has no id.",
+      i = "This is unexpected; contact Posit support if this persists."
+    ))
   }
 
   # resend invitation (api already built above)

--- a/R/auth.R
+++ b/R/auth.R
@@ -182,8 +182,10 @@ addAuthorizedUser <- function(
 
   application <- resolveContentTarget(accountDetails, appDir, appName)
 
-  # check for and remove password file
-  cleanupPasswordFile(appDir)
+  # check for and remove password file (shinyapps.io only; PCC has no password file)
+  if (!isPositConnectCloudServer(accountDetails$server)) {
+    cleanupPasswordFile(appDir)
+  }
 
   # PCC always emails invitees; warn only when caller explicitly opts out
   if (isPositConnectCloudServer(accountDetails$server) && identical(sendEmail, FALSE)) {
@@ -247,8 +249,10 @@ removeAuthorizedUser <- function(
 
   application <- resolveContentTarget(accountDetails, appDir, appName)
 
-  # check and remove password file
-  cleanupPasswordFile(appDir)
+  # check and remove password file (shinyapps.io only; PCC has no password file)
+  if (!isPositConnectCloudServer(accountDetails$server)) {
+    cleanupPasswordFile(appDir)
+  }
 
   # resolve content exactly once: use impl so showUsers() does not call
   # resolveContentTarget() a second time (a second interactive prompt could
@@ -258,20 +262,15 @@ removeAuthorizedUser <- function(
   api <- clientForAccount(accountDetails)
   users <- showUsers_impl(api, application$id)
 
-  if (is.numeric(user)) {
-    # lookup by id
-    if (user %in% users$id) {
-      user <- users[users$id == user, ]
-    } else {
-      stop("User ", user, " not found", call. = FALSE)
-    }
+  user <- as.character(user)
+  # Match id first (UUID strings on PCC, numeric-as-character on shinyapps.io),
+  # then fall back to email. The old is.numeric() branch missed PCC UUID ids.
+  if (user %in% users$id) {
+    user <- users[users$id == user, ]
+  } else if (user %in% users$email) {
+    user <- users[users$email == user, ]
   } else {
-    # lookup by email
-    if (user %in% users$email) {
-      user <- users[users$email == user, ]
-    } else {
-      stop("User \"", user, "\" not found", call. = FALSE)
-    }
+    stop("User \"", user, "\" not found", call. = FALSE)
   }
 
   # remove user (api already built above)
@@ -416,20 +415,15 @@ resendInvitation <- function(
   api <- clientForAccount(accountDetails)
   invited <- showInvited_impl(api, application$id)
 
-  if (is.numeric(invite)) {
-    # lookup by id
-    if (invite %in% invited$id) {
-      invite <- invited[invited$id == invite, ]
-    } else {
-      stop("Invitation \"", invite, "\" not found", call. = FALSE)
-    }
+  invite <- as.character(invite)
+  # Match id first (UUID strings on PCC, numeric-as-character on shinyapps.io),
+  # then fall back to email. The old is.numeric() branch missed PCC UUID ids.
+  if (invite %in% invited$id) {
+    invite <- invited[invited$id == invite, ]
+  } else if (invite %in% invited$email) {
+    invite <- invited[invited$email == invite, ]
   } else {
-    # lookup by email
-    if (invite %in% invited$email) {
-      invite <- invited[invited$email == invite, ]
-    } else {
-      stop("Invitation for \"", invite, "\" not found", call. = FALSE)
-    }
+    stop("Invitation for \"", invite, "\" not found", call. = FALSE)
   }
 
   # resend invitation (api already built above)

--- a/R/auth.R
+++ b/R/auth.R
@@ -27,9 +27,10 @@ showUsers_impl <- function(api, applicationId, isPCC = FALSE) {
     id <- as.character(x$user$id %||% NA_character_)
     email <- as.character(x$user$email %||% NA_character_)
     if (is.na(id) && is.na(email)) {
+      backend <- if (isPCC) "Posit Connect Cloud" else "shinyapps.io"
       cli::cli_abort(
         c(
-          "Unexpected response from Connect Cloud: a user record has neither an {.field id} nor an {.field email}.",
+          "Unexpected response from {backend}: a user record has neither an {.field id} nor an {.field email}.",
           i = "The response shape may have changed; contact Posit support if this persists."
         )
       )
@@ -191,9 +192,10 @@ resolveContentTarget <- function(accountDetails, appDir, appName) {
 #'   PCC always sends an invitation email.
 #'
 #'   On Posit Connect Cloud, the content is resolved from the local deployment
-#'   record in \code{appDir}; the call must run from the directory that contains
-#'   the \code{rsconnect/} deployment record. \code{appName} selects among
-#'   multiple records in the same directory.
+#'   record under \code{appDir}, which defaults to the working directory. Pass
+#'   \code{appDir} to point at the project directory that contains the
+#'   \code{rsconnect/} record. \code{appName} selects among multiple records in
+#'   the same directory.
 #' @export
 addAuthorizedUser <- function(
   email,
@@ -263,9 +265,10 @@ addAuthorizedUser <- function(
 #' @note This function works for ShinyApps and Posit Connect Cloud.
 #'
 #'   On Posit Connect Cloud, the content is resolved from the local deployment
-#'   record in \code{appDir}; the call must run from the directory that contains
-#'   the \code{rsconnect/} deployment record. \code{appName} selects among
-#'   multiple records in the same directory.
+#'   record under \code{appDir}, which defaults to the working directory. Pass
+#'   \code{appDir} to point at the project directory that contains the
+#'   \code{rsconnect/} record. \code{appName} selects among multiple records in
+#'   the same directory.
 #' @export
 removeAuthorizedUser <- function(
   user,
@@ -303,9 +306,9 @@ removeAuthorizedUser <- function(
   # Match id first (UUID strings on PCC, numeric-as-character on shinyapps.io),
   # then fall back to email. The old is.numeric() branch missed PCC UUID ids.
   if (user %in% users$id) {
-    user <- users[users$id == user, ]
+    user <- users[which(users$id == user), ]
   } else if (user %in% users$email) {
-    user <- users[users$email == user, ]
+    user <- users[which(users$email == user), ]
   } else {
     # Only PCC redacts emails, and the hint only helps someone who searched by
     # email (an id-based lookup already avoids the problem).
@@ -358,9 +361,10 @@ removeAuthorizedUser <- function(
 #' @note This function works for ShinyApps and Posit Connect Cloud.
 #'
 #'   On Posit Connect Cloud, the content is resolved from the local deployment
-#'   record in \code{appDir}; the call must run from the directory that contains
-#'   the \code{rsconnect/} deployment record. \code{appName} selects among
-#'   multiple records in the same directory.
+#'   record under \code{appDir}, which defaults to the working directory. Pass
+#'   \code{appDir} to point at the project directory that contains the
+#'   \code{rsconnect/} record. \code{appName} selects among multiple records in
+#'   the same directory.
 #' @export
 showUsers <- function(
   appDir = getwd(),
@@ -408,9 +412,10 @@ showUsers <- function(
 #'   the API.
 #'
 #'   On Posit Connect Cloud, the content is resolved from the local deployment
-#'   record in \code{appDir}; the call must run from the directory that contains
-#'   the \code{rsconnect/} deployment record. \code{appName} selects among
-#'   multiple records in the same directory.
+#'   record under \code{appDir}, which defaults to the working directory. Pass
+#'   \code{appDir} to point at the project directory that contains the
+#'   \code{rsconnect/} record. \code{appName} selects among multiple records in
+#'   the same directory.
 #' @export
 showInvited <- function(
   appDir = getwd(),
@@ -456,9 +461,10 @@ showInvited <- function(
 #'   the \code{regenerate} argument has no effect.
 #'
 #'   On Posit Connect Cloud, the content is resolved from the local deployment
-#'   record in \code{appDir}; the call must run from the directory that contains
-#'   the \code{rsconnect/} deployment record. \code{appName} selects among
-#'   multiple records in the same directory.
+#'   record under \code{appDir}, which defaults to the working directory. Pass
+#'   \code{appDir} to point at the project directory that contains the
+#'   \code{rsconnect/} record. \code{appName} selects among multiple records in
+#'   the same directory.
 #' @export
 resendInvitation <- function(
   invite,
@@ -488,9 +494,9 @@ resendInvitation <- function(
   # Match id first (UUID strings on PCC, numeric-as-character on shinyapps.io),
   # then fall back to email. The old is.numeric() branch missed PCC UUID ids.
   if (invite %in% invited$id) {
-    invite <- invited[invited$id == invite, ]
+    invite <- invited[which(invited$id == invite), ]
   } else if (invite %in% invited$email) {
-    invite <- invited[invited$email == invite, ]
+    invite <- invited[which(invited$email == invite), ]
   } else {
     stop("Invitation for \"", invite, "\" not found", call. = FALSE)
   }

--- a/R/auth.R
+++ b/R/auth.R
@@ -15,9 +15,19 @@ collaboratorDeprecationDetails <- function(server) {
 showUsers_impl <- function(api, applicationId) {
   res <- api$listApplicationAuthorization(applicationId)
   rows <- lapply(res, function(x) {
+    id    <- as.character(x$user$id    %||% NA_character_)
+    email <- as.character(x$user$email %||% NA_character_)
+    if (is.na(id) && is.na(email)) {
+      cli::cli_abort(
+        c(
+          "Unexpected response from Connect Cloud: a user record has neither an {.field id} nor an {.field email}.",
+          i = "The response shape may have changed; contact Posit support if this persists."
+        )
+      )
+    }
     data.frame(
-      id      = as.character(x$user$id %||% NA_character_),
-      email   = as.character(x$user$email %||% NA_character_),
+      id      = id,
+      email   = email,
       account = if (!is.null(x$account)) as.character(x$account) else NA_character_,
       stringsAsFactors = FALSE
     )

--- a/R/client-connectCloud.R
+++ b/R/client-connectCloud.R
@@ -22,6 +22,17 @@ connectCloudContentUrl <- function(getAccounts, accountId, contentId) {
   paste0(connectCloudUrls()$ui, "/", ownerAccount$name, "/content/", contentId)
 }
 
+# Standalone (served) content URL -- the link handed to app consumers, and the
+# value returned in the `url` column of `applications()`. Consistent with the
+# served URL that shinyapps.io and Posit Connect report. The canonical scheme is
+# <content-id>.share.<connect-cloud-host> (e.g.
+# https://abc-123.share.connect.posit.cloud/). Derived from the UI base so it
+# tracks the active environment (production/staging/development).
+connectCloudStandaloneUrl <- function(contentId) {
+  host <- sub("^https?://", "", connectCloudUrls()$ui)
+  paste0("https://", contentId, ".share.", host, "/")
+}
+
 # Map rsconnect appMode to Connect Cloud contentType
 cloudContentTypeFromAppMode <- function(appMode) {
   switch(

--- a/R/client-connectCloud.R
+++ b/R/client-connectCloud.R
@@ -449,6 +449,31 @@ connectCloudClient <- function(service, authInfo) {
       path <- paste0("/contents/", appId, "/users/", userId)
       withTokenRefreshRetry(DELETE, path)
       invisible(TRUE)
+    },
+
+    inviteApplicationUser = function(appId, email, sendEmail, emailMessage) {
+      path <- paste0("/contents/", appId, "/invitations")
+      json <- list(
+        message = emailMessage,
+        email_invitations = list(list(email_address = email)),
+        recipient_invitations = list()
+      )
+      withTokenRefreshRetry(POST_JSON, path, json)
+      invisible(TRUE)
+    },
+
+    listApplicationInvitations = function(appId) {
+      path <- paste0("/contents/", appId, "/invitations?accepted_time__isnull=true")
+      response <- withTokenRefreshRetry(GET, path)
+      response$data
+    },
+
+    resendApplicationInvitation = function(inviteId, regenerate) {
+      # regenerate is shinyapps.io-specific; PCC re-sends the existing invite email.
+      # Use setNames(list(), character(0)) to produce {} not [] at the wire level.
+      path <- paste0("/content_invitations/", inviteId, "/resend")
+      withTokenRefreshRetry(POST_JSON, path, setNames(list(), character(0)))
+      invisible(TRUE)
     }
   )
 }

--- a/R/client-connectCloud.R
+++ b/R/client-connectCloud.R
@@ -183,10 +183,12 @@ connectCloudClient <- function(service, authInfo) {
       offset <- 0
       allItems <- list()
       repeat {
+        # order_by gives the list a stable total order; without it offset-based
+        # paging can skip or duplicate rows across requests.
         path <- paste0(
           "/contents?account_id=",
           accountId,
-          "&include_total=true&limit=",
+          "&order_by=created_time&include_total=true&limit=",
           pageSize,
           "&offset=",
           offset
@@ -203,6 +205,12 @@ connectCloudClient <- function(service, authInfo) {
           break
         }
       }
+      # Drop content that has been soft-deleted but not yet hard-deleted: an
+      # account owner can still see it in the window before the cleanup job runs.
+      allItems <- Filter(
+        function(item) !identical(item$state, "deleted"),
+        allItems
+      )
       # Set name = title so resolveApplication (which matches on app$name) works for PCC.
       items <- lapply(allItems, function(item) {
         item$name <- item$title
@@ -474,11 +482,12 @@ connectCloudClient <- function(service, authInfo) {
       offset <- 0
       allItems <- list()
       repeat {
+        # order_by keeps offset-based paging stable (see listApplications).
         path <- paste0(
           "/contents/",
           appId,
           "/users",
-          "?include_total=true&limit=",
+          "?order_by=created_time&include_total=true&limit=",
           pageSize,
           "&offset=",
           offset
@@ -520,11 +529,12 @@ connectCloudClient <- function(service, authInfo) {
       offset <- 0
       allItems <- list()
       repeat {
+        # order_by keeps offset-based paging stable (see listApplications).
         path <- paste0(
           "/contents/",
           appId,
           "/invitations",
-          "?accepted_time__isnull=true&include_total=true&limit=",
+          "?accepted_time__isnull=true&order_by=created_time&include_total=true&limit=",
           pageSize,
           "&offset=",
           offset

--- a/R/client-connectCloud.R
+++ b/R/client-connectCloud.R
@@ -168,8 +168,24 @@ connectCloudClient <- function(service, authInfo) {
     withTokenRefreshRetry = withTokenRefreshRetry,
 
     listApplications = function(accountId, filters = list()) {
-      # TODO: call the real API when available (api doesn't support filtering by name yet)
-      return(list())
+      pageSize <- 100
+      offset <- 0
+      allItems <- list()
+      repeat {
+        path <- paste0(
+          "/contents?account_id=", accountId,
+          "&include_total=true&limit=", pageSize,
+          "&offset=", offset
+        )
+        response <- withTokenRefreshRetry(GET, path)
+        allItems <- c(allItems, response$data)
+        offset <- offset + length(response$data)
+        if (length(response$data) == 0 || isTRUE(offset >= as.numeric(response$total))) {
+          break
+        }
+      }
+      # Set name = title so resolveApplication (which matches on app$name) works for PCC.
+      lapply(allItems, function(item) { item$name <- item$title; item })
     },
 
     createContent = function(

--- a/R/client-connectCloud.R
+++ b/R/client-connectCloud.R
@@ -191,10 +191,10 @@ connectCloudClient <- function(service, authInfo) {
       items <- lapply(allItems, function(item) { item$name <- item$title; item })
       # Honor filters$name with exact-match semantics to match the shinyapps.io
       # client contract (listApplications callers may pass filters$name).
-      # NOTE: no current PCC deploy path reaches this block — deploy adoption is
-      # gated off in findDeploymentTargetByAppName, and resolveApplication lists
-      # without filters — but removing it would silently break the contract for
-      # any future caller that does pass filters$name.
+      # NOTE: getAppByName()/getLogs() historically reached this block; getLogs()
+      # is now guarded with checkShinyappsServer() so PCC callers never reach it.
+      # The block is kept for listApplications contract parity with shinyapps.io:
+      # removing it would silently break any future caller that passes filters$name.
       if (!is.null(filters$name)) {
         items <- Filter(function(item) identical(item$name, filters$name), items)
       }

--- a/R/client-connectCloud.R
+++ b/R/client-connectCloud.R
@@ -140,31 +140,41 @@ connectCloudClient <- function(service, authInfo) {
     content
   }
 
-  # Paginates through GET /accounts?has_user_role=true, accumulating every
-  # account the caller has a role on (not just the first page), since the
-  # content being migrated/published may belong to any of them.
-  getAccounts <- function() {
-    pageSize <- 100
+  # Accumulate every page of a paginated GET list endpoint. `buildPath(limit,
+  # offset)` returns the request path for a single page; it must include
+  # `include_total=true` and a stable `order_by` so offset paging can't skip or
+  # duplicate rows. Callers do any post-filtering on the returned list.
+  paginate <- function(buildPath, pageSize = 100) {
     offset <- 0
-    allAccounts <- list()
+    allItems <- list()
     repeat {
-      path <- paste0(
-        "/accounts?has_user_role=true&include_total=true&limit=",
-        pageSize,
-        "&offset=",
-        offset
-      )
-      response <- withTokenRefreshRetry(GET, path)
-      allAccounts <- c(allAccounts, response$data)
+      response <- withTokenRefreshRetry(GET, buildPath(pageSize, offset))
+      allItems <- c(allItems, response$data)
       offset <- offset + length(response$data)
+      total <- as.numeric(response$total)
       if (
         length(response$data) == 0 ||
-          isTRUE(offset >= as.numeric(response$total))
+          isTRUE(offset >= total) ||
+          (length(total) == 0L && length(response$data) < pageSize)
       ) {
         break
       }
     }
-    list(data = allAccounts)
+    allItems
+  }
+
+  # Accumulates every account the caller has a role on (not just the first
+  # page), since the content being migrated/published may belong to any of them.
+  getAccounts <- function() {
+    accounts <- paginate(function(limit, offset) {
+      paste0(
+        "/accounts?has_user_role=true&include_total=true&limit=",
+        limit,
+        "&offset=",
+        offset
+      )
+    })
+    list(data = accounts)
   }
 
   list(
@@ -179,32 +189,18 @@ connectCloudClient <- function(service, authInfo) {
     withTokenRefreshRetry = withTokenRefreshRetry,
 
     listApplications = function(accountId, filters = list()) {
-      pageSize <- 100
-      offset <- 0
-      allItems <- list()
-      repeat {
-        # order_by gives the list a stable total order; without it offset-based
-        # paging can skip or duplicate rows across requests.
-        path <- paste0(
+      # order_by gives the list a stable total order; without it offset-based
+      # paging can skip or duplicate rows across requests.
+      allItems <- paginate(function(limit, offset) {
+        paste0(
           "/contents?account_id=",
           accountId,
           "&order_by=created_time&include_total=true&limit=",
-          pageSize,
+          limit,
           "&offset=",
           offset
         )
-        response <- withTokenRefreshRetry(GET, path)
-        allItems <- c(allItems, response$data)
-        offset <- offset + length(response$data)
-        total <- as.numeric(response$total)
-        if (
-          length(response$data) == 0 ||
-            isTRUE(offset >= total) ||
-            (length(total) == 0L && length(response$data) < pageSize)
-        ) {
-          break
-        }
-      }
+      })
       # Drop content that has been soft-deleted but not yet hard-deleted: an
       # account owner can still see it in the window before the cleanup job runs.
       allItems <- Filter(
@@ -478,33 +474,17 @@ connectCloudClient <- function(service, authInfo) {
     getAccounts = getAccounts,
 
     listApplicationAuthorization = function(appId) {
-      pageSize <- 100
-      offset <- 0
-      allItems <- list()
-      repeat {
-        # order_by keeps offset-based paging stable (see listApplications).
-        path <- paste0(
+      # order_by keeps offset-based paging stable (see paginate()).
+      paginate(function(limit, offset) {
+        paste0(
           "/contents/",
           appId,
-          "/users",
-          "?order_by=created_time&include_total=true&limit=",
-          pageSize,
+          "/users?order_by=created_time&include_total=true&limit=",
+          limit,
           "&offset=",
           offset
         )
-        response <- withTokenRefreshRetry(GET, path)
-        allItems <- c(allItems, response$data)
-        offset <- offset + length(response$data)
-        total <- as.numeric(response$total)
-        if (
-          length(response$data) == 0 ||
-            isTRUE(offset >= total) ||
-            (length(total) == 0L && length(response$data) < pageSize)
-        ) {
-          break
-        }
-      }
-      allItems
+      })
     },
 
     removeApplicationUser = function(appId, userId) {
@@ -525,33 +505,17 @@ connectCloudClient <- function(service, authInfo) {
     },
 
     listApplicationInvitations = function(appId) {
-      pageSize <- 100
-      offset <- 0
-      allItems <- list()
-      repeat {
-        # order_by keeps offset-based paging stable (see listApplications).
-        path <- paste0(
+      # order_by keeps offset-based paging stable (see paginate()).
+      paginate(function(limit, offset) {
+        paste0(
           "/contents/",
           appId,
-          "/invitations",
-          "?accepted_time__isnull=true&order_by=created_time&include_total=true&limit=",
-          pageSize,
+          "/invitations?accepted_time__isnull=true&order_by=created_time&include_total=true&limit=",
+          limit,
           "&offset=",
           offset
         )
-        response <- withTokenRefreshRetry(GET, path)
-        allItems <- c(allItems, response$data)
-        offset <- offset + length(response$data)
-        total <- as.numeric(response$total)
-        if (
-          length(response$data) == 0 ||
-            isTRUE(offset >= total) ||
-            (length(total) == 0L && length(response$data) < pageSize)
-        ) {
-          break
-        }
-      }
-      allItems
+      })
     },
 
     resendApplicationInvitation = function(inviteId, regenerate) {

--- a/R/client-connectCloud.R
+++ b/R/client-connectCloud.R
@@ -437,6 +437,18 @@ connectCloudClient <- function(service, authInfo) {
 
     getAuthorization = getAuthorization,
 
-    getAccounts = getAccounts
+    getAccounts = getAccounts,
+
+    listApplicationAuthorization = function(appId) {
+      path <- paste0("/contents/", appId, "/users")
+      response <- withTokenRefreshRetry(GET, path)
+      response$data
+    },
+
+    removeApplicationUser = function(appId, userId) {
+      path <- paste0("/contents/", appId, "/users/", userId)
+      withTokenRefreshRetry(DELETE, path)
+      invisible(TRUE)
+    }
   )
 }

--- a/R/client-connectCloud.R
+++ b/R/client-connectCloud.R
@@ -185,7 +185,12 @@ connectCloudClient <- function(service, authInfo) {
         }
       }
       # Set name = title so resolveApplication (which matches on app$name) works for PCC.
-      lapply(allItems, function(item) { item$name <- item$title; item })
+      items <- lapply(allItems, function(item) { item$name <- item$title; item })
+      # Honor filters$name with exact-match semantics (mirrors shinyapps.io contract).
+      if (!is.null(filters$name)) {
+        items <- Filter(function(item) identical(item$name, filters$name), items)
+      }
+      items
     },
 
     createContent = function(

--- a/R/client-connectCloud.R
+++ b/R/client-connectCloud.R
@@ -153,7 +153,7 @@ connectCloudClient <- function(service, authInfo) {
       offset <- offset + length(response$data)
       total <- as.numeric(response$total)
       if (
-        length(response$data) == 0 ||
+        length(response$data) == 0L ||
           isTRUE(offset >= total) ||
           (length(total) == 0L && length(response$data) < pageSize)
       ) {

--- a/R/client-connectCloud.R
+++ b/R/client-connectCloud.R
@@ -180,7 +180,10 @@ connectCloudClient <- function(service, authInfo) {
         response <- withTokenRefreshRetry(GET, path)
         allItems <- c(allItems, response$data)
         offset <- offset + length(response$data)
-        if (length(response$data) == 0 || isTRUE(offset >= as.numeric(response$total))) {
+        total <- as.numeric(response$total)
+        if (length(response$data) == 0 ||
+            isTRUE(offset >= total) ||
+            (length(total) == 0L && length(response$data) < pageSize)) {
           break
         }
       }

--- a/R/client-connectCloud.R
+++ b/R/client-connectCloud.R
@@ -189,7 +189,12 @@ connectCloudClient <- function(service, authInfo) {
       }
       # Set name = title so resolveApplication (which matches on app$name) works for PCC.
       items <- lapply(allItems, function(item) { item$name <- item$title; item })
-      # Honor filters$name with exact-match semantics (mirrors shinyapps.io contract).
+      # Honor filters$name with exact-match semantics to match the shinyapps.io
+      # client contract (listApplications callers may pass filters$name).
+      # NOTE: no current PCC deploy path reaches this block — deploy adoption is
+      # gated off in findDeploymentTargetByAppName, and resolveApplication lists
+      # without filters — but removing it would silently break the contract for
+      # any future caller that does pass filters$name.
       if (!is.null(filters$name)) {
         items <- Filter(function(item) identical(item$name, filters$name), items)
       }

--- a/R/client-connectCloud.R
+++ b/R/client-connectCloud.R
@@ -448,9 +448,26 @@ connectCloudClient <- function(service, authInfo) {
     getAccounts = getAccounts,
 
     listApplicationAuthorization = function(appId) {
-      path <- paste0("/contents/", appId, "/users")
-      response <- withTokenRefreshRetry(GET, path)
-      response$data
+      pageSize <- 100
+      offset <- 0
+      allItems <- list()
+      repeat {
+        path <- paste0(
+          "/contents/", appId, "/users",
+          "?include_total=true&limit=", pageSize,
+          "&offset=", offset
+        )
+        response <- withTokenRefreshRetry(GET, path)
+        allItems <- c(allItems, response$data)
+        offset <- offset + length(response$data)
+        total <- as.numeric(response$total)
+        if (length(response$data) == 0 ||
+            isTRUE(offset >= total) ||
+            (length(total) == 0L && length(response$data) < pageSize)) {
+          break
+        }
+      }
+      allItems
     },
 
     removeApplicationUser = function(appId, userId) {
@@ -471,9 +488,26 @@ connectCloudClient <- function(service, authInfo) {
     },
 
     listApplicationInvitations = function(appId) {
-      path <- paste0("/contents/", appId, "/invitations?accepted_time__isnull=true")
-      response <- withTokenRefreshRetry(GET, path)
-      response$data
+      pageSize <- 100
+      offset <- 0
+      allItems <- list()
+      repeat {
+        path <- paste0(
+          "/contents/", appId, "/invitations",
+          "?accepted_time__isnull=true&include_total=true&limit=", pageSize,
+          "&offset=", offset
+        )
+        response <- withTokenRefreshRetry(GET, path)
+        allItems <- c(allItems, response$data)
+        offset <- offset + length(response$data)
+        total <- as.numeric(response$total)
+        if (length(response$data) == 0 ||
+            isTRUE(offset >= total) ||
+            (length(total) == 0L && length(response$data) < pageSize)) {
+          break
+        }
+      }
+      allItems
     },
 
     resendApplicationInvitation = function(inviteId, regenerate) {

--- a/R/client-connectCloud.R
+++ b/R/client-connectCloud.R
@@ -173,22 +173,30 @@ connectCloudClient <- function(service, authInfo) {
       allItems <- list()
       repeat {
         path <- paste0(
-          "/contents?account_id=", accountId,
-          "&include_total=true&limit=", pageSize,
-          "&offset=", offset
+          "/contents?account_id=",
+          accountId,
+          "&include_total=true&limit=",
+          pageSize,
+          "&offset=",
+          offset
         )
         response <- withTokenRefreshRetry(GET, path)
         allItems <- c(allItems, response$data)
         offset <- offset + length(response$data)
         total <- as.numeric(response$total)
-        if (length(response$data) == 0 ||
+        if (
+          length(response$data) == 0 ||
             isTRUE(offset >= total) ||
-            (length(total) == 0L && length(response$data) < pageSize)) {
+            (length(total) == 0L && length(response$data) < pageSize)
+        ) {
           break
         }
       }
       # Set name = title so resolveApplication (which matches on app$name) works for PCC.
-      items <- lapply(allItems, function(item) { item$name <- item$title; item })
+      items <- lapply(allItems, function(item) {
+        item$name <- item$title
+        item
+      })
       # Honor filters$name with exact-match semantics to match the shinyapps.io
       # client contract (listApplications callers may pass filters$name).
       # NOTE: getAppByName()/getLogs() historically reached this block; getLogs()
@@ -196,7 +204,10 @@ connectCloudClient <- function(service, authInfo) {
       # The block is kept for listApplications contract parity with shinyapps.io:
       # removing it would silently break any future caller that passes filters$name.
       if (!is.null(filters$name)) {
-        items <- Filter(function(item) identical(item$name, filters$name), items)
+        items <- Filter(
+          function(item) identical(item$name, filters$name),
+          items
+        )
       }
       items
     },
@@ -453,17 +464,23 @@ connectCloudClient <- function(service, authInfo) {
       allItems <- list()
       repeat {
         path <- paste0(
-          "/contents/", appId, "/users",
-          "?include_total=true&limit=", pageSize,
-          "&offset=", offset
+          "/contents/",
+          appId,
+          "/users",
+          "?include_total=true&limit=",
+          pageSize,
+          "&offset=",
+          offset
         )
         response <- withTokenRefreshRetry(GET, path)
         allItems <- c(allItems, response$data)
         offset <- offset + length(response$data)
         total <- as.numeric(response$total)
-        if (length(response$data) == 0 ||
+        if (
+          length(response$data) == 0 ||
             isTRUE(offset >= total) ||
-            (length(total) == 0L && length(response$data) < pageSize)) {
+            (length(total) == 0L && length(response$data) < pageSize)
+        ) {
           break
         }
       }
@@ -493,17 +510,23 @@ connectCloudClient <- function(service, authInfo) {
       allItems <- list()
       repeat {
         path <- paste0(
-          "/contents/", appId, "/invitations",
-          "?accepted_time__isnull=true&include_total=true&limit=", pageSize,
-          "&offset=", offset
+          "/contents/",
+          appId,
+          "/invitations",
+          "?accepted_time__isnull=true&include_total=true&limit=",
+          pageSize,
+          "&offset=",
+          offset
         )
         response <- withTokenRefreshRetry(GET, path)
         allItems <- c(allItems, response$data)
         offset <- offset + length(response$data)
         total <- as.numeric(response$total)
-        if (length(response$data) == 0 ||
+        if (
+          length(response$data) == 0 ||
             isTRUE(offset >= total) ||
-            (length(total) == 0L && length(response$data) < pageSize)) {
+            (length(total) == 0L && length(response$data) < pageSize)
+        ) {
           break
         }
       }

--- a/R/deploymentTarget.R
+++ b/R/deploymentTarget.R
@@ -249,32 +249,34 @@ findDeploymentTargetByAppName <- function(
   # server. That content is conditionally used. A resolved account is
   # required.
   accountDetails <- findAccountInfo(account, server, error_call = error_call)
-  client <- clientForAccount(accountDetails)
-  application <- tryCatch(
-    getAppByName(client, accountDetails, appName, error_call = error_call),
-    rsconnect_app_not_found = function(err) NULL
-  )
-  if (!is.null(application)) {
-    uniqueName <- findUnique(appName, application$name)
-    if (
-      shouldUpdateApp(
-        application,
-        uniqueName,
-        forceUpdate,
-        error_call = error_call
-      )
-    ) {
-      deployment <- createDeploymentFromApplication(
-        application,
-        accountDetails
-      )
-      deployment <- updateDeployment(deployment, appTitle, envVars)
-      return(list(
-        accountDetails = accountDetails,
-        deployment = deployment
-      ))
-    } else {
-      appName <- uniqueName
+  if (!isPositConnectCloudServer(accountDetails$server)) {
+    client <- clientForAccount(accountDetails)
+    application <- tryCatch(
+      getAppByName(client, accountDetails, appName, error_call = error_call),
+      rsconnect_app_not_found = function(err) NULL
+    )
+    if (!is.null(application)) {
+      uniqueName <- findUnique(appName, application$name)
+      if (
+        shouldUpdateApp(
+          application,
+          uniqueName,
+          forceUpdate,
+          error_call = error_call
+        )
+      ) {
+        deployment <- createDeploymentFromApplication(
+          application,
+          accountDetails
+        )
+        deployment <- updateDeployment(deployment, appTitle, envVars)
+        return(list(
+          accountDetails = accountDetails,
+          deployment = deployment
+        ))
+      } else {
+        appName <- uniqueName
+      }
     }
   }
 

--- a/man/addAuthorizedUser.Rd
+++ b/man/addAuthorizedUser.Rd
@@ -36,12 +36,17 @@ custom message to send in email invitation. Defaults to NULL, which
 will use default invitation message.}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
 Add authorized user to application
 
-Supported servers: ShinyApps servers
+Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{
-This function works only for ShinyApps servers.
+This function works for ShinyApps and Posit Connect Cloud. On Posit
+Connect Cloud, the content's account must be an organization account.
+The \code{sendEmail} argument is ignored on Posit Connect Cloud;
+PCC always sends an invitation email.
 }
 \seealso{
 \code{\link[=removeAuthorizedUser]{removeAuthorizedUser()}} and \code{\link[=showUsers]{showUsers()}}

--- a/man/addAuthorizedUser.Rd
+++ b/man/addAuthorizedUser.Rd
@@ -36,6 +36,8 @@ custom message to send in email invitation. Defaults to NULL, which
 will use default invitation message.}
 }
 \description{
+Add authorized user to application
+
 Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{
@@ -47,7 +49,7 @@ PCC always sends an invitation email.
 On Posit Connect Cloud, the content is resolved from the local deployment
 record under \code{appDir}, which defaults to the working directory. Pass
 \code{appDir} to point at the project directory that contains the
-\code{rsconnect/} record. \code{appName} selects among multiple records in
+\code{rsconnect/} deployment record. \code{appName} selects among multiple records in
 the same directory.
 }
 \seealso{

--- a/man/addAuthorizedUser.Rd
+++ b/man/addAuthorizedUser.Rd
@@ -36,10 +36,6 @@ custom message to send in email invitation. Defaults to NULL, which
 will use default invitation message.}
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
-
-Add authorized user to application
-
 Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{

--- a/man/addAuthorizedUser.Rd
+++ b/man/addAuthorizedUser.Rd
@@ -49,9 +49,10 @@ The \code{sendEmail} argument is ignored on Posit Connect Cloud;
 PCC always sends an invitation email.
 
 On Posit Connect Cloud, the content is resolved from the local deployment
-record in \code{appDir}; the call must run from the directory that contains
-the \code{rsconnect/} deployment record. \code{appName} selects among
-multiple records in the same directory.
+record under \code{appDir}, which defaults to the working directory. Pass
+\code{appDir} to point at the project directory that contains the
+\code{rsconnect/} record. \code{appName} selects among multiple records in
+the same directory.
 }
 \seealso{
 \code{\link[=removeAuthorizedUser]{removeAuthorizedUser()}} and \code{\link[=showUsers]{showUsers()}}

--- a/man/addAuthorizedUser.Rd
+++ b/man/addAuthorizedUser.Rd
@@ -8,6 +8,7 @@ addAuthorizedUser(
   email,
   appDir = getwd(),
   appName = NULL,
+  contentId = NULL,
   account = NULL,
   server = NULL,
   sendEmail = NULL,
@@ -21,6 +22,12 @@ addAuthorizedUser(
 current working directory.}
 
 \item{appName}{Name of application.}
+
+\item{contentId}{On Posit Connect Cloud, the content ID to manage, taken from
+the content URL
+(\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+supplied, \code{appDir} and \code{appName} are ignored and no local
+deployment record is required. Not supported on shinyapps.io.}
 
 \item{account, server}{Uniquely identify a remote server with either your
 user \code{account}, the \code{server} name, or both. If neither are supplied, and
@@ -50,7 +57,8 @@ On Posit Connect Cloud, the content is resolved from the local deployment
 record under \code{appDir}, which defaults to the working directory. Pass
 \code{appDir} to point at the project directory that contains the
 \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-the same directory.
+the same directory. Alternatively, pass \code{contentId} to target the
+content directly, without a local deployment record.
 }
 \seealso{
 \code{\link[=removeAuthorizedUser]{removeAuthorizedUser()}} and \code{\link[=showUsers]{showUsers()}}

--- a/man/addAuthorizedUser.Rd
+++ b/man/addAuthorizedUser.Rd
@@ -47,6 +47,11 @@ This function works for ShinyApps and Posit Connect Cloud. On Posit
 Connect Cloud, the content's account must be an organization account.
 The \code{sendEmail} argument is ignored on Posit Connect Cloud;
 PCC always sends an invitation email.
+
+On Posit Connect Cloud, the content is resolved from the local deployment
+record in \code{appDir}; the call must run from the directory that contains
+the \code{rsconnect/} deployment record. \code{appName} selects among
+multiple records in the same directory.
 }
 \seealso{
 \code{\link[=removeAuthorizedUser]{removeAuthorizedUser()}} and \code{\link[=showUsers]{showUsers()}}

--- a/man/removeAuthorizedUser.Rd
+++ b/man/removeAuthorizedUser.Rd
@@ -27,6 +27,8 @@ there are multiple options, you'll be prompted to pick one.
 Use \code{\link[=accounts]{accounts()}} to see the full list of available options.}
 }
 \description{
+Remove authorized user from an application
+
 Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{
@@ -35,7 +37,7 @@ This function works for ShinyApps and Posit Connect Cloud.
 On Posit Connect Cloud, the content is resolved from the local deployment
 record under \code{appDir}, which defaults to the working directory. Pass
 \code{appDir} to point at the project directory that contains the
-\code{rsconnect/} record. \code{appName} selects among multiple records in
+\code{rsconnect/} deployment record. \code{appName} selects among multiple records in
 the same directory.
 }
 \seealso{

--- a/man/removeAuthorizedUser.Rd
+++ b/man/removeAuthorizedUser.Rd
@@ -27,10 +27,6 @@ there are multiple options, you'll be prompted to pick one.
 Use \code{\link[=accounts]{accounts()}} to see the full list of available options.}
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
-
-Remove authorized user from an application
-
 Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{

--- a/man/removeAuthorizedUser.Rd
+++ b/man/removeAuthorizedUser.Rd
@@ -35,6 +35,11 @@ Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{
 This function works for ShinyApps and Posit Connect Cloud.
+
+On Posit Connect Cloud, the content is resolved from the local deployment
+record in \code{appDir}; the call must run from the directory that contains
+the \code{rsconnect/} deployment record. \code{appName} selects among
+multiple records in the same directory.
 }
 \seealso{
 \code{\link[=addAuthorizedUser]{addAuthorizedUser()}} and \code{\link[=showUsers]{showUsers()}}

--- a/man/removeAuthorizedUser.Rd
+++ b/man/removeAuthorizedUser.Rd
@@ -27,12 +27,14 @@ there are multiple options, you'll be prompted to pick one.
 Use \code{\link[=accounts]{accounts()}} to see the full list of available options.}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
 Remove authorized user from an application
 
-Supported servers: ShinyApps servers
+Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{
-This function works only for ShinyApps servers.
+This function works for ShinyApps and Posit Connect Cloud.
 }
 \seealso{
 \code{\link[=addAuthorizedUser]{addAuthorizedUser()}} and \code{\link[=showUsers]{showUsers()}}

--- a/man/removeAuthorizedUser.Rd
+++ b/man/removeAuthorizedUser.Rd
@@ -8,6 +8,7 @@ removeAuthorizedUser(
   user,
   appDir = getwd(),
   appName = NULL,
+  contentId = NULL,
   account = NULL,
   server = NULL
 )
@@ -19,6 +20,12 @@ removeAuthorizedUser(
 current working directory.}
 
 \item{appName}{Name of application.}
+
+\item{contentId}{On Posit Connect Cloud, the content ID to manage, taken from
+the content URL
+(\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+supplied, \code{appDir} and \code{appName} are ignored and no local
+deployment record is required. Not supported on shinyapps.io.}
 
 \item{account, server}{Uniquely identify a remote server with either your
 user \code{account}, the \code{server} name, or both. If neither are supplied, and
@@ -38,7 +45,8 @@ On Posit Connect Cloud, the content is resolved from the local deployment
 record under \code{appDir}, which defaults to the working directory. Pass
 \code{appDir} to point at the project directory that contains the
 \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-the same directory.
+the same directory. Alternatively, pass \code{contentId} to target the
+content directly, without a local deployment record.
 }
 \seealso{
 \code{\link[=addAuthorizedUser]{addAuthorizedUser()}} and \code{\link[=showUsers]{showUsers()}}

--- a/man/removeAuthorizedUser.Rd
+++ b/man/removeAuthorizedUser.Rd
@@ -37,9 +37,10 @@ Supported servers: ShinyApps, Posit Connect Cloud
 This function works for ShinyApps and Posit Connect Cloud.
 
 On Posit Connect Cloud, the content is resolved from the local deployment
-record in \code{appDir}; the call must run from the directory that contains
-the \code{rsconnect/} deployment record. \code{appName} selects among
-multiple records in the same directory.
+record under \code{appDir}, which defaults to the working directory. Pass
+\code{appDir} to point at the project directory that contains the
+\code{rsconnect/} record. \code{appName} selects among multiple records in
+the same directory.
 }
 \seealso{
 \code{\link[=addAuthorizedUser]{addAuthorizedUser()}} and \code{\link[=showUsers]{showUsers()}}

--- a/man/resendInvitation.Rd
+++ b/man/resendInvitation.Rd
@@ -43,9 +43,10 @@ invitation can be selected by id or email address. On Posit Connect Cloud,
 the \code{regenerate} argument has no effect.
 
 On Posit Connect Cloud, the content is resolved from the local deployment
-record in \code{appDir}; the call must run from the directory that contains
-the \code{rsconnect/} deployment record. \code{appName} selects among
-multiple records in the same directory.
+record under \code{appDir}, which defaults to the working directory. Pass
+\code{appDir} to point at the project directory that contains the
+\code{rsconnect/} record. \code{appName} selects among multiple records in
+the same directory.
 }
 \seealso{
 \code{\link[=showInvited]{showInvited()}}

--- a/man/resendInvitation.Rd
+++ b/man/resendInvitation.Rd
@@ -9,6 +9,7 @@ resendInvitation(
   regenerate = FALSE,
   appDir = getwd(),
   appName = NULL,
+  contentId = NULL,
   account = NULL,
   server = NULL
 )
@@ -23,6 +24,12 @@ invitation has expired.}
 current working directory.}
 
 \item{appName}{Name of application.}
+
+\item{contentId}{On Posit Connect Cloud, the content ID to manage, taken from
+the content URL
+(\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+supplied, \code{appDir} and \code{appName} are ignored and no local
+deployment record is required. Not supported on shinyapps.io.}
 
 \item{account, server}{Uniquely identify a remote server with either your
 user \code{account}, the \code{server} name, or both. If neither are supplied, and
@@ -44,7 +51,8 @@ On Posit Connect Cloud, the content is resolved from the local deployment
 record under \code{appDir}, which defaults to the working directory. Pass
 \code{appDir} to point at the project directory that contains the
 \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-the same directory.
+the same directory. Alternatively, pass \code{contentId} to target the
+content directly, without a local deployment record.
 }
 \seealso{
 \code{\link[=showInvited]{showInvited()}}

--- a/man/resendInvitation.Rd
+++ b/man/resendInvitation.Rd
@@ -31,6 +31,8 @@ there are multiple options, you'll be prompted to pick one.
 Use \code{\link[=accounts]{accounts()}} to see the full list of available options.}
 }
 \description{
+Resend invitation for invited users of an application
+
 Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{
@@ -41,7 +43,7 @@ the \code{regenerate} argument has no effect.
 On Posit Connect Cloud, the content is resolved from the local deployment
 record under \code{appDir}, which defaults to the working directory. Pass
 \code{appDir} to point at the project directory that contains the
-\code{rsconnect/} record. \code{appName} selects among multiple records in
+\code{rsconnect/} deployment record. \code{appName} selects among multiple records in
 the same directory.
 }
 \seealso{

--- a/man/resendInvitation.Rd
+++ b/man/resendInvitation.Rd
@@ -38,9 +38,14 @@ Resend invitation for invited users of an application
 Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{
-This function works for ShinyApps and Posit Connect Cloud. On Posit
-Connect Cloud, look up the invitation by email address; the
-\code{regenerate} argument has no effect.
+This function works for ShinyApps and Posit Connect Cloud. The
+invitation can be selected by id or email address. On Posit Connect Cloud,
+the \code{regenerate} argument has no effect.
+
+On Posit Connect Cloud, the content is resolved from the local deployment
+record in \code{appDir}; the call must run from the directory that contains
+the \code{rsconnect/} deployment record. \code{appName} selects among
+multiple records in the same directory.
 }
 \seealso{
 \code{\link[=showInvited]{showInvited()}}

--- a/man/resendInvitation.Rd
+++ b/man/resendInvitation.Rd
@@ -31,10 +31,6 @@ there are multiple options, you'll be prompted to pick one.
 Use \code{\link[=accounts]{accounts()}} to see the full list of available options.}
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
-
-Resend invitation for invited users of an application
-
 Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{

--- a/man/resendInvitation.Rd
+++ b/man/resendInvitation.Rd
@@ -31,12 +31,16 @@ there are multiple options, you'll be prompted to pick one.
 Use \code{\link[=accounts]{accounts()}} to see the full list of available options.}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
 Resend invitation for invited users of an application
 
-Supported servers: ShinyApps servers
+Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{
-This function works only for ShinyApps servers.
+This function works for ShinyApps and Posit Connect Cloud. On Posit
+Connect Cloud, look up the invitation by email address; the
+\code{regenerate} argument has no effect.
 }
 \seealso{
 \code{\link[=showInvited]{showInvited()}}

--- a/man/showInvited.Rd
+++ b/man/showInvited.Rd
@@ -30,6 +30,11 @@ This function works for ShinyApps and Posit Connect Cloud. On Posit
 Connect Cloud, the \code{link} column is always \code{NA} because the
 accept link is only emailed to the recipient and is never returned by
 the API.
+
+On Posit Connect Cloud, the content is resolved from the local deployment
+record in \code{appDir}; the call must run from the directory that contains
+the \code{rsconnect/} deployment record. \code{appName} selects among
+multiple records in the same directory.
 }
 \seealso{
 \code{\link[=addAuthorizedUser]{addAuthorizedUser()}} and \code{\link[=showUsers]{showUsers()}}

--- a/man/showInvited.Rd
+++ b/man/showInvited.Rd
@@ -19,12 +19,17 @@ there are multiple options, you'll be prompted to pick one.
 Use \code{\link[=accounts]{accounts()}} to see the full list of available options.}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
 List invited users for an application
 
-Supported servers: ShinyApps servers
+Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{
-This function works only for ShinyApps servers.
+This function works for ShinyApps and Posit Connect Cloud. On Posit
+Connect Cloud, the \code{link} column is always \code{NA} because the
+accept link is only emailed to the recipient and is never returned by
+the API.
 }
 \seealso{
 \code{\link[=addAuthorizedUser]{addAuthorizedUser()}} and \code{\link[=showUsers]{showUsers()}}

--- a/man/showInvited.Rd
+++ b/man/showInvited.Rd
@@ -19,10 +19,6 @@ there are multiple options, you'll be prompted to pick one.
 Use \code{\link[=accounts]{accounts()}} to see the full list of available options.}
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
-
-List invited users for an application
-
 Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{

--- a/man/showInvited.Rd
+++ b/man/showInvited.Rd
@@ -19,6 +19,8 @@ there are multiple options, you'll be prompted to pick one.
 Use \code{\link[=accounts]{accounts()}} to see the full list of available options.}
 }
 \description{
+List invited users for an application
+
 Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{
@@ -30,7 +32,7 @@ the API.
 On Posit Connect Cloud, the content is resolved from the local deployment
 record under \code{appDir}, which defaults to the working directory. Pass
 \code{appDir} to point at the project directory that contains the
-\code{rsconnect/} record. \code{appName} selects among multiple records in
+\code{rsconnect/} deployment record. \code{appName} selects among multiple records in
 the same directory.
 }
 \seealso{

--- a/man/showInvited.Rd
+++ b/man/showInvited.Rd
@@ -32,9 +32,10 @@ accept link is only emailed to the recipient and is never returned by
 the API.
 
 On Posit Connect Cloud, the content is resolved from the local deployment
-record in \code{appDir}; the call must run from the directory that contains
-the \code{rsconnect/} deployment record. \code{appName} selects among
-multiple records in the same directory.
+record under \code{appDir}, which defaults to the working directory. Pass
+\code{appDir} to point at the project directory that contains the
+\code{rsconnect/} record. \code{appName} selects among multiple records in
+the same directory.
 }
 \seealso{
 \code{\link[=addAuthorizedUser]{addAuthorizedUser()}} and \code{\link[=showUsers]{showUsers()}}

--- a/man/showInvited.Rd
+++ b/man/showInvited.Rd
@@ -4,13 +4,25 @@
 \alias{showInvited}
 \title{List invited users for an application}
 \usage{
-showInvited(appDir = getwd(), appName = NULL, account = NULL, server = NULL)
+showInvited(
+  appDir = getwd(),
+  appName = NULL,
+  contentId = NULL,
+  account = NULL,
+  server = NULL
+)
 }
 \arguments{
 \item{appDir}{Directory containing application. Defaults to
 current working directory.}
 
 \item{appName}{Name of application.}
+
+\item{contentId}{On Posit Connect Cloud, the content ID to manage, taken from
+the content URL
+(\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+supplied, \code{appDir} and \code{appName} are ignored and no local
+deployment record is required. Not supported on shinyapps.io.}
 
 \item{account, server}{Uniquely identify a remote server with either your
 user \code{account}, the \code{server} name, or both. If neither are supplied, and
@@ -33,7 +45,8 @@ On Posit Connect Cloud, the content is resolved from the local deployment
 record under \code{appDir}, which defaults to the working directory. Pass
 \code{appDir} to point at the project directory that contains the
 \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-the same directory.
+the same directory. Alternatively, pass \code{contentId} to target the
+content directly, without a local deployment record.
 }
 \seealso{
 \code{\link[=addAuthorizedUser]{addAuthorizedUser()}} and \code{\link[=showUsers]{showUsers()}}

--- a/man/showUsers.Rd
+++ b/man/showUsers.Rd
@@ -4,13 +4,25 @@
 \alias{showUsers}
 \title{List authorized users for an application}
 \usage{
-showUsers(appDir = getwd(), appName = NULL, account = NULL, server = NULL)
+showUsers(
+  appDir = getwd(),
+  appName = NULL,
+  contentId = NULL,
+  account = NULL,
+  server = NULL
+)
 }
 \arguments{
 \item{appDir}{Directory containing application. Defaults to
 current working directory.}
 
 \item{appName}{Name of application.}
+
+\item{contentId}{On Posit Connect Cloud, the content ID to manage, taken from
+the content URL
+(\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+supplied, \code{appDir} and \code{appName} are ignored and no local
+deployment record is required. Not supported on shinyapps.io.}
 
 \item{account, server}{Uniquely identify a remote server with either your
 user \code{account}, the \code{server} name, or both. If neither are supplied, and
@@ -38,7 +50,8 @@ On Posit Connect Cloud, the content is resolved from the local deployment
 record under \code{appDir}, which defaults to the working directory. Pass
 \code{appDir} to point at the project directory that contains the
 \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-the same directory.
+the same directory. Alternatively, pass \code{contentId} to target the
+content directly, without a local deployment record.
 }
 \seealso{
 \code{\link[=addAuthorizedUser]{addAuthorizedUser()}} and \code{\link[=showInvited]{showInvited()}}

--- a/man/showUsers.Rd
+++ b/man/showUsers.Rd
@@ -27,10 +27,6 @@ Cloud. On Posit Connect Cloud the data frame additionally includes
 \code{"collaborator"}) from the API response.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
-
-List authorized users for an application
-
 Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{

--- a/man/showUsers.Rd
+++ b/man/showUsers.Rd
@@ -19,12 +19,14 @@ there are multiple options, you'll be prompted to pick one.
 Use \code{\link[=accounts]{accounts()}} to see the full list of available options.}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
 List authorized users for an application
 
-Supported servers: ShinyApps servers
+Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{
-This function works only for ShinyApps servers.
+This function works for ShinyApps and Posit Connect Cloud.
 }
 \seealso{
 \code{\link[=addAuthorizedUser]{addAuthorizedUser()}} and \code{\link[=showInvited]{showInvited()}}

--- a/man/showUsers.Rd
+++ b/man/showUsers.Rd
@@ -37,9 +37,10 @@ Supported servers: ShinyApps, Posit Connect Cloud
 This function works for ShinyApps and Posit Connect Cloud.
 
 On Posit Connect Cloud, the content is resolved from the local deployment
-record in \code{appDir}; the call must run from the directory that contains
-the \code{rsconnect/} deployment record. \code{appName} selects among
-multiple records in the same directory.
+record under \code{appDir}, which defaults to the working directory. Pass
+\code{appDir} to point at the project directory that contains the
+\code{rsconnect/} record. \code{appName} selects among multiple records in
+the same directory.
 }
 \seealso{
 \code{\link[=addAuthorizedUser]{addAuthorizedUser()}} and \code{\link[=showInvited]{showInvited()}}

--- a/man/showUsers.Rd
+++ b/man/showUsers.Rd
@@ -27,6 +27,11 @@ Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{
 This function works for ShinyApps and Posit Connect Cloud.
+
+On Posit Connect Cloud, the content is resolved from the local deployment
+record in \code{appDir}; the call must run from the directory that contains
+the \code{rsconnect/} deployment record. \code{appName} selects among
+multiple records in the same directory.
 }
 \seealso{
 \code{\link[=addAuthorizedUser]{addAuthorizedUser()}} and \code{\link[=showInvited]{showInvited()}}

--- a/man/showUsers.Rd
+++ b/man/showUsers.Rd
@@ -27,6 +27,8 @@ Cloud. On Posit Connect Cloud the data frame additionally includes
 \code{"collaborator"}) from the API response.
 }
 \description{
+List authorized users for an application
+
 Supported servers: ShinyApps, Posit Connect Cloud
 }
 \note{
@@ -35,7 +37,7 @@ This function works for ShinyApps and Posit Connect Cloud.
 On Posit Connect Cloud, the content is resolved from the local deployment
 record under \code{appDir}, which defaults to the working directory. Pass
 \code{appDir} to point at the project directory that contains the
-\code{rsconnect/} record. \code{appName} selects among multiple records in
+\code{rsconnect/} deployment record. \code{appName} selects among multiple records in
 the same directory.
 }
 \seealso{

--- a/man/showUsers.Rd
+++ b/man/showUsers.Rd
@@ -18,6 +18,14 @@ there are multiple options, you'll be prompted to pick one.
 
 Use \code{\link[=accounts]{accounts()}} to see the full list of available options.}
 }
+\value{
+A data frame with one row per authorized user. Columns always
+present: \code{id}, \code{email}, \code{account}. The \code{account}
+column is populated on shinyapps.io only and is \code{NA} on Posit Connect
+Cloud. On Posit Connect Cloud the data frame additionally includes
+\code{display_name} and \code{role} (e.g. \code{"viewer"} or
+\code{"collaborator"}) from the API response.
+}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 

--- a/tests/testthat/test-applications.R
+++ b/tests/testthat/test-applications.R
@@ -34,3 +34,47 @@ test_that("syncAppMetadata deletes deployment records if needed", {
   expect_snapshot(syncAppMetadata(app))
   expect_equal(nrow(deployments(app)), 0)
 })
+
+test_that("applications() returns a data frame for PCC accounts", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplications = function(accountId, ...) {
+        list(list(
+          id = "abc-123",
+          title = "My App",
+          name = "My App",
+          current_revision = list(url = "https://connect.posit.cloud/myaccount/content/abc-123"),
+          created_time = "2024-01-01T00:00:00Z",
+          updated_time = "2024-01-02T00:00:00Z"
+        ))
+      }
+    )
+  })
+
+  result <- applications(account = "myaccount", server = "connect.posit.cloud")
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 1)
+  expect_equal(result$title, "My App")
+  expect_equal(result$url, "https://connect.posit.cloud/myaccount/content/abc-123")
+  expect_true(grepl("myaccount/content/abc-123", result$config_url))
+})
+
+test_that("applications() returns empty data frame for PCC account with no content", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(listApplications = function(...) list())
+  })
+
+  result <- applications(account = "myaccount", server = "connect.posit.cloud")
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 0)
+  expect_named(result, c("id", "name", "title", "url", "status", "size",
+                          "instances", "config_url", "created_time", "updated_time", "guid"))
+})

--- a/tests/testthat/test-applications.R
+++ b/tests/testthat/test-applications.R
@@ -37,12 +37,14 @@ test_that("syncAppMetadata deletes deployment records if needed", {
 
 test_that("applications() returns a data frame for PCC accounts", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   # Local alias "myaccount" intentionally differs from the server-side slug
   # "real-slug" to confirm that url/config_url use the resolved slug, not the alias.
   # userId is passed as accountId in registerAccount() via addTestAccount().
-  addTestAccount("myaccount", server = "connect.posit.cloud",
-                 userId = "acct-1")
+  addTestAccount("myaccount", server = "connect.posit.cloud", userId = "acct-1")
 
   local_mocked_bindings(clientForAccount = function(...) {
     list(
@@ -51,9 +53,9 @@ test_that("applications() returns a data frame for PCC accounts", {
         # No current_revision$url — that field is not documented on the content
         # list endpoint and should not be relied on.
         list(list(
-          id           = "abc-123",
-          title        = "My App",
-          account_id   = "acct-1",
+          id = "abc-123",
+          title = "My App",
+          account_id = "acct-1",
           created_time = "2024-01-01T00:00:00Z",
           updated_time = "2024-01-02T00:00:00Z"
         ))
@@ -69,13 +71,22 @@ test_that("applications() returns a data frame for PCC accounts", {
   expect_equal(nrow(result), 1)
   expect_equal(result$title, "My App")
   # Both url and config_url must use the server-side slug, not the local alias.
-  expect_equal(result$url,        "https://connect.posit.cloud/real-slug/content/abc-123")
-  expect_equal(result$config_url, "https://connect.posit.cloud/real-slug/content/abc-123")
+  expect_equal(
+    result$url,
+    "https://connect.posit.cloud/real-slug/content/abc-123"
+  )
+  expect_equal(
+    result$config_url,
+    "https://connect.posit.cloud/real-slug/content/abc-123"
+  )
 })
 
 test_that("applications() returns empty data frame for PCC account with no content", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   local_mocked_bindings(clientForAccount = function(...) {
@@ -85,6 +96,20 @@ test_that("applications() returns empty data frame for PCC account with no conte
   result <- applications(account = "myaccount", server = "connect.posit.cloud")
   expect_s3_class(result, "data.frame")
   expect_equal(nrow(result), 0)
-  expect_named(result, c("id", "name", "title", "url", "status", "size",
-                          "instances", "config_url", "created_time", "updated_time", "guid"))
+  expect_named(
+    result,
+    c(
+      "id",
+      "name",
+      "title",
+      "url",
+      "status",
+      "size",
+      "instances",
+      "config_url",
+      "created_time",
+      "updated_time",
+      "guid"
+    )
+  )
 })

--- a/tests/testthat/test-applications.R
+++ b/tests/testthat/test-applications.R
@@ -49,15 +49,17 @@ test_that("applications() returns a data frame for PCC accounts", {
   local_mocked_bindings(clientForAccount = function(...) {
     list(
       listApplications = function(accountId, ...) {
-        # Real GET /contents response shape: id, title, account_id, timestamps.
-        # No current_revision$url — that field is not documented on the content
-        # list endpoint and should not be relied on.
+        # GET /contents embeds the current revision, whose `url` is the served
+        # (vanity/custom) URL of the published content.
         list(list(
           id = "abc-123",
           title = "My App",
           account_id = "acct-1",
           created_time = "2024-01-01T00:00:00Z",
-          updated_time = "2024-01-02T00:00:00Z"
+          updated_time = "2024-01-02T00:00:00Z",
+          current_revision = list(
+            url = "https://my-app.share.connect.posit.cloud/"
+          )
         ))
       },
       getAccounts = function() {
@@ -70,15 +72,47 @@ test_that("applications() returns a data frame for PCC accounts", {
   expect_s3_class(result, "data.frame")
   expect_equal(nrow(result), 1)
   expect_equal(result$title, "My App")
-  # url = content view page (server-side slug, not the local alias).
-  # config_url = the content settings page.
+  # url = the revision's served URL; config_url = the settings page (built from
+  # the server-side slug, not the local alias).
   expect_equal(
     result$url,
-    "https://connect.posit.cloud/real-slug/content/abc-123"
+    "https://my-app.share.connect.posit.cloud/"
   )
   expect_equal(
     result$config_url,
     "https://connect.posit.cloud/real-slug/content/abc-123/settings/info"
+  )
+})
+
+test_that("applications() falls back to the constructed url when content is unpublished", {
+  local_temp_config()
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
+  addTestAccount("myaccount", server = "connect.posit.cloud", userId = "acct-1")
+
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      # No current_revision for content that has never published successfully;
+      # url falls back to the constructed content-id URL.
+      listApplications = function(accountId, ...) {
+        list(list(
+          id = "abc-123",
+          title = "My App",
+          account_id = "acct-1"
+        ))
+      },
+      getAccounts = function() {
+        list(data = list(list(id = "acct-1", name = "real-slug")))
+      }
+    )
+  })
+
+  result <- applications(account = "myaccount", server = "connect.posit.cloud")
+  expect_equal(
+    result$url,
+    "https://abc-123.share.connect.posit.cloud/"
   )
 })
 

--- a/tests/testthat/test-applications.R
+++ b/tests/testthat/test-applications.R
@@ -70,14 +70,15 @@ test_that("applications() returns a data frame for PCC accounts", {
   expect_s3_class(result, "data.frame")
   expect_equal(nrow(result), 1)
   expect_equal(result$title, "My App")
-  # Both url and config_url must use the server-side slug, not the local alias.
+  # url = content view page (server-side slug, not the local alias).
+  # config_url = the content settings page.
   expect_equal(
     result$url,
     "https://connect.posit.cloud/real-slug/content/abc-123"
   )
   expect_equal(
     result$config_url,
-    "https://connect.posit.cloud/real-slug/content/abc-123"
+    "https://connect.posit.cloud/real-slug/content/abc-123/settings/info"
   )
 })
 

--- a/tests/testthat/test-applications.R
+++ b/tests/testthat/test-applications.R
@@ -38,19 +38,28 @@ test_that("syncAppMetadata deletes deployment records if needed", {
 test_that("applications() returns a data frame for PCC accounts", {
   local_temp_config()
   addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
-  addTestAccount("myaccount", server = "connect.posit.cloud")
+  # Local alias "myaccount" intentionally differs from the server-side slug
+  # "real-slug" to confirm that url/config_url use the resolved slug, not the alias.
+  # userId is passed as accountId in registerAccount() via addTestAccount().
+  addTestAccount("myaccount", server = "connect.posit.cloud",
+                 userId = "acct-1")
 
   local_mocked_bindings(clientForAccount = function(...) {
     list(
       listApplications = function(accountId, ...) {
+        # Real GET /contents response shape: id, title, account_id, timestamps.
+        # No current_revision$url — that field is not documented on the content
+        # list endpoint and should not be relied on.
         list(list(
-          id = "abc-123",
-          title = "My App",
-          name = "My App",
-          current_revision = list(url = "https://connect.posit.cloud/myaccount/content/abc-123"),
+          id           = "abc-123",
+          title        = "My App",
+          account_id   = "acct-1",
           created_time = "2024-01-01T00:00:00Z",
           updated_time = "2024-01-02T00:00:00Z"
         ))
+      },
+      getAccounts = function() {
+        list(data = list(list(id = "acct-1", name = "real-slug")))
       }
     )
   })
@@ -59,8 +68,9 @@ test_that("applications() returns a data frame for PCC accounts", {
   expect_s3_class(result, "data.frame")
   expect_equal(nrow(result), 1)
   expect_equal(result$title, "My App")
-  expect_equal(result$url, "https://connect.posit.cloud/myaccount/content/abc-123")
-  expect_true(grepl("myaccount/content/abc-123", result$config_url))
+  # Both url and config_url must use the server-side slug, not the local alias.
+  expect_equal(result$url,        "https://connect.posit.cloud/real-slug/content/abc-123")
+  expect_equal(result$config_url, "https://connect.posit.cloud/real-slug/content/abc-123")
 })
 
 test_that("applications() returns empty data frame for PCC account with no content", {

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -857,6 +857,47 @@ test_that("removeAuthorizedUser hints at redaction when the user cannot be match
   )
 })
 
+test_that("removeAuthorizedUser omits the redaction hint for an id lookup", {
+  local_temp_config()
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplicationAuthorization = function(appId) {
+        list(list(user = list(id = "user-uuid-1", email = "alice@example.com")))
+      }
+    )
+  })
+
+  # An id-based lookup that misses is a plain not-found: the redaction hint
+  # (which only helps email searches) must not appear.
+  cnd <- suppressWarnings(
+    expect_error(
+      removeAuthorizedUser(
+        "user-uuid-missing",
+        appDir = app_dir,
+        account = "myaccount",
+        server = "connect.posit.cloud"
+      ),
+      regexp = "not found"
+    )
+  )
+  expect_false(grepl("redacted", conditionMessage(cnd)))
+})
+
 test_that("resendInvitation aborts with clear message when matched invitation has no id", {
   local_temp_config()
   addTestServer(

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -1,0 +1,57 @@
+test_that("showUsers emits deprecation and returns data frame for PCC", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplications = function(accountId, ...) {
+        list(list(name = "myapp", id = "content-uuid-123"))
+      },
+      listApplicationAuthorization = function(appId) {
+        list(
+          list(user = list(id = "user-uuid-1", email = "alice@example.com")),
+          list(user = list(id = "user-uuid-2", email = "bob@example.com"))
+        )
+      }
+    )
+  })
+
+  expect_warning(
+    result <- showUsers(appName = "myapp", account = "myaccount",
+                        server = "connect.posit.cloud"),
+    regexp = "deprecated"
+  )
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 2)
+  expect_equal(result$email, c("alice@example.com", "bob@example.com"))
+})
+
+test_that("removeAuthorizedUser emits deprecation and calls removeApplicationUser on PCC", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  removed_user_id <- NULL
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplications = function(accountId, ...) {
+        list(list(name = "myapp", id = "content-uuid-123"))
+      },
+      listApplicationAuthorization = function(appId) {
+        list(list(user = list(id = "user-uuid-1", email = "alice@example.com")))
+      },
+      removeApplicationUser = function(appId, userId) {
+        removed_user_id <<- userId
+        invisible(TRUE)
+      }
+    )
+  })
+
+  expect_warning(
+    removeAuthorizedUser("alice@example.com", appName = "myapp",
+                          account = "myaccount", server = "connect.posit.cloud"),
+    regexp = "deprecated"
+  )
+  expect_equal(removed_user_id, "user-uuid-1")
+})

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -817,6 +817,46 @@ test_that("removeAuthorizedUser aborts with clear message when matched user has 
   )
 })
 
+test_that("removeAuthorizedUser hints at redaction when the user cannot be matched", {
+  local_temp_config()
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      # PCC redacted the email, so matching on the caller's email fails.
+      listApplicationAuthorization = function(appId) {
+        list(list(user = list(id = "user-uuid-1", email = "REDACTED")))
+      }
+    )
+  })
+
+  expect_warning(
+    expect_error(
+      removeAuthorizedUser(
+        "alice@example.com",
+        appDir = app_dir,
+        account = "myaccount",
+        server = "connect.posit.cloud"
+      ),
+      regexp = "redacted"
+    ),
+    regexp = "deprecated"
+  )
+})
+
 test_that("resendInvitation aborts with clear message when matched invitation has no id", {
   local_temp_config()
   addTestServer(

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -618,6 +618,72 @@ test_that("resendInvitation resolves by UUID invite id on PCC (not email-only fa
   expect_equal(resent_id, "invite-uuid-xyz")
 })
 
+test_that("removeAuthorizedUser aborts with clear message when matched user has no id", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplicationAuthorization = function(appId) {
+        # user record has email but no id field — id will be NA after showUsers_impl
+        list(list(user = list(email = "alice@example.com")))
+      }
+    )
+  })
+
+  expect_warning(
+    expect_error(
+      removeAuthorizedUser("alice@example.com", appDir = app_dir,
+                           account = "myaccount", server = "connect.posit.cloud"),
+      regexp = "no id"
+    ),
+    regexp = "deprecated"
+  )
+})
+
+test_that("resendInvitation aborts with clear message when matched invitation has no id", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplicationInvitations = function(appId) {
+        # invitation record has email_address but no id — id will be NA after showInvited_impl
+        list(list(email_address = "alice@example.com", is_expired = FALSE))
+      }
+    )
+  })
+
+  expect_warning(
+    expect_error(
+      resendInvitation("alice@example.com", appDir = app_dir,
+                       account = "myaccount", server = "connect.posit.cloud"),
+      regexp = "no id"
+    ),
+    regexp = "deprecated"
+  )
+})
+
 test_that("cleanupPasswordFile is NOT called on PCC accounts", {
   local_temp_config()
   addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -79,3 +79,93 @@ test_that("showUsers returns empty data frame with correct columns when no users
   expect_equal(nrow(result), 0L)
   expect_named(result, c("id", "email", "account"))
 })
+
+test_that("addAuthorizedUser emits deprecation and calls inviteApplicationUser on PCC", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  invited <- list()
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplications = function(accountId, ...) {
+        list(list(name = "myapp", id = "content-uuid-123"))
+      },
+      inviteApplicationUser = function(appId, email, sendEmail, emailMessage) {
+        invited[[length(invited) + 1]] <<- list(appId = appId, email = email)
+        invisible(TRUE)
+      }
+    )
+  })
+
+  expect_warning(
+    addAuthorizedUser("alice@example.com", appName = "myapp",
+                      account = "myaccount", server = "connect.posit.cloud"),
+    regexp = "deprecated"
+  )
+  expect_length(invited, 1)
+  expect_equal(invited[[1]]$email, "alice@example.com")
+})
+
+test_that("showInvited emits deprecation and maps PCC email_address/is_expired fields", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplications = function(accountId, ...) {
+        list(list(name = "myapp", id = "content-uuid-123"))
+      },
+      listApplicationInvitations = function(appId) {
+        list(list(
+          id = "invite-uuid-1",
+          email_address = "alice@example.com",
+          is_expired = FALSE
+        ))
+      }
+    )
+  })
+
+  expect_warning(
+    result <- showInvited(appName = "myapp", account = "myaccount",
+                          server = "connect.posit.cloud"),
+    regexp = "deprecated"
+  )
+  expect_equal(result$email, "alice@example.com")
+  expect_true(is.na(result$link))
+  expect_false(result$expired)
+})
+
+test_that("resendInvitation emits deprecation and calls resendApplicationInvitation on PCC", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  resent_id <- NULL
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplications = function(accountId, ...) {
+        list(list(name = "myapp", id = "content-uuid-123"))
+      },
+      listApplicationInvitations = function(appId) {
+        list(list(
+          id = "invite-uuid-1",
+          email_address = "alice@example.com",
+          is_expired = FALSE
+        ))
+      },
+      resendApplicationInvitation = function(inviteId, regenerate) {
+        resent_id <<- inviteId
+        invisible(TRUE)
+      }
+    )
+  })
+
+  expect_warning(
+    resendInvitation("alice@example.com", appName = "myapp",
+                     account = "myaccount", server = "connect.posit.cloud"),
+    regexp = "deprecated"
+  )
+  expect_equal(resent_id, "invite-uuid-1")
+})

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -482,3 +482,60 @@ test_that("resolveContentTarget delegates to resolveApplication on shinyapps.io"
   )
   expect_equal(captured_app_id, 42L)
 })
+
+test_that("removeAuthorizedUser resolves content target exactly once (no double prompt)", {
+  # Regression test for double resolveContentTarget() via public showUsers().
+  # Before the fix, removeAuthorizedUser() called resolveContentTarget() and
+  # then showUsers() called it again — two independent prompts on multi-record
+  # appDir, potentially acting on different content. After the fix, clientForAccount
+  # is built once and showUsers_impl() is called directly with the resolved id.
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "a",
+    appId = "content-uuid-aaa",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+  addTestDeployment(
+    app_dir,
+    appName = "b",
+    appId = "content-uuid-bbb",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
+  client_build_count <- 0L
+  removed_app_id <- NULL
+  local_mocked_bindings(clientForAccount = function(...) {
+    client_build_count <<- client_build_count + 1L
+    list(
+      listApplicationAuthorization = function(appId) {
+        list(list(user = list(id = "user-uuid-1", email = "alice@example.com")))
+      },
+      removeApplicationUser = function(appId, userId) {
+        removed_app_id <<- appId
+        invisible(TRUE)
+      }
+    )
+  })
+
+  expect_warning(
+    removeAuthorizedUser(
+      "alice@example.com",
+      appDir = app_dir,
+      appName = "b",
+      account = "myaccount",
+      server = "connect.posit.cloud"
+    ),
+    regexp = "deprecated"
+  )
+  # clientForAccount built exactly once → content resolved exactly once
+  expect_equal(client_build_count, 1L)
+  # removeApplicationUser called with "b"'s appId, not "a"'s
+  expect_equal(removed_app_id, "content-uuid-bbb")
+})

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -1,6 +1,9 @@
 test_that("showUsers emits deprecation and returns data frame for PCC", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -24,8 +27,11 @@ test_that("showUsers emits deprecation and returns data frame for PCC", {
   })
 
   expect_warning(
-    result <- showUsers(appDir = app_dir, account = "myaccount",
-                        server = "connect.posit.cloud"),
+    result <- showUsers(
+      appDir = app_dir,
+      account = "myaccount",
+      server = "connect.posit.cloud"
+    ),
     regexp = "deprecated"
   )
   expect_s3_class(result, "data.frame")
@@ -35,7 +41,10 @@ test_that("showUsers emits deprecation and returns data frame for PCC", {
 
 test_that("removeAuthorizedUser emits deprecation and calls removeApplicationUser on PCC", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -61,8 +70,12 @@ test_that("removeAuthorizedUser emits deprecation and calls removeApplicationUse
   })
 
   expect_warning(
-    removeAuthorizedUser("alice@example.com", appDir = app_dir,
-                          account = "myaccount", server = "connect.posit.cloud"),
+    removeAuthorizedUser(
+      "alice@example.com",
+      appDir = app_dir,
+      account = "myaccount",
+      server = "connect.posit.cloud"
+    ),
     regexp = "deprecated"
   )
   expect_equal(removed_user_id, "user-uuid-1")
@@ -70,7 +83,10 @@ test_that("removeAuthorizedUser emits deprecation and calls removeApplicationUse
 
 test_that("showUsers returns empty data frame with correct columns when no users authorized", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -89,8 +105,11 @@ test_that("showUsers returns empty data frame with correct columns when no users
   })
 
   expect_warning(
-    result <- showUsers(appDir = app_dir, account = "myaccount",
-                        server = "connect.posit.cloud"),
+    result <- showUsers(
+      appDir = app_dir,
+      account = "myaccount",
+      server = "connect.posit.cloud"
+    ),
     regexp = "deprecated"
   )
   expect_s3_class(result, "data.frame")
@@ -100,7 +119,10 @@ test_that("showUsers returns empty data frame with correct columns when no users
 
 test_that("addAuthorizedUser emits deprecation and calls inviteApplicationUser on PCC", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -123,8 +145,12 @@ test_that("addAuthorizedUser emits deprecation and calls inviteApplicationUser o
   })
 
   expect_warning(
-    addAuthorizedUser("alice@example.com", appDir = app_dir,
-                      account = "myaccount", server = "connect.posit.cloud"),
+    addAuthorizedUser(
+      "alice@example.com",
+      appDir = app_dir,
+      account = "myaccount",
+      server = "connect.posit.cloud"
+    ),
     regexp = "deprecated"
   )
   expect_length(invited, 1)
@@ -133,7 +159,10 @@ test_that("addAuthorizedUser emits deprecation and calls inviteApplicationUser o
 
 test_that("showInvited emits deprecation and maps PCC email_address/is_expired fields", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -158,8 +187,11 @@ test_that("showInvited emits deprecation and maps PCC email_address/is_expired f
   })
 
   expect_warning(
-    result <- showInvited(appDir = app_dir, account = "myaccount",
-                          server = "connect.posit.cloud"),
+    result <- showInvited(
+      appDir = app_dir,
+      account = "myaccount",
+      server = "connect.posit.cloud"
+    ),
     regexp = "deprecated"
   )
   expect_equal(result$email, "alice@example.com")
@@ -169,7 +201,10 @@ test_that("showInvited emits deprecation and maps PCC email_address/is_expired f
 
 test_that("addAuthorizedUser warns when sendEmail is non-NULL on PCC", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -204,12 +239,18 @@ test_that("addAuthorizedUser warns when sendEmail is non-NULL on PCC", {
     }
   )
   expect_true(any(grepl("deprecated", msgs, ignore.case = TRUE)))
-  expect_true(any(grepl("sendEmail.*ignored|ignored.*sendEmail|PCC always", msgs)))
+  expect_true(any(grepl(
+    "sendEmail.*ignored|ignored.*sendEmail|PCC always",
+    msgs
+  )))
 })
 
 test_that("showInvited returns NA for invitation records missing email and expired fields", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -246,7 +287,10 @@ test_that("showInvited returns NA for invitation records missing email and expir
 
 test_that("showUsers aborts with a clear message when a user record has neither id nor email", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -283,14 +327,20 @@ test_that("showUsers aborts with a clear message when a user record has neither 
 
 test_that("showUsers errors on non-shinyapps non-PCC server without emitting deprecation", {
   local_temp_config()
-  addTestServer(url = "https://connect.example.com", name = "connect.example.com")
+  addTestServer(
+    url = "https://connect.example.com",
+    name = "connect.example.com"
+  )
   addTestAccount("myaccount", server = "connect.example.com")
 
   saw_deprecation <- FALSE
   expect_error(
     withCallingHandlers(
-      showUsers(appName = "myapp", account = "myaccount",
-                server = "connect.example.com"),
+      showUsers(
+        appName = "myapp",
+        account = "myaccount",
+        server = "connect.example.com"
+      ),
       warning = function(w) {
         if (grepl("deprecated", conditionMessage(w), ignore.case = TRUE)) {
           saw_deprecation <<- TRUE
@@ -305,7 +355,10 @@ test_that("showUsers errors on non-shinyapps non-PCC server without emitting dep
 
 test_that("resendInvitation emits deprecation and calls resendApplicationInvitation on PCC", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -335,8 +388,12 @@ test_that("resendInvitation emits deprecation and calls resendApplicationInvitat
   })
 
   expect_warning(
-    resendInvitation("alice@example.com", appDir = app_dir,
-                     account = "myaccount", server = "connect.posit.cloud"),
+    resendInvitation(
+      "alice@example.com",
+      appDir = app_dir,
+      account = "myaccount",
+      server = "connect.posit.cloud"
+    ),
     regexp = "deprecated"
   )
   expect_equal(resent_id, "invite-uuid-1")
@@ -344,7 +401,10 @@ test_that("resendInvitation emits deprecation and calls resendApplicationInvitat
 
 test_that("resolveContentTarget uses deployment-record appId on PCC, not title", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -367,7 +427,11 @@ test_that("resolveContentTarget uses deployment-record appId on PCC, not title",
   })
 
   expect_warning(
-    showUsers(appDir = app_dir, account = "myaccount", server = "connect.posit.cloud"),
+    showUsers(
+      appDir = app_dir,
+      account = "myaccount",
+      server = "connect.posit.cloud"
+    ),
     regexp = "deprecated"
   )
   expect_equal(captured_app_id, "content-uuid-abc")
@@ -375,7 +439,10 @@ test_that("resolveContentTarget uses deployment-record appId on PCC, not title",
 
 test_that("resolveContentTarget aborts with clear message on PCC when no deployment record", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -383,7 +450,11 @@ test_that("resolveContentTarget aborts with clear message on PCC when no deploym
 
   expect_error(
     suppressWarnings(
-      showUsers(appDir = app_dir, account = "myaccount", server = "connect.posit.cloud")
+      showUsers(
+        appDir = app_dir,
+        account = "myaccount",
+        server = "connect.posit.cloud"
+      )
     ),
     regexp = "No deployment record found"
   )
@@ -391,7 +462,10 @@ test_that("resolveContentTarget aborts with clear message on PCC when no deploym
 
 test_that("resolveContentTarget: appName selects correct record among multiple in appDir", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -421,8 +495,12 @@ test_that("resolveContentTarget: appName selects correct record among multiple i
   })
 
   expect_warning(
-    showUsers(appDir = app_dir, appName = "b",
-              account = "myaccount", server = "connect.posit.cloud"),
+    showUsers(
+      appDir = app_dir,
+      appName = "b",
+      account = "myaccount",
+      server = "connect.posit.cloud"
+    ),
     regexp = "deprecated"
   )
   expect_equal(captured_app_id, "content-uuid-bbb")
@@ -430,7 +508,10 @@ test_that("resolveContentTarget: appName selects correct record among multiple i
 
 test_that("resolveContentTarget: omitting appName with multiple records lists candidates non-interactively", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -451,8 +532,11 @@ test_that("resolveContentTarget: omitting appName with multiple records lists ca
 
   expect_error(
     suppressWarnings(
-      showUsers(appDir = app_dir, account = "myaccount",
-                server = "connect.posit.cloud")
+      showUsers(
+        appDir = app_dir,
+        account = "myaccount",
+        server = "connect.posit.cloud"
+      )
     ),
     regexp = "appName|disambiguate|Known"
   )
@@ -477,7 +561,11 @@ test_that("resolveContentTarget delegates to resolveApplication on shinyapps.io"
   })
 
   expect_warning(
-    showUsers(appName = "myapp", account = "myaccount", server = "shinyapps.io"),
+    showUsers(
+      appName = "myapp",
+      account = "myaccount",
+      server = "shinyapps.io"
+    ),
     regexp = "deprecated"
   )
   expect_equal(captured_app_id, 42L)
@@ -490,7 +578,10 @@ test_that("removeAuthorizedUser resolves content target exactly once (no double 
   # appDir, potentially acting on different content. After the fix, clientForAccount
   # is built once and showUsers_impl() is called directly with the resolved id.
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -544,7 +635,10 @@ test_that("removeAuthorizedUser resolves by UUID id on PCC (not email-only fallb
   # Regression: is.numeric("uuid-string") == FALSE, so the old code fell to the
   # email branch and never matched PCC UUID ids.
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -560,7 +654,9 @@ test_that("removeAuthorizedUser resolves by UUID id on PCC (not email-only fallb
   local_mocked_bindings(clientForAccount = function(...) {
     list(
       listApplicationAuthorization = function(appId) {
-        list(list(user = list(id = "user-uuid-abc", email = "alice@example.com")))
+        list(list(
+          user = list(id = "user-uuid-abc", email = "alice@example.com")
+        ))
       },
       removeApplicationUser = function(appId, userId) {
         removed_user_id <<- userId
@@ -570,8 +666,12 @@ test_that("removeAuthorizedUser resolves by UUID id on PCC (not email-only fallb
   })
 
   expect_warning(
-    removeAuthorizedUser("user-uuid-abc", appDir = app_dir,
-                          account = "myaccount", server = "connect.posit.cloud"),
+    removeAuthorizedUser(
+      "user-uuid-abc",
+      appDir = app_dir,
+      account = "myaccount",
+      server = "connect.posit.cloud"
+    ),
     regexp = "deprecated"
   )
   expect_equal(removed_user_id, "user-uuid-abc")
@@ -581,7 +681,10 @@ test_that("resendInvitation resolves by UUID invite id on PCC (not email-only fa
   # Same is.numeric() bug as removeAuthorizedUser: UUID invite ids are character,
   # so the old code fell to the email branch and never matched by id.
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -611,8 +714,12 @@ test_that("resendInvitation resolves by UUID invite id on PCC (not email-only fa
   })
 
   expect_warning(
-    resendInvitation("invite-uuid-xyz", appDir = app_dir,
-                     account = "myaccount", server = "connect.posit.cloud"),
+    resendInvitation(
+      "invite-uuid-xyz",
+      appDir = app_dir,
+      account = "myaccount",
+      server = "connect.posit.cloud"
+    ),
     regexp = "deprecated"
   )
   expect_equal(resent_id, "invite-uuid-xyz")
@@ -620,7 +727,10 @@ test_that("resendInvitation resolves by UUID invite id on PCC (not email-only fa
 
 test_that("removeAuthorizedUser aborts with clear message when matched user has no id", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -643,8 +753,12 @@ test_that("removeAuthorizedUser aborts with clear message when matched user has 
 
   expect_warning(
     expect_error(
-      removeAuthorizedUser("alice@example.com", appDir = app_dir,
-                           account = "myaccount", server = "connect.posit.cloud"),
+      removeAuthorizedUser(
+        "alice@example.com",
+        appDir = app_dir,
+        account = "myaccount",
+        server = "connect.posit.cloud"
+      ),
       regexp = "no id"
     ),
     regexp = "deprecated"
@@ -653,7 +767,10 @@ test_that("removeAuthorizedUser aborts with clear message when matched user has 
 
 test_that("resendInvitation aborts with clear message when matched invitation has no id", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -676,8 +793,12 @@ test_that("resendInvitation aborts with clear message when matched invitation ha
 
   expect_warning(
     expect_error(
-      resendInvitation("alice@example.com", appDir = app_dir,
-                       account = "myaccount", server = "connect.posit.cloud"),
+      resendInvitation(
+        "alice@example.com",
+        appDir = app_dir,
+        account = "myaccount",
+        server = "connect.posit.cloud"
+      ),
       regexp = "no id"
     ),
     regexp = "deprecated"
@@ -686,7 +807,10 @@ test_that("resendInvitation aborts with clear message when matched invitation ha
 
 test_that("cleanupPasswordFile is NOT called on PCC accounts", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   app_dir <- withr::local_tempdir()
@@ -700,7 +824,10 @@ test_that("cleanupPasswordFile is NOT called on PCC accounts", {
 
   cleanup_called <- FALSE
   local_mocked_bindings(
-    cleanupPasswordFile = function(...) { cleanup_called <<- TRUE; invisible(TRUE) },
+    cleanupPasswordFile = function(...) {
+      cleanup_called <<- TRUE
+      invisible(TRUE)
+    },
     clientForAccount = function(...) {
       list(
         inviteApplicationUser = function(...) invisible(TRUE)
@@ -709,8 +836,12 @@ test_that("cleanupPasswordFile is NOT called on PCC accounts", {
   )
 
   expect_warning(
-    addAuthorizedUser("alice@example.com", appDir = app_dir,
-                      account = "myaccount", server = "connect.posit.cloud"),
+    addAuthorizedUser(
+      "alice@example.com",
+      appDir = app_dir,
+      account = "myaccount",
+      server = "connect.posit.cloud"
+    ),
     regexp = "deprecated"
   )
   expect_false(cleanup_called)

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -55,3 +55,27 @@ test_that("removeAuthorizedUser emits deprecation and calls removeApplicationUse
   )
   expect_equal(removed_user_id, "user-uuid-1")
 })
+
+test_that("showUsers returns empty data frame with correct columns when no users authorized", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplications = function(accountId, ...) {
+        list(list(name = "myapp", id = "content-uuid-123"))
+      },
+      listApplicationAuthorization = function(appId) list()
+    )
+  })
+
+  expect_warning(
+    result <- showUsers(appName = "myapp", account = "myaccount",
+                        server = "connect.posit.cloud"),
+    regexp = "deprecated"
+  )
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 0L)
+  expect_named(result, c("id", "email", "account"))
+})

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -389,6 +389,75 @@ test_that("resolveContentTarget aborts with clear message on PCC when no deploym
   )
 })
 
+test_that("resolveContentTarget: appName selects correct record among multiple in appDir", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "a",
+    appId = "content-uuid-aaa",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+  addTestDeployment(
+    app_dir,
+    appName = "b",
+    appId = "content-uuid-bbb",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
+  captured_app_id <- NULL
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplicationAuthorization = function(appId) {
+        captured_app_id <<- appId
+        list()
+      }
+    )
+  })
+
+  expect_warning(
+    showUsers(appDir = app_dir, appName = "b",
+              account = "myaccount", server = "connect.posit.cloud"),
+    regexp = "deprecated"
+  )
+  expect_equal(captured_app_id, "content-uuid-bbb")
+})
+
+test_that("resolveContentTarget: omitting appName with multiple records lists candidates non-interactively", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "a",
+    appId = "content-uuid-aaa",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+  addTestDeployment(
+    app_dir,
+    appName = "b",
+    appId = "content-uuid-bbb",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
+  expect_error(
+    suppressWarnings(
+      showUsers(appDir = app_dir, account = "myaccount",
+                server = "connect.posit.cloud")
+    ),
+    regexp = "appName|disambiguate|Known"
+  )
+})
+
 test_that("resolveContentTarget delegates to resolveApplication on shinyapps.io", {
   local_temp_config()
   addTestServer(url = "https://shinyapps.io", name = "shinyapps.io")

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -539,3 +539,113 @@ test_that("removeAuthorizedUser resolves content target exactly once (no double 
   # removeApplicationUser called with "b"'s appId, not "a"'s
   expect_equal(removed_app_id, "content-uuid-bbb")
 })
+
+test_that("removeAuthorizedUser resolves by UUID id on PCC (not email-only fallback)", {
+  # Regression: is.numeric("uuid-string") == FALSE, so the old code fell to the
+  # email branch and never matched PCC UUID ids.
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
+  removed_user_id <- NULL
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplicationAuthorization = function(appId) {
+        list(list(user = list(id = "user-uuid-abc", email = "alice@example.com")))
+      },
+      removeApplicationUser = function(appId, userId) {
+        removed_user_id <<- userId
+        invisible(TRUE)
+      }
+    )
+  })
+
+  expect_warning(
+    removeAuthorizedUser("user-uuid-abc", appDir = app_dir,
+                          account = "myaccount", server = "connect.posit.cloud"),
+    regexp = "deprecated"
+  )
+  expect_equal(removed_user_id, "user-uuid-abc")
+})
+
+test_that("resendInvitation resolves by UUID invite id on PCC (not email-only fallback)", {
+  # Same is.numeric() bug as removeAuthorizedUser: UUID invite ids are character,
+  # so the old code fell to the email branch and never matched by id.
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
+  resent_id <- NULL
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplicationInvitations = function(appId) {
+        list(list(
+          id = "invite-uuid-xyz",
+          email_address = "bob@example.com",
+          is_expired = FALSE
+        ))
+      },
+      resendApplicationInvitation = function(inviteId, regenerate) {
+        resent_id <<- inviteId
+        invisible(TRUE)
+      }
+    )
+  })
+
+  expect_warning(
+    resendInvitation("invite-uuid-xyz", appDir = app_dir,
+                     account = "myaccount", server = "connect.posit.cloud"),
+    regexp = "deprecated"
+  )
+  expect_equal(resent_id, "invite-uuid-xyz")
+})
+
+test_that("cleanupPasswordFile is NOT called on PCC accounts", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
+  cleanup_called <- FALSE
+  local_mocked_bindings(
+    cleanupPasswordFile = function(...) { cleanup_called <<- TRUE; invisible(TRUE) },
+    clientForAccount = function(...) {
+      list(
+        inviteApplicationUser = function(...) invisible(TRUE)
+      )
+    }
+  )
+
+  expect_warning(
+    addAuthorizedUser("alice@example.com", appDir = app_dir,
+                      account = "myaccount", server = "connect.posit.cloud"),
+    regexp = "deprecated"
+  )
+  expect_false(cleanup_called)
+})

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -202,6 +202,59 @@ test_that("showInvited returns NA for invitation records missing email and expir
   expect_true(is.na(result$expired))
 })
 
+test_that("showUsers returns NA for user records with absent id and email fields", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplications = function(accountId, ...) {
+        list(list(name = "myapp", id = "content-uuid-123"))
+      },
+      listApplicationAuthorization = function(appId) {
+        # record with no user$id or user$email fields
+        list(list(user = list()))
+      }
+    )
+  })
+
+  expect_warning(
+    result <- showUsers(
+      appName = "myapp",
+      account = "myaccount",
+      server = "connect.posit.cloud"
+    ),
+    regexp = "deprecated"
+  )
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 1L)
+  expect_true(is.na(result$id))
+  expect_true(is.na(result$email))
+})
+
+test_that("showUsers errors on non-shinyapps non-PCC server without emitting deprecation", {
+  local_temp_config()
+  addTestServer(url = "https://connect.example.com", name = "connect.example.com")
+  addTestAccount("myaccount", server = "connect.example.com")
+
+  saw_deprecation <- FALSE
+  expect_error(
+    withCallingHandlers(
+      showUsers(appName = "myapp", account = "myaccount",
+                server = "connect.example.com"),
+      warning = function(w) {
+        if (grepl("deprecated", conditionMessage(w), ignore.case = TRUE)) {
+          saw_deprecation <<- TRUE
+        }
+        invokeRestart("muffleWarning")
+      }
+    ),
+    regexp = "shinyapps\\.io"
+  )
+  expect_false(saw_deprecation)
+})
+
 test_that("resendInvitation emits deprecation and calls resendApplicationInvitation on PCC", {
   local_temp_config()
   addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -19,8 +19,22 @@ test_that("showUsers emits deprecation and returns data frame for PCC", {
     list(
       listApplicationAuthorization = function(appId) {
         list(
-          list(user = list(id = "user-uuid-1", email = "alice@example.com")),
-          list(user = list(id = "user-uuid-2", email = "bob@example.com"))
+          list(
+            user = list(
+              id = "user-uuid-1",
+              email = "alice@example.com",
+              display_name = "Alice Smith"
+            ),
+            role = "collaborator"
+          ),
+          list(
+            user = list(
+              id = "user-uuid-2",
+              email = "bob@example.com",
+              display_name = "Bob Jones"
+            ),
+            role = "viewer"
+          )
         )
       }
     )
@@ -37,6 +51,9 @@ test_that("showUsers emits deprecation and returns data frame for PCC", {
   expect_s3_class(result, "data.frame")
   expect_equal(nrow(result), 2)
   expect_equal(result$email, c("alice@example.com", "bob@example.com"))
+  expect_equal(result$display_name, c("Alice Smith", "Bob Jones"))
+  expect_equal(result$role, c("collaborator", "viewer"))
+  expect_true(all(is.na(result$account)))
 })
 
 test_that("removeAuthorizedUser emits deprecation and calls removeApplicationUser on PCC", {
@@ -114,7 +131,42 @@ test_that("showUsers returns empty data frame with correct columns when no users
   )
   expect_s3_class(result, "data.frame")
   expect_equal(nrow(result), 0L)
+  expect_named(result, c("id", "email", "account", "display_name", "role"))
+})
+
+test_that("showUsers on shinyapps.io returns only id/email/account columns (no display_name/role)", {
+  local_temp_config()
+  addTestServer(url = "https://shinyapps.io", name = "shinyapps.io")
+  addTestAccount("myaccount", server = "shinyapps.io")
+
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplications = function(accountId, ...) {
+        list(list(name = "myapp", id = 42L))
+      },
+      listApplicationAuthorization = function(appId) {
+        list(
+          list(
+            user = list(id = "101", email = "alice@example.com"),
+            account = "alice-account"
+          )
+        )
+      }
+    )
+  })
+
+  expect_warning(
+    result <- showUsers(
+      appName = "myapp",
+      account = "myaccount",
+      server = "shinyapps.io"
+    ),
+    regexp = "deprecated"
+  )
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 1L)
   expect_named(result, c("id", "email", "account"))
+  expect_equal(result$account, "alice-account")
 })
 
 test_that("addAuthorizedUser emits deprecation and calls inviteApplicationUser on PCC", {

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -137,6 +137,71 @@ test_that("showInvited emits deprecation and maps PCC email_address/is_expired f
   expect_false(result$expired)
 })
 
+test_that("addAuthorizedUser warns when sendEmail is non-NULL on PCC", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplications = function(accountId, ...) {
+        list(list(name = "myapp", id = "content-uuid-123"))
+      },
+      inviteApplicationUser = function(appId, email, sendEmail, emailMessage) {
+        invisible(TRUE)
+      }
+    )
+  })
+
+  msgs <- character(0)
+  withCallingHandlers(
+    addAuthorizedUser(
+      "alice@example.com",
+      appName = "myapp",
+      account = "myaccount",
+      server = "connect.posit.cloud",
+      sendEmail = FALSE
+    ),
+    warning = function(w) {
+      msgs <<- c(msgs, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    }
+  )
+  expect_true(any(grepl("deprecated", msgs, ignore.case = TRUE)))
+  expect_true(any(grepl("sendEmail.*ignored|ignored.*sendEmail|PCC always", msgs)))
+})
+
+test_that("showInvited returns NA for invitation records missing email and expired fields", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplications = function(accountId, ...) {
+        list(list(name = "myapp", id = "content-uuid-123"))
+      },
+      listApplicationInvitations = function(appId) {
+        # record with neither email_address/email nor is_expired/expired
+        list(list(id = "invite-uuid-missing"))
+      }
+    )
+  })
+
+  expect_warning(
+    result <- showInvited(
+      appName = "myapp",
+      account = "myaccount",
+      server = "connect.posit.cloud"
+    ),
+    regexp = "deprecated"
+  )
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 1L)
+  expect_true(is.na(result$email))
+  expect_true(is.na(result$expired))
+})
+
 test_that("resendInvitation emits deprecation and calls resendApplicationInvitation on PCC", {
   local_temp_config()
   addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -401,7 +401,7 @@ test_that("showUsers aborts with a clear message when a user record has neither 
         account = "myaccount",
         server = "connect.posit.cloud"
       ),
-      regexp = "Unexpected response from Connect Cloud"
+      regexp = "Unexpected response from Posit Connect Cloud"
     ),
     regexp = "deprecated"
   )

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -1,4 +1,4 @@
-test_that("showUsers emits deprecation and returns data frame for PCC", {
+test_that("showUsers returns a data frame for PCC", {
   local_temp_config()
   addTestServer(
     url = "https://connect.posit.cloud",
@@ -40,13 +40,10 @@ test_that("showUsers emits deprecation and returns data frame for PCC", {
     )
   })
 
-  expect_warning(
-    result <- showUsers(
-      appDir = app_dir,
-      account = "myaccount",
-      server = "connect.posit.cloud"
-    ),
-    regexp = "deprecated"
+  result <- showUsers(
+    appDir = app_dir,
+    account = "myaccount",
+    server = "connect.posit.cloud"
   )
   expect_s3_class(result, "data.frame")
   expect_equal(nrow(result), 2)
@@ -56,7 +53,7 @@ test_that("showUsers emits deprecation and returns data frame for PCC", {
   expect_true(all(is.na(result$account)))
 })
 
-test_that("removeAuthorizedUser emits deprecation and calls removeApplicationUser on PCC", {
+test_that("removeAuthorizedUser calls removeApplicationUser on PCC", {
   local_temp_config()
   addTestServer(
     url = "https://connect.posit.cloud",
@@ -86,14 +83,11 @@ test_that("removeAuthorizedUser emits deprecation and calls removeApplicationUse
     )
   })
 
-  expect_warning(
-    removeAuthorizedUser(
-      "alice@example.com",
-      appDir = app_dir,
-      account = "myaccount",
-      server = "connect.posit.cloud"
-    ),
-    regexp = "deprecated"
+  removeAuthorizedUser(
+    "alice@example.com",
+    appDir = app_dir,
+    account = "myaccount",
+    server = "connect.posit.cloud"
   )
   expect_equal(removed_user_id, "user-uuid-1")
 })
@@ -121,13 +115,10 @@ test_that("showUsers returns empty data frame with correct columns when no users
     )
   })
 
-  expect_warning(
-    result <- showUsers(
-      appDir = app_dir,
-      account = "myaccount",
-      server = "connect.posit.cloud"
-    ),
-    regexp = "deprecated"
+  result <- showUsers(
+    appDir = app_dir,
+    account = "myaccount",
+    server = "connect.posit.cloud"
   )
   expect_s3_class(result, "data.frame")
   expect_equal(nrow(result), 0L)
@@ -155,13 +146,10 @@ test_that("showUsers on shinyapps.io returns only id/email/account columns (no d
     )
   })
 
-  expect_warning(
-    result <- showUsers(
-      appName = "myapp",
-      account = "myaccount",
-      server = "shinyapps.io"
-    ),
-    regexp = "deprecated"
+  result <- showUsers(
+    appName = "myapp",
+    account = "myaccount",
+    server = "shinyapps.io"
   )
   expect_s3_class(result, "data.frame")
   expect_equal(nrow(result), 1L)
@@ -186,20 +174,17 @@ test_that("showUsers names shinyapps.io (not Connect Cloud) in the malformed-rec
     )
   })
 
-  expect_warning(
-    expect_error(
-      showUsers(
-        appName = "myapp",
-        account = "myaccount",
-        server = "shinyapps.io"
-      ),
-      regexp = "Unexpected response from shinyapps\\.io"
+  expect_error(
+    showUsers(
+      appName = "myapp",
+      account = "myaccount",
+      server = "shinyapps.io"
     ),
-    regexp = "deprecated"
+    regexp = "Unexpected response from shinyapps\\.io"
   )
 })
 
-test_that("addAuthorizedUser emits deprecation and calls inviteApplicationUser on PCC", {
+test_that("addAuthorizedUser calls inviteApplicationUser on PCC", {
   local_temp_config()
   addTestServer(
     url = "https://connect.posit.cloud",
@@ -226,20 +211,17 @@ test_that("addAuthorizedUser emits deprecation and calls inviteApplicationUser o
     )
   })
 
-  expect_warning(
-    addAuthorizedUser(
-      "alice@example.com",
-      appDir = app_dir,
-      account = "myaccount",
-      server = "connect.posit.cloud"
-    ),
-    regexp = "deprecated"
+  addAuthorizedUser(
+    "alice@example.com",
+    appDir = app_dir,
+    account = "myaccount",
+    server = "connect.posit.cloud"
   )
   expect_length(invited, 1)
   expect_equal(invited[[1]]$email, "alice@example.com")
 })
 
-test_that("showInvited emits deprecation and maps PCC email_address/is_expired fields", {
+test_that("showInvited maps PCC email_address/is_expired fields", {
   local_temp_config()
   addTestServer(
     url = "https://connect.posit.cloud",
@@ -268,13 +250,10 @@ test_that("showInvited emits deprecation and maps PCC email_address/is_expired f
     )
   })
 
-  expect_warning(
-    result <- showInvited(
-      appDir = app_dir,
-      account = "myaccount",
-      server = "connect.posit.cloud"
-    ),
-    regexp = "deprecated"
+  result <- showInvited(
+    appDir = app_dir,
+    account = "myaccount",
+    server = "connect.posit.cloud"
   )
   expect_equal(result$email, "alice@example.com")
   expect_true(is.na(result$link))
@@ -320,7 +299,6 @@ test_that("addAuthorizedUser warns when sendEmail is non-NULL on PCC", {
       invokeRestart("muffleWarning")
     }
   )
-  expect_true(any(grepl("deprecated", msgs, ignore.case = TRUE)))
   expect_true(any(grepl(
     "sendEmail.*ignored|ignored.*sendEmail|PCC always",
     msgs
@@ -353,13 +331,10 @@ test_that("showInvited returns NA for invitation records missing email and expir
     )
   })
 
-  expect_warning(
-    result <- showInvited(
-      appDir = app_dir,
-      account = "myaccount",
-      server = "connect.posit.cloud"
-    ),
-    regexp = "deprecated"
+  result <- showInvited(
+    appDir = app_dir,
+    account = "myaccount",
+    server = "connect.posit.cloud"
   )
   expect_s3_class(result, "data.frame")
   expect_equal(nrow(result), 1L)
@@ -393,21 +368,18 @@ test_that("showUsers aborts with a clear message when a user record has neither 
     )
   })
 
-  # The deprecation warn fires first; the abort follows inside showUsers_impl.
-  expect_warning(
-    expect_error(
-      showUsers(
-        appDir = app_dir,
-        account = "myaccount",
-        server = "connect.posit.cloud"
-      ),
-      regexp = "Unexpected response from Posit Connect Cloud"
+  # The abort is raised inside showUsers_impl.
+  expect_error(
+    showUsers(
+      appDir = app_dir,
+      account = "myaccount",
+      server = "connect.posit.cloud"
     ),
-    regexp = "deprecated"
+    regexp = "Unexpected response from Posit Connect Cloud"
   )
 })
 
-test_that("showUsers errors on non-shinyapps non-PCC server without emitting deprecation", {
+test_that("showUsers errors on a non-shinyapps, non-PCC server", {
   local_temp_config()
   addTestServer(
     url = "https://connect.example.com",
@@ -415,27 +387,17 @@ test_that("showUsers errors on non-shinyapps non-PCC server without emitting dep
   )
   addTestAccount("myaccount", server = "connect.example.com")
 
-  saw_deprecation <- FALSE
   expect_error(
-    withCallingHandlers(
-      showUsers(
-        appName = "myapp",
-        account = "myaccount",
-        server = "connect.example.com"
-      ),
-      warning = function(w) {
-        if (grepl("deprecated", conditionMessage(w), ignore.case = TRUE)) {
-          saw_deprecation <<- TRUE
-        }
-        invokeRestart("muffleWarning")
-      }
+    showUsers(
+      appName = "myapp",
+      account = "myaccount",
+      server = "connect.example.com"
     ),
     regexp = "shinyapps\\.io"
   )
-  expect_false(saw_deprecation)
 })
 
-test_that("resendInvitation emits deprecation and calls resendApplicationInvitation on PCC", {
+test_that("resendInvitation calls resendApplicationInvitation on PCC", {
   local_temp_config()
   addTestServer(
     url = "https://connect.posit.cloud",
@@ -469,14 +431,11 @@ test_that("resendInvitation emits deprecation and calls resendApplicationInvitat
     )
   })
 
-  expect_warning(
-    resendInvitation(
-      "alice@example.com",
-      appDir = app_dir,
-      account = "myaccount",
-      server = "connect.posit.cloud"
-    ),
-    regexp = "deprecated"
+  resendInvitation(
+    "alice@example.com",
+    appDir = app_dir,
+    account = "myaccount",
+    server = "connect.posit.cloud"
   )
   expect_equal(resent_id, "invite-uuid-1")
 })
@@ -508,13 +467,10 @@ test_that("resolveContentTarget uses deployment-record appId on PCC, not title",
     )
   })
 
-  expect_warning(
-    showUsers(
-      appDir = app_dir,
-      account = "myaccount",
-      server = "connect.posit.cloud"
-    ),
-    regexp = "deprecated"
+  showUsers(
+    appDir = app_dir,
+    account = "myaccount",
+    server = "connect.posit.cloud"
   )
   expect_equal(captured_app_id, "content-uuid-abc")
 })
@@ -576,14 +532,11 @@ test_that("resolveContentTarget: appName selects correct record among multiple i
     )
   })
 
-  expect_warning(
-    showUsers(
-      appDir = app_dir,
-      appName = "b",
-      account = "myaccount",
-      server = "connect.posit.cloud"
-    ),
-    regexp = "deprecated"
+  showUsers(
+    appDir = app_dir,
+    appName = "b",
+    account = "myaccount",
+    server = "connect.posit.cloud"
   )
   expect_equal(captured_app_id, "content-uuid-bbb")
 })
@@ -642,13 +595,10 @@ test_that("resolveContentTarget delegates to resolveApplication on shinyapps.io"
     )
   })
 
-  expect_warning(
-    showUsers(
-      appName = "myapp",
-      account = "myaccount",
-      server = "shinyapps.io"
-    ),
-    regexp = "deprecated"
+  showUsers(
+    appName = "myapp",
+    account = "myaccount",
+    server = "shinyapps.io"
   )
   expect_equal(captured_app_id, 42L)
 })
@@ -697,15 +647,12 @@ test_that("removeAuthorizedUser resolves content target exactly once (no double 
     )
   })
 
-  expect_warning(
-    removeAuthorizedUser(
-      "alice@example.com",
-      appDir = app_dir,
-      appName = "b",
-      account = "myaccount",
-      server = "connect.posit.cloud"
-    ),
-    regexp = "deprecated"
+  removeAuthorizedUser(
+    "alice@example.com",
+    appDir = app_dir,
+    appName = "b",
+    account = "myaccount",
+    server = "connect.posit.cloud"
   )
   # clientForAccount built exactly once → content resolved exactly once
   expect_equal(client_build_count, 1L)
@@ -747,14 +694,11 @@ test_that("removeAuthorizedUser resolves by UUID id on PCC (not email-only fallb
     )
   })
 
-  expect_warning(
-    removeAuthorizedUser(
-      "user-uuid-abc",
-      appDir = app_dir,
-      account = "myaccount",
-      server = "connect.posit.cloud"
-    ),
-    regexp = "deprecated"
+  removeAuthorizedUser(
+    "user-uuid-abc",
+    appDir = app_dir,
+    account = "myaccount",
+    server = "connect.posit.cloud"
   )
   expect_equal(removed_user_id, "user-uuid-abc")
 })
@@ -796,14 +740,11 @@ test_that("removeAuthorizedUser matches by email when another record has no emai
     )
   })
 
-  expect_warning(
-    removeAuthorizedUser(
-      "alice@example.com",
-      appDir = app_dir,
-      account = "myaccount",
-      server = "connect.posit.cloud"
-    ),
-    regexp = "deprecated"
+  removeAuthorizedUser(
+    "alice@example.com",
+    appDir = app_dir,
+    account = "myaccount",
+    server = "connect.posit.cloud"
   )
   expect_equal(removed_user_id, "id-alice")
 })
@@ -844,14 +785,11 @@ test_that("resendInvitation resolves by UUID invite id on PCC (not email-only fa
     )
   })
 
-  expect_warning(
-    resendInvitation(
-      "invite-uuid-xyz",
-      appDir = app_dir,
-      account = "myaccount",
-      server = "connect.posit.cloud"
-    ),
-    regexp = "deprecated"
+  resendInvitation(
+    "invite-uuid-xyz",
+    appDir = app_dir,
+    account = "myaccount",
+    server = "connect.posit.cloud"
   )
   expect_equal(resent_id, "invite-uuid-xyz")
 })
@@ -882,17 +820,14 @@ test_that("removeAuthorizedUser aborts with clear message when matched user has 
     )
   })
 
-  expect_warning(
-    expect_error(
-      removeAuthorizedUser(
-        "alice@example.com",
-        appDir = app_dir,
-        account = "myaccount",
-        server = "connect.posit.cloud"
-      ),
-      regexp = "no id"
+  expect_error(
+    removeAuthorizedUser(
+      "alice@example.com",
+      appDir = app_dir,
+      account = "myaccount",
+      server = "connect.posit.cloud"
     ),
-    regexp = "deprecated"
+    regexp = "no id"
   )
 })
 
@@ -922,17 +857,14 @@ test_that("removeAuthorizedUser hints at redaction when the user cannot be match
     )
   })
 
-  expect_warning(
-    expect_error(
-      removeAuthorizedUser(
-        "alice@example.com",
-        appDir = app_dir,
-        account = "myaccount",
-        server = "connect.posit.cloud"
-      ),
-      regexp = "redacted"
+  expect_error(
+    removeAuthorizedUser(
+      "alice@example.com",
+      appDir = app_dir,
+      account = "myaccount",
+      server = "connect.posit.cloud"
     ),
-    regexp = "deprecated"
+    regexp = "redacted"
   )
 })
 
@@ -1003,17 +935,14 @@ test_that("resendInvitation aborts with clear message when matched invitation ha
     )
   })
 
-  expect_warning(
-    expect_error(
-      resendInvitation(
-        "alice@example.com",
-        appDir = app_dir,
-        account = "myaccount",
-        server = "connect.posit.cloud"
-      ),
-      regexp = "no id"
+  expect_error(
+    resendInvitation(
+      "alice@example.com",
+      appDir = app_dir,
+      account = "myaccount",
+      server = "connect.posit.cloud"
     ),
-    regexp = "deprecated"
+    regexp = "no id"
   )
 })
 
@@ -1047,14 +976,11 @@ test_that("cleanupPasswordFile is NOT called on PCC accounts", {
     }
   )
 
-  expect_warning(
-    addAuthorizedUser(
-      "alice@example.com",
-      appDir = app_dir,
-      account = "myaccount",
-      server = "connect.posit.cloud"
-    ),
-    regexp = "deprecated"
+  addAuthorizedUser(
+    "alice@example.com",
+    appDir = app_dir,
+    account = "myaccount",
+    server = "connect.posit.cloud"
   )
   expect_false(cleanup_called)
 })

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -244,7 +244,7 @@ test_that("showInvited returns NA for invitation records missing email and expir
   expect_true(is.na(result$expired))
 })
 
-test_that("showUsers returns NA for user records with absent id and email fields", {
+test_that("showUsers aborts with a clear message when a user record has neither id nor email", {
   local_temp_config()
   addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
   addTestAccount("myaccount", server = "connect.posit.cloud")
@@ -261,24 +261,24 @@ test_that("showUsers returns NA for user records with absent id and email fields
   local_mocked_bindings(clientForAccount = function(...) {
     list(
       listApplicationAuthorization = function(appId) {
-        # record with no user$id or user$email fields
+        # record with no user$id or user$email fields — unexpected shape
         list(list(user = list()))
       }
     )
   })
 
+  # The deprecation warn fires first; the abort follows inside showUsers_impl.
   expect_warning(
-    result <- showUsers(
-      appDir = app_dir,
-      account = "myaccount",
-      server = "connect.posit.cloud"
+    expect_error(
+      showUsers(
+        appDir = app_dir,
+        account = "myaccount",
+        server = "connect.posit.cloud"
+      ),
+      regexp = "Unexpected response from Connect Cloud"
     ),
     regexp = "deprecated"
   )
-  expect_s3_class(result, "data.frame")
-  expect_equal(nrow(result), 1L)
-  expect_true(is.na(result$id))
-  expect_true(is.na(result$email))
 })
 
 test_that("showUsers errors on non-shinyapps non-PCC server without emitting deprecation", {

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -475,6 +475,51 @@ test_that("resolveContentTarget uses deployment-record appId on PCC, not title",
   expect_equal(captured_app_id, "content-uuid-abc")
 })
 
+test_that("contentId targets PCC content directly without a deployment record", {
+  local_temp_config()
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  app_dir <- withr::local_tempdir()
+  # No addTestDeployment — contentId must not require a local record.
+
+  captured_app_id <- NULL
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplicationAuthorization = function(appId) {
+        captured_app_id <<- appId
+        list()
+      }
+    )
+  })
+
+  showUsers(
+    appDir = app_dir,
+    contentId = "content-uuid-direct",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+  expect_equal(captured_app_id, "content-uuid-direct")
+})
+
+test_that("contentId is rejected on shinyapps.io", {
+  local_temp_config()
+  addTestServer(url = "https://shinyapps.io", name = "shinyapps.io")
+  addTestAccount("myaccount", server = "shinyapps.io")
+
+  expect_error(
+    showUsers(
+      contentId = "content-uuid-direct",
+      account = "myaccount",
+      server = "shinyapps.io"
+    ),
+    regexp = "only supported on Posit Connect Cloud"
+  )
+})
+
 test_that("resolveContentTarget aborts with clear message on PCC when no deployment record", {
   local_temp_config()
   addTestServer(

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -169,6 +169,36 @@ test_that("showUsers on shinyapps.io returns only id/email/account columns (no d
   expect_equal(result$account, "alice-account")
 })
 
+test_that("showUsers names shinyapps.io (not Connect Cloud) in the malformed-record error", {
+  local_temp_config()
+  addTestServer(url = "https://shinyapps.io", name = "shinyapps.io")
+  addTestAccount("myaccount", server = "shinyapps.io")
+
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplications = function(accountId, ...) {
+        list(list(name = "myapp", id = 42L))
+      },
+      listApplicationAuthorization = function(appId) {
+        # record with neither id nor email — unexpected shape
+        list(list(user = list()))
+      }
+    )
+  })
+
+  expect_warning(
+    expect_error(
+      showUsers(
+        appName = "myapp",
+        account = "myaccount",
+        server = "shinyapps.io"
+      ),
+      regexp = "Unexpected response from shinyapps\\.io"
+    ),
+    regexp = "deprecated"
+  )
+})
+
 test_that("addAuthorizedUser emits deprecation and calls inviteApplicationUser on PCC", {
   local_temp_config()
   addTestServer(
@@ -727,6 +757,55 @@ test_that("removeAuthorizedUser resolves by UUID id on PCC (not email-only fallb
     regexp = "deprecated"
   )
   expect_equal(removed_user_id, "user-uuid-abc")
+})
+
+test_that("removeAuthorizedUser matches by email when another record has no email", {
+  # Regression: a co-listed record with a redacted (NA) email made the logical
+  # subset `users[users$email == user, ]` include a phantom NA row, so the later
+  # `is.na(user$id)` check saw length > 1 and errored. which() drops the NA.
+  local_temp_config()
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
+  removed_user_id <- NULL
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplicationAuthorization = function(appId) {
+        list(
+          list(user = list(id = "id-alice", email = "alice@example.com")),
+          # A second member whose email is redacted (absent) on PCC.
+          list(user = list(id = "id-redacted", email = NULL))
+        )
+      },
+      removeApplicationUser = function(appId, userId) {
+        removed_user_id <<- userId
+        invisible(TRUE)
+      }
+    )
+  })
+
+  expect_warning(
+    removeAuthorizedUser(
+      "alice@example.com",
+      appDir = app_dir,
+      account = "myaccount",
+      server = "connect.posit.cloud"
+    ),
+    regexp = "deprecated"
+  )
+  expect_equal(removed_user_id, "id-alice")
 })
 
 test_that("resendInvitation resolves by UUID invite id on PCC (not email-only fallback)", {

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -3,11 +3,17 @@ test_that("showUsers emits deprecation and returns data frame for PCC", {
   addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
   local_mocked_bindings(clientForAccount = function(...) {
     list(
-      listApplications = function(accountId, ...) {
-        list(list(name = "myapp", id = "content-uuid-123"))
-      },
       listApplicationAuthorization = function(appId) {
         list(
           list(user = list(id = "user-uuid-1", email = "alice@example.com")),
@@ -18,7 +24,7 @@ test_that("showUsers emits deprecation and returns data frame for PCC", {
   })
 
   expect_warning(
-    result <- showUsers(appName = "myapp", account = "myaccount",
+    result <- showUsers(appDir = app_dir, account = "myaccount",
                         server = "connect.posit.cloud"),
     regexp = "deprecated"
   )
@@ -32,12 +38,18 @@ test_that("removeAuthorizedUser emits deprecation and calls removeApplicationUse
   addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
   removed_user_id <- NULL
   local_mocked_bindings(clientForAccount = function(...) {
     list(
-      listApplications = function(accountId, ...) {
-        list(list(name = "myapp", id = "content-uuid-123"))
-      },
       listApplicationAuthorization = function(appId) {
         list(list(user = list(id = "user-uuid-1", email = "alice@example.com")))
       },
@@ -49,7 +61,7 @@ test_that("removeAuthorizedUser emits deprecation and calls removeApplicationUse
   })
 
   expect_warning(
-    removeAuthorizedUser("alice@example.com", appName = "myapp",
+    removeAuthorizedUser("alice@example.com", appDir = app_dir,
                           account = "myaccount", server = "connect.posit.cloud"),
     regexp = "deprecated"
   )
@@ -61,17 +73,23 @@ test_that("showUsers returns empty data frame with correct columns when no users
   addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
   local_mocked_bindings(clientForAccount = function(...) {
     list(
-      listApplications = function(accountId, ...) {
-        list(list(name = "myapp", id = "content-uuid-123"))
-      },
       listApplicationAuthorization = function(appId) list()
     )
   })
 
   expect_warning(
-    result <- showUsers(appName = "myapp", account = "myaccount",
+    result <- showUsers(appDir = app_dir, account = "myaccount",
                         server = "connect.posit.cloud"),
     regexp = "deprecated"
   )
@@ -85,12 +103,18 @@ test_that("addAuthorizedUser emits deprecation and calls inviteApplicationUser o
   addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
   invited <- list()
   local_mocked_bindings(clientForAccount = function(...) {
     list(
-      listApplications = function(accountId, ...) {
-        list(list(name = "myapp", id = "content-uuid-123"))
-      },
       inviteApplicationUser = function(appId, email, sendEmail, emailMessage) {
         invited[[length(invited) + 1]] <<- list(appId = appId, email = email)
         invisible(TRUE)
@@ -99,7 +123,7 @@ test_that("addAuthorizedUser emits deprecation and calls inviteApplicationUser o
   })
 
   expect_warning(
-    addAuthorizedUser("alice@example.com", appName = "myapp",
+    addAuthorizedUser("alice@example.com", appDir = app_dir,
                       account = "myaccount", server = "connect.posit.cloud"),
     regexp = "deprecated"
   )
@@ -112,11 +136,17 @@ test_that("showInvited emits deprecation and maps PCC email_address/is_expired f
   addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
   local_mocked_bindings(clientForAccount = function(...) {
     list(
-      listApplications = function(accountId, ...) {
-        list(list(name = "myapp", id = "content-uuid-123"))
-      },
       listApplicationInvitations = function(appId) {
         list(list(
           id = "invite-uuid-1",
@@ -128,7 +158,7 @@ test_that("showInvited emits deprecation and maps PCC email_address/is_expired f
   })
 
   expect_warning(
-    result <- showInvited(appName = "myapp", account = "myaccount",
+    result <- showInvited(appDir = app_dir, account = "myaccount",
                           server = "connect.posit.cloud"),
     regexp = "deprecated"
   )
@@ -142,11 +172,17 @@ test_that("addAuthorizedUser warns when sendEmail is non-NULL on PCC", {
   addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
   local_mocked_bindings(clientForAccount = function(...) {
     list(
-      listApplications = function(accountId, ...) {
-        list(list(name = "myapp", id = "content-uuid-123"))
-      },
       inviteApplicationUser = function(appId, email, sendEmail, emailMessage) {
         invisible(TRUE)
       }
@@ -157,7 +193,7 @@ test_that("addAuthorizedUser warns when sendEmail is non-NULL on PCC", {
   withCallingHandlers(
     addAuthorizedUser(
       "alice@example.com",
-      appName = "myapp",
+      appDir = app_dir,
       account = "myaccount",
       server = "connect.posit.cloud",
       sendEmail = FALSE
@@ -176,11 +212,17 @@ test_that("showInvited returns NA for invitation records missing email and expir
   addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
   local_mocked_bindings(clientForAccount = function(...) {
     list(
-      listApplications = function(accountId, ...) {
-        list(list(name = "myapp", id = "content-uuid-123"))
-      },
       listApplicationInvitations = function(appId) {
         # record with neither email_address/email nor is_expired/expired
         list(list(id = "invite-uuid-missing"))
@@ -190,7 +232,7 @@ test_that("showInvited returns NA for invitation records missing email and expir
 
   expect_warning(
     result <- showInvited(
-      appName = "myapp",
+      appDir = app_dir,
       account = "myaccount",
       server = "connect.posit.cloud"
     ),
@@ -207,11 +249,17 @@ test_that("showUsers returns NA for user records with absent id and email fields
   addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
   local_mocked_bindings(clientForAccount = function(...) {
     list(
-      listApplications = function(accountId, ...) {
-        list(list(name = "myapp", id = "content-uuid-123"))
-      },
       listApplicationAuthorization = function(appId) {
         # record with no user$id or user$email fields
         list(list(user = list()))
@@ -221,7 +269,7 @@ test_that("showUsers returns NA for user records with absent id and email fields
 
   expect_warning(
     result <- showUsers(
-      appName = "myapp",
+      appDir = app_dir,
       account = "myaccount",
       server = "connect.posit.cloud"
     ),
@@ -260,12 +308,18 @@ test_that("resendInvitation emits deprecation and calls resendApplicationInvitat
   addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "myapp",
+    appId = "content-uuid-123",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
   resent_id <- NULL
   local_mocked_bindings(clientForAccount = function(...) {
     list(
-      listApplications = function(accountId, ...) {
-        list(list(name = "myapp", id = "content-uuid-123"))
-      },
       listApplicationInvitations = function(appId) {
         list(list(
           id = "invite-uuid-1",
@@ -281,9 +335,81 @@ test_that("resendInvitation emits deprecation and calls resendApplicationInvitat
   })
 
   expect_warning(
-    resendInvitation("alice@example.com", appName = "myapp",
+    resendInvitation("alice@example.com", appDir = app_dir,
                      account = "myaccount", server = "connect.posit.cloud"),
     regexp = "deprecated"
   )
   expect_equal(resent_id, "invite-uuid-1")
+})
+
+test_that("resolveContentTarget uses deployment-record appId on PCC, not title", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  app_dir <- withr::local_tempdir()
+  addTestDeployment(
+    app_dir,
+    appName = "my-content",
+    appId = "content-uuid-abc",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+
+  captured_app_id <- NULL
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplicationAuthorization = function(appId) {
+        captured_app_id <<- appId
+        list()
+      }
+    )
+  })
+
+  expect_warning(
+    showUsers(appDir = app_dir, account = "myaccount", server = "connect.posit.cloud"),
+    regexp = "deprecated"
+  )
+  expect_equal(captured_app_id, "content-uuid-abc")
+})
+
+test_that("resolveContentTarget aborts with clear message on PCC when no deployment record", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  app_dir <- withr::local_tempdir()
+  # No addTestDeployment — no record exists
+
+  expect_error(
+    suppressWarnings(
+      showUsers(appDir = app_dir, account = "myaccount", server = "connect.posit.cloud")
+    ),
+    regexp = "No deployment record found"
+  )
+})
+
+test_that("resolveContentTarget delegates to resolveApplication on shinyapps.io", {
+  local_temp_config()
+  addTestServer(url = "https://shinyapps.io", name = "shinyapps.io")
+  addTestAccount("myaccount", server = "shinyapps.io")
+
+  captured_app_id <- NULL
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplications = function(accountId, ...) {
+        list(list(name = "myapp", id = 42L))
+      },
+      listApplicationAuthorization = function(appId) {
+        captured_app_id <<- appId
+        list()
+      }
+    )
+  })
+
+  expect_warning(
+    showUsers(appName = "myapp", account = "myaccount", server = "shinyapps.io"),
+    regexp = "deprecated"
+  )
+  expect_equal(captured_app_id, 42L)
 })

--- a/tests/testthat/test-client-connectCloud.R
+++ b/tests/testthat/test-client-connectCloud.R
@@ -638,3 +638,64 @@ test_that("listApplications() filters by exact name, not substring", {
   expect_equal(result[[1]]$id, "c1")
   expect_equal(result[[1]]$name, "my-app")
 })
+
+test_that("listApplicationAuthorization GETs /contents/{id}/users and returns parsed data", {
+  skip_if_not_installed("webfakes")
+
+  users_app <- webfakes::new_app()
+  users_app$use(webfakes::mw_json())
+  users_app$get("/contents/:id/users", function(req, res) {
+    res$set_status(200L)$send_json(
+      list(
+        data = list(
+          list(user = list(id = "user-uuid-1", email = "alice@example.com"), account = "acct-a"),
+          list(user = list(id = "user-uuid-2", email = "bob@example.com"),   account = "acct-b")
+        )
+      ),
+      auto_unbox = TRUE
+    )
+  })
+  app <- webfakes::new_app_process(users_app)
+  service <- parseHttpUrl(app$url())
+
+  authInfo <- list(
+    server = "connect.posit.cloud",
+    name = "some-user",
+    username = "some-user",
+    accountId = "123",
+    accessToken = "current-token",
+    refreshToken = "refresh-token"
+  )
+  client <- connectCloudClient(service, authInfo)
+
+  result <- client$listApplicationAuthorization("content-abc")
+  expect_equal(length(result), 2L)
+  expect_equal(result[[1]]$user$email, "alice@example.com")
+  expect_equal(result[[2]]$user$email, "bob@example.com")
+  expect_equal(result[[1]]$user$id,    "user-uuid-1")
+})
+
+test_that("removeApplicationUser DELETEs /contents/{id}/users/{userId} and returns TRUE", {
+  skip_if_not_installed("webfakes")
+
+  delete_app <- webfakes::new_app()
+  delete_app$use(webfakes::mw_json())
+  delete_app$delete("/contents/:id/users/:userId", function(req, res) {
+    res$set_status(200L)$send_json(list(), auto_unbox = TRUE)
+  })
+  app <- webfakes::new_app_process(delete_app)
+  service <- parseHttpUrl(app$url())
+
+  authInfo <- list(
+    server = "connect.posit.cloud",
+    name = "some-user",
+    username = "some-user",
+    accountId = "123",
+    accessToken = "current-token",
+    refreshToken = "refresh-token"
+  )
+  client <- connectCloudClient(service, authInfo)
+
+  result <- client$removeApplicationUser("content-abc", "user-uuid-1")
+  expect_true(result)
+})

--- a/tests/testthat/test-client-connectCloud.R
+++ b/tests/testthat/test-client-connectCloud.R
@@ -748,7 +748,7 @@ test_that("inviteApplicationUser sends null message field when emailMessage is N
     # jsonlite parses null back to NULL, so is.null(j$message) must be TRUE.
     has_email_inv <- is.list(j$email_invitations) && length(j$email_invitations) >= 1L
     has_addr <- identical(j$email_invitations[[1]]$email_address, "alice@example.com")
-    has_null_msg <- is.null(j$message)
+    has_null_msg <- is.null(j$message) && "message" %in% names(j)
     if (has_email_inv && has_addr && has_null_msg) {
       res$set_status(200L)$send_json(list(), auto_unbox = TRUE)
     } else {

--- a/tests/testthat/test-client-connectCloud.R
+++ b/tests/testthat/test-client-connectCloud.R
@@ -639,6 +639,51 @@ test_that("listApplications() filters by exact name, not substring", {
   expect_equal(result[[1]]$name, "my-app")
 })
 
+test_that("listApplications() requests a stable sort and drops deleted content", {
+  skip_if_not_installed("webfakes")
+
+  contents_app <- webfakes::new_app()
+  contents_app$use(webfakes::mw_json())
+  contents_app$get("/contents", function(req, res) {
+    # Reject if the stable-sort param is absent (paging regression guard).
+    if (!identical(req$query$order_by, "created_time")) {
+      res$set_status(400L)$send_json(
+        list(error = "order_by=created_time must be present"),
+        auto_unbox = TRUE
+      )
+      return()
+    }
+    res$set_status(200L)$send_json(
+      list(
+        data = list(
+          list(id = "c1", title = "active-app", state = "active"),
+          list(id = "c2", title = "deleted-app", state = "deleted")
+        ),
+        total = 2L
+      ),
+      auto_unbox = TRUE
+    )
+  })
+  app <- webfakes::local_app_process(contents_app)
+  service <- parseHttpUrl(app$url())
+
+  authInfo <- list(
+    server = "connect.posit.cloud",
+    name = "some-user",
+    username = "some-user",
+    accountId = "acct-1",
+    accessToken = "current-token",
+    refreshToken = "refresh-token"
+  )
+  client <- connectCloudClient(service, authInfo)
+
+  # order_by must have been sent (else the app 400s); deleted content is dropped.
+  result <- client$listApplications("acct-1")
+  expect_equal(length(result), 1L)
+  expect_equal(result[[1]]$id, "c1")
+  expect_equal(result[[1]]$name, "active-app")
+})
+
 test_that("listApplicationAuthorization GETs /contents/{id}/users and returns parsed data", {
   skip_if_not_installed("webfakes")
 
@@ -897,6 +942,14 @@ test_that("listApplicationAuthorization accumulates multiple pages", {
   users_app <- webfakes::new_app()
   users_app$use(webfakes::mw_json())
   users_app$get("/contents/:id/users", function(req, res) {
+    # Reject if the stable-sort param is absent (paging regression guard).
+    if (!identical(req$query$order_by, "created_time")) {
+      res$set_status(400L)$send_json(
+        list(error = "order_by=created_time must be present"),
+        auto_unbox = TRUE
+      )
+      return()
+    }
     offset <- as.integer(req$query$offset %||% "0")
     if (offset == 0L) {
       res$set_status(200L)$send_json(
@@ -944,10 +997,15 @@ test_that("listApplicationInvitations accumulates multiple pages and keeps accep
   inv_app <- webfakes::new_app()
   inv_app$use(webfakes::mw_json())
   inv_app$get("/contents/:id/invitations", function(req, res) {
-    # Reject if the required filter param is absent
-    if (!identical(req$query$accepted_time__isnull, "true")) {
+    # Reject if the required filter or stable-sort param is absent.
+    if (
+      !identical(req$query$accepted_time__isnull, "true") ||
+        !identical(req$query$order_by, "created_time")
+    ) {
       res$set_status(400L)$send_json(
-        list(error = "accepted_time__isnull=true must be present"),
+        list(
+          error = "accepted_time__isnull=true and order_by=created_time must be present"
+        ),
         auto_unbox = TRUE
       )
       return()

--- a/tests/testthat/test-client-connectCloud.R
+++ b/tests/testthat/test-client-connectCloud.R
@@ -553,3 +553,88 @@ test_that("withTokenRefreshRetry uses client_credentials when clientSecret is se
   expect_equal(call_count, 2)
   expect_true(register_called)
 })
+
+test_that("listApplications() paginates through multiple pages", {
+  skip_if_not_installed("webfakes")
+
+  allContents <- list(
+    list(id = "c1", title = "app-one"),
+    list(id = "c2", title = "app-two"),
+    list(id = "c3", title = "app-three")
+  )
+
+  contents_app <- webfakes::new_app()
+  contents_app$use(webfakes::mw_json())
+  # Serve at most 2 items per page regardless of the client's limit param,
+  # forcing two GET /contents requests to accumulate all 3 items.
+  contents_app$get("/contents", function(req, res) {
+    offset <- as.integer(req$query$offset)
+    remaining <- allContents[seq(offset + 1L, length(allContents))]
+    page <- remaining[seq_len(min(2L, length(remaining)))]
+    res$set_status(200L)$send_json(
+      list(data = page, total = length(allContents)),
+      auto_unbox = TRUE
+    )
+  })
+  app <- webfakes::new_app_process(contents_app)
+  service <- parseHttpUrl(app$url())
+
+  authInfo <- list(
+    server = "connect.posit.cloud",
+    name = "some-user",
+    username = "some-user",
+    accountId = "acct-1",
+    accessToken = "current-token",
+    refreshToken = "refresh-token"
+  )
+  client <- connectCloudClient(service, authInfo)
+
+  result <- client$listApplications("acct-1")
+  expect_equal(length(result), 3L)
+  expect_equal(
+    vapply(result, function(x) x$id, character(1)),
+    c("c1", "c2", "c3")
+  )
+  # name must be derived from title
+  expect_equal(
+    vapply(result, function(x) x$name, character(1)),
+    c("app-one", "app-two", "app-three")
+  )
+})
+
+test_that("listApplications() filters by exact name, not substring", {
+  skip_if_not_installed("webfakes")
+
+  allContents <- list(
+    list(id = "c1", title = "my-app"),
+    list(id = "c2", title = "my-app-extra"),
+    list(id = "c3", title = "other-app")
+  )
+
+  contents_app <- webfakes::new_app()
+  contents_app$use(webfakes::mw_json())
+  contents_app$get("/contents", function(req, res) {
+    res$set_status(200L)$send_json(
+      list(data = allContents, total = length(allContents)),
+      auto_unbox = TRUE
+    )
+  })
+  app <- webfakes::new_app_process(contents_app)
+  service <- parseHttpUrl(app$url())
+
+  authInfo <- list(
+    server = "connect.posit.cloud",
+    name = "some-user",
+    username = "some-user",
+    accountId = "acct-1",
+    accessToken = "current-token",
+    refreshToken = "refresh-token"
+  )
+  client <- connectCloudClient(service, authInfo)
+
+  # "my-app-extra" shares a prefix with "my-app"; exact match must exclude it.
+  result <- client$listApplications("acct-1", filters = list(name = "my-app"))
+  expect_equal(length(result), 1L)
+  expect_equal(result[[1]]$id, "c1")
+  expect_equal(result[[1]]$name, "my-app")
+})

--- a/tests/testthat/test-client-connectCloud.R
+++ b/tests/testthat/test-client-connectCloud.R
@@ -648,8 +648,14 @@ test_that("listApplicationAuthorization GETs /contents/{id}/users and returns pa
     res$set_status(200L)$send_json(
       list(
         data = list(
-          list(user = list(id = "user-uuid-1", email = "alice@example.com"), account = "acct-a"),
-          list(user = list(id = "user-uuid-2", email = "bob@example.com"),   account = "acct-b")
+          list(
+            user = list(id = "user-uuid-1", email = "alice@example.com"),
+            account = "acct-a"
+          ),
+          list(
+            user = list(id = "user-uuid-2", email = "bob@example.com"),
+            account = "acct-b"
+          )
         )
       ),
       auto_unbox = TRUE
@@ -672,7 +678,7 @@ test_that("listApplicationAuthorization GETs /contents/{id}/users and returns pa
   expect_equal(length(result), 2L)
   expect_equal(result[[1]]$user$email, "alice@example.com")
   expect_equal(result[[2]]$user$email, "bob@example.com")
-  expect_equal(result[[1]]$user$id,    "user-uuid-1")
+  expect_equal(result[[1]]$user$id, "user-uuid-1")
 })
 
 test_that("removeApplicationUser DELETEs /contents/{id}/users/{userId} and returns TRUE", {
@@ -708,14 +714,21 @@ test_that("inviteApplicationUser POSTs expected JSON fields to /contents/{id}/in
   invite_app$post("/contents/:id/invitations", function(req, res) {
     j <- req$json
     # Validate required payload shape; 400 forces a client error if the body is wrong
-    has_email_inv <- is.list(j$email_invitations) && length(j$email_invitations) >= 1L
-    has_addr <- identical(j$email_invitations[[1]]$email_address, "alice@example.com")
+    has_email_inv <- is.list(j$email_invitations) &&
+      length(j$email_invitations) >= 1L
+    has_addr <- identical(
+      j$email_invitations[[1]]$email_address,
+      "alice@example.com"
+    )
     has_recv_inv <- is.list(j$recipient_invitations)
     has_message <- identical(j$message, "Welcome!")
     if (has_email_inv && has_addr && has_recv_inv && has_message) {
       res$set_status(200L)$send_json(list(), auto_unbox = TRUE)
     } else {
-      res$set_status(400L)$send_json(list(error = "unexpected body shape"), auto_unbox = TRUE)
+      res$set_status(400L)$send_json(
+        list(error = "unexpected body shape"),
+        auto_unbox = TRUE
+      )
     }
   })
   app <- webfakes::new_app_process(invite_app)
@@ -732,7 +745,10 @@ test_that("inviteApplicationUser POSTs expected JSON fields to /contents/{id}/in
   client <- connectCloudClient(service, authInfo)
 
   result <- client$inviteApplicationUser(
-    "content-abc", "alice@example.com", TRUE, "Welcome!"
+    "content-abc",
+    "alice@example.com",
+    TRUE,
+    "Welcome!"
   )
   expect_true(result)
 })
@@ -746,8 +762,12 @@ test_that("inviteApplicationUser sends null message field when emailMessage is N
     j <- req$json
     # toJSON(list(message = NULL), null = "null") renders {"message":null,...};
     # jsonlite parses null back to NULL, so is.null(j$message) must be TRUE.
-    has_email_inv <- is.list(j$email_invitations) && length(j$email_invitations) >= 1L
-    has_addr <- identical(j$email_invitations[[1]]$email_address, "alice@example.com")
+    has_email_inv <- is.list(j$email_invitations) &&
+      length(j$email_invitations) >= 1L
+    has_addr <- identical(
+      j$email_invitations[[1]]$email_address,
+      "alice@example.com"
+    )
     has_null_msg <- is.null(j$message) && "message" %in% names(j)
     if (has_email_inv && has_addr && has_null_msg) {
       res$set_status(200L)$send_json(list(), auto_unbox = TRUE)
@@ -771,7 +791,12 @@ test_that("inviteApplicationUser sends null message field when emailMessage is N
   )
   client <- connectCloudClient(service, authInfo)
 
-  result <- client$inviteApplicationUser("content-abc", "alice@example.com", TRUE, NULL)
+  result <- client$inviteApplicationUser(
+    "content-abc",
+    "alice@example.com",
+    TRUE,
+    NULL
+  )
   expect_true(result)
 })
 
@@ -786,7 +811,11 @@ test_that("listApplicationInvitations GETs /contents/{id}/invitations?accepted_t
       res$set_status(200L)$send_json(
         list(
           data = list(
-            list(id = "inv-1", email_address = "bob@example.com", is_expired = FALSE)
+            list(
+              id = "inv-1",
+              email_address = "bob@example.com",
+              is_expired = FALSE
+            )
           )
         ),
         auto_unbox = TRUE
@@ -885,8 +914,12 @@ test_that("listApplicationAuthorization accumulates multiple pages", {
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(
-    server = "connect.posit.cloud", name = "some-user", username = "some-user",
-    accountId = "123", accessToken = "tok", refreshToken = "ref"
+    server = "connect.posit.cloud",
+    name = "some-user",
+    username = "some-user",
+    accountId = "123",
+    accessToken = "tok",
+    refreshToken = "ref"
   )
   client <- connectCloudClient(service, authInfo)
 
@@ -936,8 +969,12 @@ test_that("listApplicationInvitations accumulates multiple pages and keeps accep
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(
-    server = "connect.posit.cloud", name = "some-user", username = "some-user",
-    accountId = "123", accessToken = "tok", refreshToken = "ref"
+    server = "connect.posit.cloud",
+    name = "some-user",
+    username = "some-user",
+    accountId = "123",
+    accessToken = "tok",
+    refreshToken = "ref"
   )
   client <- connectCloudClient(service, authInfo)
 

--- a/tests/testthat/test-client-connectCloud.R
+++ b/tests/testthat/test-client-connectCloud.R
@@ -711,7 +711,8 @@ test_that("inviteApplicationUser POSTs expected JSON fields to /contents/{id}/in
     has_email_inv <- is.list(j$email_invitations) && length(j$email_invitations) >= 1L
     has_addr <- identical(j$email_invitations[[1]]$email_address, "alice@example.com")
     has_recv_inv <- is.list(j$recipient_invitations)
-    if (has_email_inv && has_addr && has_recv_inv) {
+    has_message <- identical(j$message, "Welcome!")
+    if (has_email_inv && has_addr && has_recv_inv && has_message) {
       res$set_status(200L)$send_json(list(), auto_unbox = TRUE)
     } else {
       res$set_status(400L)$send_json(list(error = "unexpected body shape"), auto_unbox = TRUE)
@@ -733,6 +734,44 @@ test_that("inviteApplicationUser POSTs expected JSON fields to /contents/{id}/in
   result <- client$inviteApplicationUser(
     "content-abc", "alice@example.com", TRUE, "Welcome!"
   )
+  expect_true(result)
+})
+
+test_that("inviteApplicationUser sends null message field when emailMessage is NULL", {
+  skip_if_not_installed("webfakes")
+
+  null_msg_app <- webfakes::new_app()
+  null_msg_app$use(webfakes::mw_json())
+  null_msg_app$post("/contents/:id/invitations", function(req, res) {
+    j <- req$json
+    # toJSON(list(message = NULL), null = "null") renders {"message":null,...};
+    # jsonlite parses null back to NULL, so is.null(j$message) must be TRUE.
+    has_email_inv <- is.list(j$email_invitations) && length(j$email_invitations) >= 1L
+    has_addr <- identical(j$email_invitations[[1]]$email_address, "alice@example.com")
+    has_null_msg <- is.null(j$message)
+    if (has_email_inv && has_addr && has_null_msg) {
+      res$set_status(200L)$send_json(list(), auto_unbox = TRUE)
+    } else {
+      res$set_status(400L)$send_json(
+        list(error = "expected null message field"),
+        auto_unbox = TRUE
+      )
+    }
+  })
+  app <- webfakes::new_app_process(null_msg_app)
+  service <- parseHttpUrl(app$url())
+
+  authInfo <- list(
+    server = "connect.posit.cloud",
+    name = "some-user",
+    username = "some-user",
+    accountId = "123",
+    accessToken = "current-token",
+    refreshToken = "refresh-token"
+  )
+  client <- connectCloudClient(service, authInfo)
+
+  result <- client$inviteApplicationUser("content-abc", "alice@example.com", TRUE, NULL)
   expect_true(result)
 })
 

--- a/tests/testthat/test-client-connectCloud.R
+++ b/tests/testthat/test-client-connectCloud.R
@@ -28,7 +28,7 @@ test_that("awaitCompletion", {
       auto_unbox = TRUE
     )
   })
-  app <- webfakes::new_app_process(revision_app)
+  app <- webfakes::local_app_process(revision_app)
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(
@@ -87,7 +87,7 @@ test_that("awaitCompletion falls back to an empty url instead of erroring when t
       auto_unbox = TRUE
     )
   })
-  app <- webfakes::new_app_process(revision_app)
+  app <- webfakes::local_app_process(revision_app)
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(
@@ -132,7 +132,7 @@ test_that("awaitCompletion shows a specific message when content was deleted rig
       auto_unbox = TRUE
     )
   })
-  app <- webfakes::new_app_process(revision_app)
+  app <- webfakes::local_app_process(revision_app)
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(
@@ -172,7 +172,7 @@ test_that("getAccounts() paginates through multiple pages", {
       auto_unbox = TRUE
     )
   })
-  app <- webfakes::new_app_process(accounts_app)
+  app <- webfakes::local_app_process(accounts_app)
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(
@@ -224,7 +224,7 @@ test_that("awaitCompletion handles failure", {
       auto_unbox = TRUE
     )
   })
-  app <- webfakes::new_app_process(revision_app)
+  app <- webfakes::local_app_process(revision_app)
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(
@@ -315,8 +315,8 @@ test_that("awaitCompletion handles failure with logs", {
   })
 
   # Start the main app and logs app
-  app <- webfakes::new_app_process(cloudApiApp)
-  logs_app_process <- webfakes::new_app_process(logs_app)
+  app <- webfakes::local_app_process(cloudApiApp)
+  logs_app_process <- webfakes::local_app_process(logs_app)
 
   service <- parseHttpUrl(app$url())
   authInfo <- list(
@@ -576,7 +576,7 @@ test_that("listApplications() paginates through multiple pages", {
       auto_unbox = TRUE
     )
   })
-  app <- webfakes::new_app_process(contents_app)
+  app <- webfakes::local_app_process(contents_app)
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(
@@ -619,7 +619,7 @@ test_that("listApplications() filters by exact name, not substring", {
       auto_unbox = TRUE
     )
   })
-  app <- webfakes::new_app_process(contents_app)
+  app <- webfakes::local_app_process(contents_app)
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(
@@ -661,7 +661,7 @@ test_that("listApplicationAuthorization GETs /contents/{id}/users and returns pa
       auto_unbox = TRUE
     )
   })
-  app <- webfakes::new_app_process(users_app)
+  app <- webfakes::local_app_process(users_app)
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(
@@ -689,7 +689,7 @@ test_that("removeApplicationUser DELETEs /contents/{id}/users/{userId} and retur
   delete_app$delete("/contents/:id/users/:userId", function(req, res) {
     res$set_status(200L)$send_json(list(), auto_unbox = TRUE)
   })
-  app <- webfakes::new_app_process(delete_app)
+  app <- webfakes::local_app_process(delete_app)
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(
@@ -731,7 +731,7 @@ test_that("inviteApplicationUser POSTs expected JSON fields to /contents/{id}/in
       )
     }
   })
-  app <- webfakes::new_app_process(invite_app)
+  app <- webfakes::local_app_process(invite_app)
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(
@@ -778,7 +778,7 @@ test_that("inviteApplicationUser sends null message field when emailMessage is N
       )
     }
   })
-  app <- webfakes::new_app_process(null_msg_app)
+  app <- webfakes::local_app_process(null_msg_app)
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(
@@ -827,7 +827,7 @@ test_that("listApplicationInvitations GETs /contents/{id}/invitations?accepted_t
       )
     }
   })
-  app <- webfakes::new_app_process(list_app)
+  app <- webfakes::local_app_process(list_app)
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(
@@ -865,7 +865,7 @@ test_that("resendApplicationInvitation sends {} (object not array) to /content_i
       )
     }
   })
-  app <- webfakes::new_app_process(resend_app)
+  app <- webfakes::local_app_process(resend_app)
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(
@@ -910,7 +910,7 @@ test_that("listApplicationAuthorization accumulates multiple pages", {
       )
     }
   })
-  app <- webfakes::new_app_process(users_app)
+  app <- webfakes::local_app_process(users_app)
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(
@@ -965,7 +965,7 @@ test_that("listApplicationInvitations accumulates multiple pages and keeps accep
       )
     }
   })
-  app <- webfakes::new_app_process(inv_app)
+  app <- webfakes::local_app_process(inv_app)
   service <- parseHttpUrl(app$url())
 
   authInfo <- list(

--- a/tests/testthat/test-client-connectCloud.R
+++ b/tests/testthat/test-client-connectCloud.R
@@ -852,3 +852,98 @@ test_that("resendApplicationInvitation sends {} (object not array) to /content_i
   result <- client$resendApplicationInvitation("inv-uuid-1", FALSE)
   expect_true(result)
 })
+
+test_that("listApplicationAuthorization accumulates multiple pages", {
+  skip_if_not_installed("webfakes")
+
+  # Page 1: 2 users. Page 2: 1 user. Total=3 reported on each page.
+  page1 <- list(
+    list(user = list(id = "u1", email = "a@example.com"), account = "acct-a"),
+    list(user = list(id = "u2", email = "b@example.com"), account = "acct-b")
+  )
+  page2 <- list(
+    list(user = list(id = "u3", email = "c@example.com"), account = "acct-c")
+  )
+
+  users_app <- webfakes::new_app()
+  users_app$use(webfakes::mw_json())
+  users_app$get("/contents/:id/users", function(req, res) {
+    offset <- as.integer(req$query$offset %||% "0")
+    if (offset == 0L) {
+      res$set_status(200L)$send_json(
+        list(data = page1, total = 3L),
+        auto_unbox = TRUE
+      )
+    } else {
+      res$set_status(200L)$send_json(
+        list(data = page2, total = 3L),
+        auto_unbox = TRUE
+      )
+    }
+  })
+  app <- webfakes::new_app_process(users_app)
+  service <- parseHttpUrl(app$url())
+
+  authInfo <- list(
+    server = "connect.posit.cloud", name = "some-user", username = "some-user",
+    accountId = "123", accessToken = "tok", refreshToken = "ref"
+  )
+  client <- connectCloudClient(service, authInfo)
+
+  result <- client$listApplicationAuthorization("content-abc")
+  expect_equal(length(result), 3L)
+  expect_equal(result[[1]]$user$id, "u1")
+  expect_equal(result[[2]]$user$id, "u2")
+  expect_equal(result[[3]]$user$id, "u3")
+})
+
+test_that("listApplicationInvitations accumulates multiple pages and keeps accepted_time__isnull filter", {
+  skip_if_not_installed("webfakes")
+
+  page1 <- list(
+    list(id = "inv-1", email_address = "a@example.com", is_expired = FALSE),
+    list(id = "inv-2", email_address = "b@example.com", is_expired = FALSE)
+  )
+  page2 <- list(
+    list(id = "inv-3", email_address = "c@example.com", is_expired = TRUE)
+  )
+
+  inv_app <- webfakes::new_app()
+  inv_app$use(webfakes::mw_json())
+  inv_app$get("/contents/:id/invitations", function(req, res) {
+    # Reject if the required filter param is absent
+    if (!identical(req$query$accepted_time__isnull, "true")) {
+      res$set_status(400L)$send_json(
+        list(error = "accepted_time__isnull=true must be present"),
+        auto_unbox = TRUE
+      )
+      return()
+    }
+    offset <- as.integer(req$query$offset %||% "0")
+    if (offset == 0L) {
+      res$set_status(200L)$send_json(
+        list(data = page1, total = 3L),
+        auto_unbox = TRUE
+      )
+    } else {
+      res$set_status(200L)$send_json(
+        list(data = page2, total = 3L),
+        auto_unbox = TRUE
+      )
+    }
+  })
+  app <- webfakes::new_app_process(inv_app)
+  service <- parseHttpUrl(app$url())
+
+  authInfo <- list(
+    server = "connect.posit.cloud", name = "some-user", username = "some-user",
+    accountId = "123", accessToken = "tok", refreshToken = "ref"
+  )
+  client <- connectCloudClient(service, authInfo)
+
+  result <- client$listApplicationInvitations("content-abc")
+  expect_equal(length(result), 3L)
+  expect_equal(result[[1]]$id, "inv-1")
+  expect_equal(result[[2]]$id, "inv-2")
+  expect_equal(result[[3]]$id, "inv-3")
+})

--- a/tests/testthat/test-client-connectCloud.R
+++ b/tests/testthat/test-client-connectCloud.R
@@ -699,3 +699,117 @@ test_that("removeApplicationUser DELETEs /contents/{id}/users/{userId} and retur
   result <- client$removeApplicationUser("content-abc", "user-uuid-1")
   expect_true(result)
 })
+
+test_that("inviteApplicationUser POSTs expected JSON fields to /contents/{id}/invitations", {
+  skip_if_not_installed("webfakes")
+
+  invite_app <- webfakes::new_app()
+  invite_app$use(webfakes::mw_json())
+  invite_app$post("/contents/:id/invitations", function(req, res) {
+    j <- req$json
+    # Validate required payload shape; 400 forces a client error if the body is wrong
+    has_email_inv <- is.list(j$email_invitations) && length(j$email_invitations) >= 1L
+    has_addr <- identical(j$email_invitations[[1]]$email_address, "alice@example.com")
+    has_recv_inv <- is.list(j$recipient_invitations)
+    if (has_email_inv && has_addr && has_recv_inv) {
+      res$set_status(200L)$send_json(list(), auto_unbox = TRUE)
+    } else {
+      res$set_status(400L)$send_json(list(error = "unexpected body shape"), auto_unbox = TRUE)
+    }
+  })
+  app <- webfakes::new_app_process(invite_app)
+  service <- parseHttpUrl(app$url())
+
+  authInfo <- list(
+    server = "connect.posit.cloud",
+    name = "some-user",
+    username = "some-user",
+    accountId = "123",
+    accessToken = "current-token",
+    refreshToken = "refresh-token"
+  )
+  client <- connectCloudClient(service, authInfo)
+
+  result <- client$inviteApplicationUser(
+    "content-abc", "alice@example.com", TRUE, "Welcome!"
+  )
+  expect_true(result)
+})
+
+test_that("listApplicationInvitations GETs /contents/{id}/invitations?accepted_time__isnull=true", {
+  skip_if_not_installed("webfakes")
+
+  list_app <- webfakes::new_app()
+  list_app$use(webfakes::mw_json())
+  list_app$get("/contents/:id/invitations", function(req, res) {
+    # 400 if the required filter query param is absent or wrong
+    if (identical(req$query$accepted_time__isnull, "true")) {
+      res$set_status(200L)$send_json(
+        list(
+          data = list(
+            list(id = "inv-1", email_address = "bob@example.com", is_expired = FALSE)
+          )
+        ),
+        auto_unbox = TRUE
+      )
+    } else {
+      res$set_status(400L)$send_json(
+        list(error = "accepted_time__isnull=true must be present"),
+        auto_unbox = TRUE
+      )
+    }
+  })
+  app <- webfakes::new_app_process(list_app)
+  service <- parseHttpUrl(app$url())
+
+  authInfo <- list(
+    server = "connect.posit.cloud",
+    name = "some-user",
+    username = "some-user",
+    accountId = "123",
+    accessToken = "current-token",
+    refreshToken = "refresh-token"
+  )
+  client <- connectCloudClient(service, authInfo)
+
+  result <- client$listApplicationInvitations("content-abc")
+
+  expect_equal(length(result), 1L)
+  expect_equal(result[[1]]$id, "inv-1")
+  expect_equal(result[[1]]$email_address, "bob@example.com")
+})
+
+test_that("resendApplicationInvitation sends {} (object not array) to /content_invitations/{id}/resend", {
+  skip_if_not_installed("webfakes")
+
+  resend_app <- webfakes::new_app()
+  resend_app$use(webfakes::mw_json())
+  resend_app$post("/content_invitations/:id/resend", function(req, res) {
+    j <- req$json
+    # {} parses to a named empty list; [] parses to an unnamed empty list
+    # 400 if setNames(list(), character(0)) somehow regressed to list()
+    if (is.list(j) && length(j) == 0L && !is.null(names(j))) {
+      res$set_status(200L)$send_json(list(), auto_unbox = TRUE)
+    } else {
+      res$set_status(400L)$send_json(
+        list(error = "body must be JSON object {} not array []"),
+        auto_unbox = TRUE
+      )
+    }
+  })
+  app <- webfakes::new_app_process(resend_app)
+  service <- parseHttpUrl(app$url())
+
+  authInfo <- list(
+    server = "connect.posit.cloud",
+    name = "some-user",
+    username = "some-user",
+    accountId = "123",
+    accessToken = "current-token",
+    refreshToken = "refresh-token"
+  )
+  client <- connectCloudClient(service, authInfo)
+
+  result <- client$resendApplicationInvitation("inv-uuid-1", FALSE)
+  expect_true(result)
+})

--- a/tests/testthat/test-deploymentTarget.R
+++ b/tests/testthat/test-deploymentTarget.R
@@ -477,9 +477,10 @@ test_that("PCC deploy with no local record creates new content, not adopting sam
   addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
-  # getAppByName and shouldUpdateApp are mocked to prove they are NOT called on PCC:
-  # if the guard were absent, shouldUpdateApp = TRUE would produce appId = "existing-uuid-123"
-  # and the expect_null assertion below would fail.
+  # getAppByName is mocked to prove it is NOT called on PCC.
+  # Without the guard, getAppByName would return the existing app and forceUpdate = TRUE
+  # would adopt it (appId = "existing-uuid-123"). With the guard, getAppByName is
+  # never reached → falls through to create-new → appId = NULL.
   local_mocked_bindings(
     getAppByName = function(...) {
       data.frame(
@@ -488,8 +489,7 @@ test_that("PCC deploy with no local record creates new content, not adopting sam
         url = "https://connect.posit.cloud/myaccount/content/existing-uuid-123",
         stringsAsFactors = FALSE
       )
-    },
-    shouldUpdateApp = function(...) TRUE
+    }
   )
 
   app_dir <- dirCreate(file.path(withr::local_tempdir(), "my_app"))
@@ -503,6 +503,7 @@ test_that("PCC deploy with no local record creates new content, not adopting sam
   )
   # Guard skips getAppByName on PCC; falls through to createDeployment(appId = NULL)
   expect_null(target$deployment$appId)
+  expect_equal(target$deployment$name, "my_app")
 })
 
 # helpers -----------------------------------------------------------------

--- a/tests/testthat/test-deploymentTarget.R
+++ b/tests/testthat/test-deploymentTarget.R
@@ -474,7 +474,10 @@ test_that("can find existing application on shinyapps.io & not use it", {
 
 test_that("PCC deploy with no local record creates new content, not adopting same-titled existing", {
   local_temp_config()
-  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
   addTestAccount("myaccount", server = "connect.posit.cloud")
 
   # getAppByName is mocked to prove it is NOT called on PCC.

--- a/tests/testthat/test-deploymentTarget.R
+++ b/tests/testthat/test-deploymentTarget.R
@@ -472,6 +472,39 @@ test_that("can find existing application on shinyapps.io & not use it", {
   confirm_existing_app_not_used("shinyapps.io")
 })
 
+test_that("PCC deploy with no local record creates new content, not adopting same-titled existing", {
+  local_temp_config()
+  addTestServer(url = "https://connect.posit.cloud", name = "connect.posit.cloud")
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  # getAppByName and shouldUpdateApp are mocked to prove they are NOT called on PCC:
+  # if the guard were absent, shouldUpdateApp = TRUE would produce appId = "existing-uuid-123"
+  # and the expect_null assertion below would fail.
+  local_mocked_bindings(
+    getAppByName = function(...) {
+      data.frame(
+        name = "my_app",
+        id = "existing-uuid-123",
+        url = "https://connect.posit.cloud/myaccount/content/existing-uuid-123",
+        stringsAsFactors = FALSE
+      )
+    },
+    shouldUpdateApp = function(...) TRUE
+  )
+
+  app_dir <- dirCreate(file.path(withr::local_tempdir(), "my_app"))
+
+  target <- findDeploymentTarget(
+    app_dir,
+    appName = "my_app",
+    account = "myaccount",
+    server = "connect.posit.cloud",
+    forceUpdate = TRUE
+  )
+  # Guard skips getAppByName on PCC; falls through to createDeployment(appId = NULL)
+  expect_null(target$deployment$appId)
+})
+
 # helpers -----------------------------------------------------------------
 
 test_that("shouldUpdateApp errors when non-interactive", {


### PR DESCRIPTION
Adds Posit Connect Cloud (PCC) support to `applications()` and to the five collaborator-management functions (`addAuthorizedUser`, `removeAuthorizedUser`, `showUsers`, `showInvited`, `resendInvitation`), and soft-deprecates those five functions.

`applications()` previously aborted for PCC accounts; it now lists PCC content via a paginated content request and returns the same column shape as the other server types. The five collaborator functions gain PCC code paths for inviting, listing, and removing members and pending invitations. On PCC, these functions identify their target content by the local deployment record's content id rather than by application name.

The five collaborator functions are soft-deprecated with `lifecycle::deprecate_warn()`, firing once per call on both shinyapps.io and PCC.

### Notes for reviewers

- The deprecation message wording is a placeholder and will be finalized before release; the `when` version is the current development version and should be bumped to the release version before CRAN submission.
- On PCC, `sendEmail = FALSE` is not honored (the platform always emails invitees) and `showInvited()`/`resendInvitation()` cannot surface an invitation link/code.
- `showUsers()` and `showInvited()` now build their data frames with atomic columns on all backends, so ids are returned as character and empty results are typed zero-row data frames (a visible change for existing shinyapps.io callers, noted in NEWS).
