### PR TITLE
Add contentId argument to collaborator management functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,17 +12,14 @@
   `showInvited()`, and `resendInvitation()` now work with Posit Connect Cloud
   accounts in addition to ShinyApps. On Posit Connect Cloud, the `sendEmail`
   argument to `addAuthorizedUser()` is ignored because PCC always emails
-  invitees; a warning is emitted when it is explicitly set to `FALSE`.
+  invitees; a warning is emitted when it is explicitly set to `FALSE`. On Posit
+  Connect Cloud these functions also accept a `contentId` argument that targets
+  the content directly (the id is shown in the content URL and returned by
+  `applications()`), so a local deployment record is not required; `contentId`
+  is not supported on shinyapps.io.
 
 * `applications()` now supports Posit Connect Cloud accounts, returning a
   data frame with the same columns as for ShinyApps and Posit Connect accounts.
-
-* `addAuthorizedUser()`, `removeAuthorizedUser()`, `showUsers()`,
-  `showInvited()`, and `resendInvitation()` gain a `contentId` argument. On
-  Posit Connect Cloud, passing `contentId` targets the content directly, so a
-  local deployment record is no longer required; the id is shown in the content
-  URL and returned by `applications()`. `contentId` is not supported on
-  shinyapps.io.
 
 # rsconnect 1.11.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,13 @@
 * `applications()` now supports Posit Connect Cloud accounts, returning a
   data frame with the same columns as for ShinyApps and Posit Connect accounts.
 
+* `addAuthorizedUser()`, `removeAuthorizedUser()`, `showUsers()`,
+  `showInvited()`, and `resendInvitation()` gain a `contentId` argument. On
+  Posit Connect Cloud, passing `contentId` targets the content directly, so a
+  local deployment record is no longer required; the id is shown in the content
+  URL and returned by `applications()`. `contentId` is not supported on
+  shinyapps.io.
+
 # rsconnect 1.11.0
 
 * rsconnect checks whether a newer version of itself is available from your

--- a/R/auth.R
+++ b/R/auth.R
@@ -119,11 +119,19 @@ cleanupPasswordFile <- function(appDir) {
 }
 
 # Internal: resolve the target content for collaborator management functions.
