### PR TITLE
Fix deployApp(appId=) for Connect Cloud

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # rsconnect (development version)
 
+* `deployApp(appId=)` now works for Posit Connect Cloud content. The Connect
+  Cloud client previously implemented no `getApplication()` method, so
+  deploying to an existing content item by id (rather than via a local
+  deployment record) errored with "attempt to apply non-function". (#1367)
+
 * `showUsers()` and `showInvited()` now always return a data frame with
   atomic `character`/`logical` columns, including a typed 0-row data frame
   (rather than `NULL`) when there are no results. User ids are now always

--- a/R/client-connectCloud.R
+++ b/R/client-connectCloud.R
@@ -275,6 +275,12 @@ connectCloudClient <- function(service, authInfo) {
 
     getContent = getContent,
 
+    getApplication = function(applicationId, deploymentRecordVersion) {
+      content <- getContent(applicationId)
+      content$name <- content$title
+      content
+    },
+
     updateContent = function(
       contentId,
       envVars,

--- a/tests/testthat/test-client-connectCloud.R
+++ b/tests/testthat/test-client-connectCloud.R
@@ -1042,3 +1042,38 @@ test_that("listApplicationInvitations accumulates multiple pages and keeps accep
   expect_equal(result[[2]]$id, "inv-2")
   expect_equal(result[[3]]$id, "inv-3")
 })
+
+test_that("getApplication() delegates to getContent and sets name = title", {
+  skip_if_not_installed("webfakes")
+
+  content_app <- webfakes::new_app()
+  content_app$use(webfakes::mw_json())
+  content_app$get("/contents/:id", function(req, res) {
+    res$set_status(200L)$send_json(
+      list(
+        id = "content-abc",
+        title = "My App Title",
+        state = "active",
+        account_id = "acct-1"
+      ),
+      auto_unbox = TRUE
+    )
+  })
+  app <- webfakes::local_app_process(content_app)
+  service <- parseHttpUrl(app$url())
+
+  authInfo <- list(
+    server = "connect.posit.cloud",
+    name = "some-user",
+    username = "some-user",
+    accountId = "123",
+    accessToken = "current-token",
+    refreshToken = "refresh-token"
+  )
+  client <- connectCloudClient(service, authInfo)
+
+  result <- client$getApplication("content-abc", "unknown")
+  expect_equal(result$id, "content-abc")
+  expect_equal(result$title, "My App Title")
+  expect_equal(result$name, "My App Title")
+})

--- a/tests/testthat/test-deploymentTarget.R
+++ b/tests/testthat/test-deploymentTarget.R
@@ -509,6 +509,41 @@ test_that("PCC deploy with no local record creates new content, not adopting sam
   expect_equal(target$deployment$name, "my_app")
 })
 
+test_that("findDeploymentTargetByAppId works for PCC with no local deployment record", {
+  local_temp_config()
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+
+  local_mocked_bindings(
+    clientForAccount = function(...) {
+      list(
+        getApplication = function(applicationId, deploymentRecordVersion) {
+          list(
+            id = applicationId,
+            title = "My PCC App",
+            name = "My PCC App"
+          )
+        }
+      )
+    }
+  )
+
+  app_dir <- withr::local_tempdir()
+
+  target <- findDeploymentTarget(
+    app_dir,
+    appId = "pcc-content-uuid",
+    account = "myaccount",
+    server = "connect.posit.cloud"
+  )
+  expect_equal(target$deployment$appId, "pcc-content-uuid")
+  expect_equal(target$deployment$name, "My PCC App")
+  expect_equal(target$accountDetails$server, "connect.posit.cloud")
+})
+
 # helpers -----------------------------------------------------------------
 
 test_that("shouldUpdateApp errors when non-interactive", {


### PR DESCRIPTION
`deployApp(appId = "<content-id>")` on Posit Connect Cloud failed with the error:
```
Error in client$getApplication(appId, "unknown") : attempt to apply non-function
``` 
because the Connect Cloud client implemented `getContent()` but not `getApplication()`. 

This PR adds `getApplication(applicationId, deploymentRecordVersion)` to the `connectCloudClient()` returned list. It delegates to the existing `getContent(applicationId)` and sets `content$name <- content$title` so that `createDeploymentFromApplication()` downstream gets a non-NULL `name` field (matching the convention already used in `listApplications`).

Fixes #1367
