### PR TITLE
Fix unset Connect Cloud environment variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rsconnect (development version)
 
+* Connect Cloud deployments no longer send empty values for environment
+  variables that are unset in the current R session. (#1361)
+
 # rsconnect 1.11.0
 
 * rsconnect checks whether a newer version of itself is available from your

--- a/R/client-connectCloud.R
+++ b/R/client-connectCloud.R
@@ -47,6 +47,22 @@ cloudContentTypeFromAppMode <- function(appMode) {
   )
 }
 
+cloudSecrets <- function(envVars) {
+  values <- Sys.getenv(envVars, unset = NA)
+  keep <- !is.na(values)
+
+  unname(Map(
+    function(name, value) {
+      list(
+        name = name,
+        value = value
+      )
+    },
+    envVars[keep],
+    values[keep]
+  ))
+}
+
 # Creates a client for interacting with the Connect Cloud API.
 connectCloudClient <- function(service, authInfo) {
   # Generic retry wrapper. If a request fails with 401 Unauthorized, it will
@@ -191,16 +207,7 @@ connectCloudClient <- function(service, authInfo) {
         primary_file = primaryFile
       )
 
-      secrets <- unname(Map(
-        function(name, value) {
-          list(
-            name = name,
-            value = value
-          )
-        },
-        envVars,
-        Sys.getenv(envVars)
-      ))
+      secrets <- cloudSecrets(envVars)
 
       json <- list(
         account_id = accountId,
@@ -232,16 +239,7 @@ connectCloudClient <- function(service, authInfo) {
         path <- paste0(path, "?new_bundle=true")
       }
 
-      secrets <- unname(Map(
-        function(name, value) {
-          list(
-            name = name,
-            value = value
-          )
-        },
-        envVars,
-        Sys.getenv(envVars)
-      ))
+      secrets <- cloudSecrets(envVars)
 
       json <- list(
         secrets = secrets,

--- a/tests/testthat/test-client-connectCloud.R
+++ b/tests/testthat/test-client-connectCloud.R
@@ -51,6 +51,62 @@ test_that("awaitCompletion", {
   expect_null(result$error)
 })
 
+test_that("Connect Cloud omits unset environment variables from secrets", {
+  local_mocked_bindings(
+    POST_JSON = function(service, authInfo, path, json) {
+      list(id = "content123", json = json)
+    },
+    PATCH_JSON = function(service, authInfo, path, json) {
+      list(id = "content123", json = json)
+    },
+    .package = "rsconnect"
+  )
+  withr::local_envvar(c(
+    RSCONNECT_1361_SET = "configured",
+    RSCONNECT_1361_EMPTY = ""
+  ))
+  Sys.unsetenv("RSCONNECT_1361_UNSET")
+  withr::defer(Sys.unsetenv(c(
+    "RSCONNECT_1361_SET",
+    "RSCONNECT_1361_EMPTY",
+    "RSCONNECT_1361_UNSET"
+  )))
+
+  client <- connectCloudClient(
+    service = list(host = "example.com", port = 443, protocol = "https"),
+    authInfo = list()
+  )
+  env_vars <- c(
+    "RSCONNECT_1361_SET",
+    "RSCONNECT_1361_EMPTY",
+    "RSCONNECT_1361_UNSET"
+  )
+
+  created <- client$createContent(
+    name = "app",
+    title = "App",
+    accountId = "account123",
+    appMode = "shiny",
+    primaryFile = "app.R",
+    envVars = env_vars
+  )
+  expect_equal(
+    created$json$secrets,
+    list(
+      list(name = "RSCONNECT_1361_SET", value = "configured"),
+      list(name = "RSCONNECT_1361_EMPTY", value = "")
+    )
+  )
+
+  updated <- client$updateContent(
+    contentId = "content123",
+    envVars = env_vars,
+    primaryFile = "app.R",
+    appMode = "shiny"
+  )
+  expect_equal(updated$json$secrets, created$json$secrets)
+})
+
 test_that("awaitCompletion falls back to an empty url instead of erroring when the account can't be resolved", {
   skip_if_not_installed("webfakes")
 


### PR DESCRIPTION
## Summary

Connect Cloud deployments omit environment variables that are unset in the current R session from the `secrets` payload. Explicitly set empty values remain sendable. This update also merges current `main` so the PR is no longer conflicted.

## Thanks to maintainers

Thanks to the rsconnect maintainers for maintaining the deployment clients and for the clear issue report.

## Issue or motivation

Fixes #1361. A deployment record stores environment variable names for later deployments. If one of those variables is absent later, the Connect Cloud client previously sent `value = ""`, clearing the existing secret.

## Root cause

`Sys.getenv(envVars)` uses an empty string for an unset variable, so the client could not distinguish an absent variable from one explicitly set to an empty value. During the conflict repair, `main` had also added guards for `envVars = NULL` and `character(0)`; the final helper preserves that empty-array behavior while filtering only absent variables.

## Change

Add a Connect Cloud-specific helper that returns an empty JSON array for no variables, uses `unset = NA` for named variables, and filters only absent variables before constructing the payload. Use it for both content creation and updates. Add a regression test that captures both request bodies and checks that an explicitly empty value is preserved while an unset variable is omitted. Merge current `main` and keep the existing Connect Cloud fixes.

## Tests

- `Rscript -e 'devtools::load_all(quiet = TRUE); testthat::test_file("tests/testthat/test-client-connectCloud.R", reporter = "summary")'`: passed.
- `air format --check R/client-connectCloud.R tests/testthat/test-client-connectCloud.R NEWS.md`: passed.
- `git diff --cached upstream/main --check`: passed before commit.
- `lintr::lint_package()`: passed, no lints.
- `R CMD build .`: passed, including vignette creation.
- `_R_CHECK_CRAN_INCOMING_REMOTE_=false R CMD check --as-cran --no-manual rsconnect_1.11.0.9000.tar.gz`: passed with 1 existing development-version NOTE.
- `_R_CHECK_FORCE_SUGGESTS_=false _R_CHECK_CRAN_INCOMING_REMOTE_=false R CMD check --no-manual rsconnect_1.11.0.9000.tar.gz`: passed with Status: OK.

## Scope

This does not change Connect Cloud authentication, secret names, explicitly empty values, deployment record storage, `deployApp(appId=)` behavior, or user-management endpoints. I did not run credentialed Connect/shinyapps.io integration workflows locally because they require repository secrets.