-# On PCC, reads the local deployment record to get the content id (appId)
-# rather than matching by title (mutable, non-unique on PCC).
-# On shinyapps.io, delegates to resolveApplication() unchanged.
-resolveContentTarget <- function(accountDetails, appDir, appName) {
+# On PCC, an explicit contentId targets the content directly; otherwise reads
+# the local deployment record to get the content id (appId) rather than matching
+# by title (mutable, non-unique on PCC).
+# On shinyapps.io, delegates to resolveApplication() unchanged; contentId is
+# not supported there.
+resolveContentTarget <- function(accountDetails, appDir, appName, contentId = NULL) {
   if (isPositConnectCloudServer(accountDetails$server)) {
+    # An explicit content id targets PCC content directly, with no local
+    # deployment record required.
+    if (!is.null(contentId)) {
+      check_string(contentId)
+      return(list(id = contentId))
+    }
     recs <- deployments(
       appPath = appDir,
       accountFilter = accountDetails$name,
@@ -145,6 +153,12 @@ resolveContentTarget <- function(accountDetails, appDir, appName) {
     }
     list(id = recs$appId[[1L]])
   } else {
+    if (!is.null(contentId)) {
+      cli::cli_abort(c(
+        "{.arg contentId} is only supported on Posit Connect Cloud.",
+        i = "On shinyapps.io, identify the application with {.arg appName}."
+      ))
+    }
     resolveApplication(accountDetails, appName %||% basename(appDir))
   }
 }
@@ -160,6 +174,11 @@ resolveContentTarget <- function(accountDetails, appDir, appName) {
 #' @param appDir Directory containing application. Defaults to
 #'   current working directory.
 #' @param appName Name of application.
+#' @param contentId On Posit Connect Cloud, the content ID to manage, taken from
+#'   the content URL
+#'   (\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+#'   supplied, \code{appDir} and \code{appName} are ignored and no local
+#'   deployment record is required. Not supported on shinyapps.io.
 #' @inheritParams deployApp
 #' @param sendEmail Send an email letting the user know the application
 #'   has been shared with them.
@@ -176,12 +195,14 @@ resolveContentTarget <- function(accountDetails, appDir, appName) {
 #'   record under \code{appDir}, which defaults to the working directory. Pass
 #'   \code{appDir} to point at the project directory that contains the
 #'   \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-#'   the same directory.
+#'   the same directory. Alternatively, pass \code{contentId} to target the
+#'   content directly, without a local deployment record.
 #' @export
 addAuthorizedUser <- function(
   email,
   appDir = getwd(),
   appName = NULL,
+  contentId = NULL,
   account = NULL,
   server = NULL,
   sendEmail = NULL,
@@ -192,7 +213,7 @@ addAuthorizedUser <- function(
     checkShinyappsServer(accountDetails$server)
   }
 
-  application <- resolveContentTarget(accountDetails, appDir, appName)
+  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
 
   # check for and remove password file (shinyapps.io only; PCC has no password file)
   if (!isPositConnectCloudServer(accountDetails$server)) {
@@ -234,6 +255,11 @@ addAuthorizedUser <- function(
 #' @param appDir Directory containing application. Defaults to
 #' current working directory.
 #' @param appName Name of application.
+#' @param contentId On Posit Connect Cloud, the content ID to manage, taken from
+#'   the content URL
+#'   (\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+#'   supplied, \code{appDir} and \code{appName} are ignored and no local
+#'   deployment record is required. Not supported on shinyapps.io.
 #' @inheritParams deployApp
 #' @seealso [addAuthorizedUser()] and [showUsers()]
 #' @note This function works for ShinyApps and Posit Connect Cloud.
@@ -242,12 +268,14 @@ addAuthorizedUser <- function(
 #'   record under \code{appDir}, which defaults to the working directory. Pass
 #'   \code{appDir} to point at the project directory that contains the
 #'   \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-#'   the same directory.
+#'   the same directory. Alternatively, pass \code{contentId} to target the
+#'   content directly, without a local deployment record.
 #' @export
 removeAuthorizedUser <- function(
   user,
   appDir = getwd(),
   appName = NULL,
+  contentId = NULL,
   account = NULL,
   server = NULL
 ) {
@@ -256,7 +284,7 @@ removeAuthorizedUser <- function(
     checkShinyappsServer(accountDetails$server)
   }
 
-  application <- resolveContentTarget(accountDetails, appDir, appName)
+  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
 
   # check and remove password file (shinyapps.io only; PCC has no password file)
   if (!isPositConnectCloudServer(accountDetails$server)) {
@@ -320,6 +348,11 @@ removeAuthorizedUser <- function(
 #' @param appDir Directory containing application. Defaults to
 #'   current working directory.
 #' @param appName Name of application.
+#' @param contentId On Posit Connect Cloud, the content ID to manage, taken from
+#'   the content URL
+#'   (\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+#'   supplied, \code{appDir} and \code{appName} are ignored and no local
+#'   deployment record is required. Not supported on shinyapps.io.
 #' @inheritParams deployApp
 #' @seealso [addAuthorizedUser()] and [showInvited()]
 #' @return A data frame with one row per authorized user. Columns always
@@ -334,11 +367,13 @@ removeAuthorizedUser <- function(
 #'   record under \code{appDir}, which defaults to the working directory. Pass
 #'   \code{appDir} to point at the project directory that contains the
 #'   \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-#'   the same directory.
+#'   the same directory. Alternatively, pass \code{contentId} to target the
+#'   content directly, without a local deployment record.
 #' @export
 showUsers <- function(
   appDir = getwd(),
   appName = NULL,
+  contentId = NULL,
   account = NULL,
   server = NULL
 ) {
@@ -347,7 +382,7 @@ showUsers <- function(
     checkShinyappsServer(accountDetails$server)
   }
 
-  application <- resolveContentTarget(accountDetails, appDir, appName)
+  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
 
   api <- clientForAccount(accountDetails)
   showUsers_impl(
@@ -367,6 +402,11 @@ showUsers <- function(
 #' @param appDir Directory containing application. Defaults to
 #'   current working directory.
 #' @param appName Name of application.
+#' @param contentId On Posit Connect Cloud, the content ID to manage, taken from
+#'   the content URL
+#'   (\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+#'   supplied, \code{appDir} and \code{appName} are ignored and no local
+#'   deployment record is required. Not supported on shinyapps.io.
 #' @inheritParams deployApp
 #' @seealso [addAuthorizedUser()] and [showUsers()]
 #' @note This function works for ShinyApps and Posit Connect Cloud. On Posit
@@ -378,11 +418,13 @@ showUsers <- function(
 #'   record under \code{appDir}, which defaults to the working directory. Pass
 #'   \code{appDir} to point at the project directory that contains the
 #'   \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-#'   the same directory.
+#'   the same directory. Alternatively, pass \code{contentId} to target the
+#'   content directly, without a local deployment record.
 #' @export
 showInvited <- function(
   appDir = getwd(),
   appName = NULL,
+  contentId = NULL,
   account = NULL,
   server = NULL
 ) {
@@ -391,7 +433,7 @@ showInvited <- function(
     checkShinyappsServer(accountDetails$server)
   }
 
-  application <- resolveContentTarget(accountDetails, appDir, appName)
+  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
 
   api <- clientForAccount(accountDetails)
   showInvited_impl(api, application$id)
@@ -410,6 +452,11 @@ showInvited <- function(
 #' @param appDir Directory containing application. Defaults to
 #'   current working directory.
 #' @param appName Name of application.
+#' @param contentId On Posit Connect Cloud, the content ID to manage, taken from
+#'   the content URL
+#'   (\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+#'   supplied, \code{appDir} and \code{appName} are ignored and no local
+#'   deployment record is required. Not supported on shinyapps.io.
 #' @inheritParams deployApp
 #' @seealso [showInvited()]
 #' @note This function works for ShinyApps and Posit Connect Cloud. The
@@ -420,13 +467,15 @@ showInvited <- function(
 #'   record under \code{appDir}, which defaults to the working directory. Pass
 #'   \code{appDir} to point at the project directory that contains the
 #'   \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-#'   the same directory.
+#'   the same directory. Alternatively, pass \code{contentId} to target the
+#'   content directly, without a local deployment record.
 #' @export
 resendInvitation <- function(
   invite,
   regenerate = FALSE,
   appDir = getwd(),
   appName = NULL,
+  contentId = NULL,
   account = NULL,
   server = NULL
 ) {
@@ -437,7 +486,7 @@ resendInvitation <- function(
 
   # resolve content exactly once, then fetch invitations via impl (avoids a
   # second resolveContentTarget() call).
-  application <- resolveContentTarget(accountDetails, appDir, appName)
+  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
   api <- clientForAccount(accountDetails)
   invited <- showInvited_impl(api, application$id)
 

--- a/R/auth.R
+++ b/R/auth.R
@@ -124,7 +124,12 @@ cleanupPasswordFile <- function(appDir) {
 # by title (mutable, non-unique on PCC).
 # On shinyapps.io, delegates to resolveApplication() unchanged; contentId is
 # not supported there.
-resolveContentTarget <- function(accountDetails, appDir, appName, contentId = NULL) {
+resolveContentTarget <- function(
+  accountDetails,
+  appDir,
+  appName,
+  contentId = NULL
+) {
   if (isPositConnectCloudServer(accountDetails$server)) {
     # An explicit content id targets PCC content directly, with no local
     # deployment record required.
@@ -213,7 +218,12 @@ addAuthorizedUser <- function(
     checkShinyappsServer(accountDetails$server)
   }
 
-  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
+  application <- resolveContentTarget(
+    accountDetails,
+    appDir,
+    appName,
+    contentId
+  )
 
   # check for and remove password file (shinyapps.io only; PCC has no password file)
   if (!isPositConnectCloudServer(accountDetails$server)) {
@@ -284,7 +294,12 @@ removeAuthorizedUser <- function(
     checkShinyappsServer(accountDetails$server)
   }
 
-  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
+  application <- resolveContentTarget(
+    accountDetails,
+    appDir,
+    appName,
+    contentId
+  )
 
   # check and remove password file (shinyapps.io only; PCC has no password file)
   if (!isPositConnectCloudServer(accountDetails$server)) {
@@ -382,7 +397,12 @@ showUsers <- function(
     checkShinyappsServer(accountDetails$server)
   }
 
-  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
+  application <- resolveContentTarget(
+    accountDetails,
+    appDir,
+    appName,
+    contentId
+  )
 
   api <- clientForAccount(accountDetails)
   showUsers_impl(
@@ -433,7 +453,12 @@ showInvited <- function(
     checkShinyappsServer(accountDetails$server)
   }
 
-  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
+  application <- resolveContentTarget(
+    accountDetails,
+    appDir,
+    appName,
+    contentId
+  )
 
   api <- clientForAccount(accountDetails)
   showInvited_impl(api, application$id)
@@ -486,7 +511,12 @@ resendInvitation <- function(
 
   # resolve content exactly once, then fetch invitations via impl (avoids a
   # second resolveContentTarget() call).
-  application <- resolveContentTarget(accountDetails, appDir, appName, contentId)
+  application <- resolveContentTarget(
+    accountDetails,
+    appDir,
+    appName,
+    contentId
+  )
   api <- clientForAccount(accountDetails)
   invited <- showInvited_impl(api, application$id)
 

--- a/man/addAuthorizedUser.Rd
+++ b/man/addAuthorizedUser.Rd
@@ -8,6 +8,7 @@ addAuthorizedUser(
   email,
   appDir = getwd(),
   appName = NULL,
+  contentId = NULL,
   account = NULL,
   server = NULL,
   sendEmail = NULL,
@@ -21,6 +22,12 @@ addAuthorizedUser(
 current working directory.}
 
 \item{appName}{Name of application.}
+
+\item{contentId}{On Posit Connect Cloud, the content ID to manage, taken from
+the content URL
+(\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+supplied, \code{appDir} and \code{appName} are ignored and no local
+deployment record is required. Not supported on shinyapps.io.}
 
 \item{account, server}{Uniquely identify a remote server with either your
 user \code{account}, the \code{server} name, or both. If neither are supplied, and
@@ -50,7 +57,8 @@ On Posit Connect Cloud, the content is resolved from the local deployment
 record under \code{appDir}, which defaults to the working directory. Pass
 \code{appDir} to point at the project directory that contains the
 \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-the same directory.
+the same directory. Alternatively, pass \code{contentId} to target the
+content directly, without a local deployment record.
 }
 \seealso{
 \code{\link[=removeAuthorizedUser]{removeAuthorizedUser()}} and \code{\link[=showUsers]{showUsers()}}

--- a/man/removeAuthorizedUser.Rd
+++ b/man/removeAuthorizedUser.Rd
@@ -8,6 +8,7 @@ removeAuthorizedUser(
   user,
   appDir = getwd(),
   appName = NULL,
+  contentId = NULL,
   account = NULL,
   server = NULL
 )
@@ -19,6 +20,12 @@ removeAuthorizedUser(
 current working directory.}
 
 \item{appName}{Name of application.}
+
+\item{contentId}{On Posit Connect Cloud, the content ID to manage, taken from
+the content URL
+(\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+supplied, \code{appDir} and \code{appName} are ignored and no local
+deployment record is required. Not supported on shinyapps.io.}
 
 \item{account, server}{Uniquely identify a remote server with either your
 user \code{account}, the \code{server} name, or both. If neither are supplied, and
@@ -38,7 +45,8 @@ On Posit Connect Cloud, the content is resolved from the local deployment
 record under \code{appDir}, which defaults to the working directory. Pass
 \code{appDir} to point at the project directory that contains the
 \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-the same directory.
+the same directory. Alternatively, pass \code{contentId} to target the
+content directly, without a local deployment record.
 }
 \seealso{
 \code{\link[=addAuthorizedUser]{addAuthorizedUser()}} and \code{\link[=showUsers]{showUsers()}}

--- a/man/resendInvitation.Rd
+++ b/man/resendInvitation.Rd
@@ -9,6 +9,7 @@ resendInvitation(
   regenerate = FALSE,
   appDir = getwd(),
   appName = NULL,
+  contentId = NULL,
   account = NULL,
   server = NULL
 )
@@ -23,6 +24,12 @@ invitation has expired.}
 current working directory.}
 
 \item{appName}{Name of application.}
+
+\item{contentId}{On Posit Connect Cloud, the content ID to manage, taken from
+the content URL
+(\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+supplied, \code{appDir} and \code{appName} are ignored and no local
+deployment record is required. Not supported on shinyapps.io.}
 
 \item{account, server}{Uniquely identify a remote server with either your
 user \code{account}, the \code{server} name, or both. If neither are supplied, and
@@ -44,7 +51,8 @@ On Posit Connect Cloud, the content is resolved from the local deployment
 record under \code{appDir}, which defaults to the working directory. Pass
 \code{appDir} to point at the project directory that contains the
 \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-the same directory.
+the same directory. Alternatively, pass \code{contentId} to target the
+content directly, without a local deployment record.
 }
 \seealso{
 \code{\link[=showInvited]{showInvited()}}

--- a/man/showInvited.Rd
+++ b/man/showInvited.Rd
@@ -4,13 +4,25 @@
 \alias{showInvited}
 \title{List invited users for an application}
 \usage{
-showInvited(appDir = getwd(), appName = NULL, account = NULL, server = NULL)
+showInvited(
+  appDir = getwd(),
+  appName = NULL,
+  contentId = NULL,
+  account = NULL,
+  server = NULL
+)
 }
 \arguments{
 \item{appDir}{Directory containing application. Defaults to
 current working directory.}
 
 \item{appName}{Name of application.}
+
+\item{contentId}{On Posit Connect Cloud, the content ID to manage, taken from
+the content URL
+(\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+supplied, \code{appDir} and \code{appName} are ignored and no local
+deployment record is required. Not supported on shinyapps.io.}
 
 \item{account, server}{Uniquely identify a remote server with either your
 user \code{account}, the \code{server} name, or both. If neither are supplied, and
@@ -33,7 +45,8 @@ On Posit Connect Cloud, the content is resolved from the local deployment
 record under \code{appDir}, which defaults to the working directory. Pass
 \code{appDir} to point at the project directory that contains the
 \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-the same directory.
+the same directory. Alternatively, pass \code{contentId} to target the
+content directly, without a local deployment record.
 }
 \seealso{
 \code{\link[=addAuthorizedUser]{addAuthorizedUser()}} and \code{\link[=showUsers]{showUsers()}}

--- a/man/showUsers.Rd
+++ b/man/showUsers.Rd
@@ -4,13 +4,25 @@
 \alias{showUsers}
 \title{List authorized users for an application}
 \usage{
-showUsers(appDir = getwd(), appName = NULL, account = NULL, server = NULL)
+showUsers(
+  appDir = getwd(),
+  appName = NULL,
+  contentId = NULL,
+  account = NULL,
+  server = NULL
+)
 }
 \arguments{
 \item{appDir}{Directory containing application. Defaults to
 current working directory.}
 
 \item{appName}{Name of application.}
+
+\item{contentId}{On Posit Connect Cloud, the content ID to manage, taken from
+the content URL
+(\code{https://connect.posit.cloud/{account}/content/{contentId}}). When
+supplied, \code{appDir} and \code{appName} are ignored and no local
+deployment record is required. Not supported on shinyapps.io.}
 
 \item{account, server}{Uniquely identify a remote server with either your
 user \code{account}, the \code{server} name, or both. If neither are supplied, and
@@ -38,7 +50,8 @@ On Posit Connect Cloud, the content is resolved from the local deployment
 record under \code{appDir}, which defaults to the working directory. Pass
 \code{appDir} to point at the project directory that contains the
 \code{rsconnect/} deployment record. \code{appName} selects among multiple records in
-the same directory.
+the same directory. Alternatively, pass \code{contentId} to target the
+content directly, without a local deployment record.
 }
 \seealso{
 \code{\link[=addAuthorizedUser]{addAuthorizedUser()}} and \code{\link[=showInvited]{showInvited()}}

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -475,6 +475,51 @@ test_that("resolveContentTarget uses deployment-record appId on PCC, not title",
   expect_equal(captured_app_id, "content-uuid-abc")
 })
 
+test_that("contentId targets PCC content directly without a deployment record", {
+  local_temp_config()
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  app_dir <- withr::local_tempdir()
+  # No addTestDeployment — contentId must not require a local record.
+
+  captured_app_id <- NULL
+  local_mocked_bindings(clientForAccount = function(...) {
+    list(
+      listApplicationAuthorization = function(appId) {
+        captured_app_id <<- appId
+        list()
+      }
+    )
+  })
+
+  showUsers(
+    appDir = app_dir,
+    contentId = "content-uuid-direct",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+  expect_equal(captured_app_id, "content-uuid-direct")
+})
+
+test_that("contentId is rejected on shinyapps.io", {
+  local_temp_config()
+  addTestServer(url = "https://shinyapps.io", name = "shinyapps.io")
+  addTestAccount("myaccount", server = "shinyapps.io")
+
+  expect_error(
+    showUsers(
+      contentId = "content-uuid-direct",
+      account = "myaccount",
+      server = "shinyapps.io"
+    ),
+    regexp = "only supported on Posit Connect Cloud"
+  )
+})
+
 test_that("resolveContentTarget aborts with clear message on PCC when no deployment record", {
   local_temp_config()
   addTestServer(


### PR DESCRIPTION
Adds an optional `contentId` argument to the five collaborator-management functions (`addAuthorizedUser`, `removeAuthorizedUser`, `showUsers`, `showInvited`, `resendInvitation`).

On Posit Connect Cloud, passing `contentId` targets the content directly, so a local deployment record is no longer required. `resolveContentTarget()` short-circuits to `list(id = contentId)` when an id is supplied, and rejects `contentId` on shinyapps.io. The id is shown in the content URL and returned by `applications()`, so the discovery-to-management workflow no longer depends on running from a project directory with an `rsconnect/` record.

Precedence: when `contentId` is supplied, `appDir` and `appName` are ignored.

### Notes for reviewers

- `contentId` is placed after `appName` in each signature, which shifts `account`/`server` by one position. These functions are near-always called by name, but if positional 4+ arg calls are a concern, `contentId` could move to the end instead.
- Supplying both `contentId` and `appName` is a quiet override (no warning). Happy to add a warning if preferred.
- `contentId` is PCC-only; on shinyapps.io it aborts with a clear message.
