### PR TITLE
docs: fix typos and trim trailing whitespace

### DIFF
--- a/R/rpubs.R
+++ b/R/rpubs.R
@@ -52,7 +52,7 @@ rpubsUpload <- function(
   check_string(title, allow_empty = FALSE)
   check_file(contentFile)
   if (!is.list(properties)) {
-    stop("properties paramater must be a named list")
+    stop("properties parameter must be a named list")
   }
 
   pathFromId <- function(id) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -48,7 +48,7 @@ Click "Connect" to add new servers.
 
 You can also connect from any R session by running a little code:
 
-- For Posit Conect Cloud, call `connectCloudUser()` to authenticate through the browser.
+- For Posit Connect Cloud, call `connectCloudUser()` to authenticate through the browser.
 
 -   For Posit Connect, first use `addServer()` to register your server with rsconnect, then call either `connectUser()` or `connectApiUser()`.
     `connectUser()` is a bit simpler if you're in an interactive session; `connectApiUser()` works anywhere but requires a you to copy and paste an API key from your user profile.

--- a/man/options.Rd
+++ b/man/options.Rd
@@ -10,7 +10,7 @@ The \pkg{rsconnect} package supports several options that control the method use
 \details{
 Supported global options include:
 \describe{
-   \item{\code{rsconnect.ca.bundle}}{Path to a custom bundle of Certificate Authority root certificates to use when connecting to servers via SSL. This option can also be specied in the environment variable \code{RSCONNECT_CA_BUNDLE}. Leave undefined to use your system's default certificate store.}
+   \item{\code{rsconnect.ca.bundle}}{Path to a custom bundle of Certificate Authority root certificates to use when connecting to servers via SSL. This option can also be specified in the environment variable \code{RSCONNECT_CA_BUNDLE}. Leave undefined to use your system's default certificate store.}
    \item{\code{rsconnect.check.certificate}}{Whether to check the SSL certificate when connecting to a remote host; defaults to \code{TRUE}. Setting to \code{FALSE} is insecure, but will allow you to connect to hosts using invalid certificates as a last resort.}
    \item{\code{rsconnect.http.trace}}{When \code{TRUE}, trace http calls (prints the method, path, and total milliseconds for each http request)}
    \item{\code{rsconnect.http.trace.json}}{When \code{TRUE}, trace JSON content (shows JSON payloads sent to and received from the server))}
@@ -53,4 +53,3 @@ options(rsconnect.http.trace.json = TRUE)
 options(rsconnect.launch.browser = FALSE)
 }
 }
-

--- a/tests/manual/publishing-dialog.Rmd
+++ b/tests/manual/publishing-dialog.Rmd
@@ -26,8 +26,8 @@ Success:
 ### Add a shiny account
 
 1. Open Options | Publishing.
-1. Click Connect, then Shinyapps.io. 
-1. Follow the on-screen instuctions, then click Connect Account.
+1. Click Connect, then Shinyapps.io.
+1. Follow the on-screen instructions, then click Connect Account.
 
 Success:
 
@@ -62,12 +62,12 @@ Success:
 
 Success:
 
-1. Dialog asks if you want to replace existing content. 
+1. Dialog asks if you want to replace existing content.
 1. After clicking "Replace" the deploy succeeds.
 
 ### Re-deploy to deleted app
 
-1. On deployed app click "..." menu, then delete. 
+1. On deployed app click "..." menu, then delete.
 1. Click ok, wait 30s, then refresh the page to confirm the app is deleted.
 1. Return to RStudio, then click the deploy drop down. Choose other destinations, then click deploy.
 

--- a/tests/testthat/shinyapp-with-absolute-paths/ShinyDocument.Rmd
+++ b/tests/testthat/shinyapp-with-absolute-paths/ShinyDocument.Rmd
@@ -6,9 +6,9 @@ output: html_document
 runtime: shiny
 ---
 
-This R Markdown document is made interactive using Shiny. Unlike the more traditional workflow of creating static reports, you can now create documents that allow your readers to change the assumptions underlying your analysis and see the results immediately. 
+This R Markdown document is made interactive using Shiny. Unlike the more traditional workflow of creating static reports, you can now create documents that allow your readers to change the assumptions underlying your analysis and see the results immediately.
 
-To learn more, see [Interative Documents](http://rmarkdown.rstudio.com/authoring_shiny.html).
+To learn more, see [Interactive Documents](http://rmarkdown.rstudio.com/authoring_shiny.html).
 
 ## Inputs and Outputs
 
@@ -50,6 +50,3 @@ Note the use of the `height` parameter to determine how much vertical space the 
 You can also use the `shinyApp` function to define an application inline rather then in an external directory.
 
 In all of R code chunks above the `echo = FALSE` attribute is used. This is to prevent the R code within the chunk from rendering in the document alongside the Shiny components.
-
-
-

--- a/tests/testthat/shinyapp-with-absolute-paths/ShinyPresentation.Rmd
+++ b/tests/testthat/shinyapp-with-absolute-paths/ShinyPresentation.Rmd
@@ -8,9 +8,9 @@ runtime: shiny
 
 ## Shiny Presentation
 
-This R Markdown presentation is made interactive using Shiny. The viewers of the presentation can change the assumptions underlying what's presented and see the results immediately. 
+This R Markdown presentation is made interactive using Shiny. The viewers of the presentation can change the assumptions underlying what's presented and see the results immediately.
 
-To learn more, see [Interative Documents](http://rmarkdown.rstudio.com/authoring_shiny.html).
+To learn more, see [Interactive Documents](http://rmarkdown.rstudio.com/authoring_shiny.html).
 
 Here's some internal help: [Helpful Link](/Users/MrBurns/)
 And another: [Favourite Goats](../../goats.txt)
@@ -46,5 +46,3 @@ renderPlot({
 ```{r}
 summary(cars)
 ```
-
-

--- a/tests/testthat/shinyapp-with-absolute-paths/server.R
+++ b/tests/testthat/shinyapp-with-absolute-paths/server.R
@@ -29,6 +29,6 @@ shinyServer(function(input, output) {
     file <- read.csv("data/College.txt") ## okay
 
     ## don't warn about absolute paths that could be URL query paths
-    file <- paste("/applcations")
+    file <- paste("/applications")
   })
 })

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -64,7 +64,7 @@ test_that("parameterized Rmd identified as parameterized when other Rmd in bundl
   expect_known_manifest_fields(manifest)
 })
 
-test_that("primary doc can be inferred (and non-parameterized dispite an included parameterized", {
+test_that("primary doc can be inferred (and non-parameterized despite an included parameterized", {
   skip_on_cran()
   bundleTempDir <- local_shiny_bundle(
     "rmd primary",


### PR DESCRIPTION
docs: fix typos and trim trailing whitespace

Does this help?