### PR TITLE
Fix null primary_file for manifest deploys to Connect Cloud

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # rsconnect (development version)
 
+* Deploying to Posit Connect Cloud from a pre-generated `manifest.json`
+  (`deployApp(manifestPath=)`) no longer fails with a null `primary_file`.
+  The primary file is now inferred from the file list even when `appMode` is
+  supplied. (#1366)
+
 * `showUsers()` and `showInvited()` now always return a data frame with
   atomic `character`/`logical` columns, including a typed 0-row data frame
   (rather than `NULL`) when there are no results. User ids are now always

--- a/R/appMetadata.R
+++ b/R/appMetadata.R
@@ -40,6 +40,16 @@ appMetadata <- function(
       appMode <- appModeResult$appMode
       inferredPrimaryFile <- appModeResult$primaryFile
     }
+  } else {
+    # appMode was supplied (e.g. from a manifest), so the inference block above
+    # is skipped -- but Connect Cloud still needs a primary_file. Infer just the
+    # primary file from the same file-list rules, keeping the supplied appMode.
+    inferredPrimaryFile <- inferAppMode(
+      appDir,
+      appFiles,
+      usesQuarto = quarto,
+      isShinyappsServer = isShinyappsServer
+    )$primaryFile
   }
 
   appPrimaryDoc <- inferAppPrimaryDoc(

--- a/tests/testthat/test-appMetadata.R
+++ b/tests/testthat/test-appMetadata.R
@@ -229,6 +229,38 @@ test_that("appMetadata returns NULL plumberInfo for nodejs", {
   expect_null(metadata$plumberInfo)
 })
 
+test_that("inferredPrimaryFile is populated when appMode is supplied (app.R)", {
+  dir <- withr::local_tempdir()
+  writeLines(
+    "library(shiny); shinyApp(fluidPage(), function(input, output) {})",
+    file.path(dir, "app.R")
+  )
+  metadata <- appMetadata(dir, appFiles = "app.R", appMode = "shiny")
+  expect_equal(metadata$inferredPrimaryFile, "app.R")
+})
+
+test_that("inferredPrimaryFile is populated when appMode is supplied (server.R)", {
+  dir <- withr::local_tempdir()
+  writeLines("", file.path(dir, "server.R"))
+  writeLines("", file.path(dir, "ui.R"))
+  metadata <- appMetadata(
+    dir,
+    appFiles = c("server.R", "ui.R"),
+    appMode = "shiny"
+  )
+  expect_equal(metadata$inferredPrimaryFile, "server.R")
+})
+
+test_that("inferredPrimaryFile is still populated when appMode is NULL (no regression)", {
+  dir <- withr::local_tempdir()
+  writeLines(
+    "library(shiny); shinyApp(fluidPage(), function(input, output) {})",
+    file.path(dir, "app.R")
+  )
+  metadata <- appMetadata(dir, appFiles = "app.R")
+  expect_equal(metadata$inferredPrimaryFile, "app.R")
+})
+
 # checkLayout -------------------------------------------------------------
 
 # inferAppMode ------------------------------------------------------------


### PR DESCRIPTION
When deploying to Posit Connect Cloud from a pre-generated `manifest.json` via `deployApp(manifestPath=)`, the deploy always failed with:

```
Field `body.next_revision.primary_file` error: Input should be a valid string
```

**Root cause:** In `R/appMetadata.R`, `inferredPrimaryFile` is initialized to `NULL` and only assigned inside the `if (is.null(appMode))` block. When `appMode` is supplied by the manifest path, that block is skipped entirely, so `inferredPrimaryFile` stays `NULL`. Connect Cloud receives `null` for `primary_file` and rejects the request.

To fix the issue, this PR adds an `else` branch that calls `inferAppMode()` solely to obtain `primaryFile`, without touching the caller-supplied `appMode`. This is safe for all other deploy targets — they ignore `inferredPrimaryFile` — and costs one extra file scan only when `appMode` is pre-supplied.

### Before / After

```r
d <- tempfile(); dir.create(d)
writeLines("library(shiny); shinyApp(fluidPage(), function(input,output){})", file.path(d,"app.R"))

# Before fix
appMetadata(appDir=d, appFiles="app.R", appMode="shiny")$inferredPrimaryFile
#> NULL   ← Connect Cloud receives null → 422 error

# After fix
appMetadata(appDir=d, appFiles="app.R", appMode="shiny")$inferredPrimaryFile
#> [1] "app.R"
```

Fixes #1366