### PR TITLE
Fix Connect Cloud redeploy: stale upload token and upload=FALSE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # rsconnect (development version)
 
+* Deploying to existing Posit Connect Cloud content that has no current
+  revision (e.g. after republishing or migrating through the UI) no longer
+  fails with "Invalid token". rsconnect now always requests a fresh bundle
+  upload URL for existing content instead of assuming a null current revision
+  means newly-created content. (#1370)
+
+* `deployApp(upload = FALSE)` no longer errors with
+  `object 'bundle' not found` on Posit Connect Cloud. (#1369)
+
 * `showUsers()` and `showInvited()` now always return a data frame with
   atomic `character`/`logical` columns, including a typed 0-row data frame
   (rather than `NULL`) when there are no results. User ids are now always

--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -525,6 +525,8 @@ deployApp <- function(
     checkConnectSupportsNodejs(client)
   }
 
+  createdContent <- is.null(deployment$appId)
+
   if (is.null(deployment$appId)) {
     taskStart(quiet, "Creating content on server...")
     if (isPositConnectCloudServer(accountDetails$server)) {
@@ -563,6 +565,7 @@ deployApp <- function(
           application
         },
         rsconnect_http_404 = function(err) {
+          createdContent <<- TRUE
           application <- applicationDeleted(
             client,
             deployment,
@@ -615,9 +618,10 @@ deployApp <- function(
 
   # Change _visibility_ & set env vars before uploading contents
   if (isPositConnectCloudServer(accountDetails$server)) {
-    # no update needed if we just created the content
-    # current revision will be null only when creating new content
-    if (!is.null(application$current_revision)) {
+    # Existing content: mint a fresh bundle + upload URL. Skipped only when we
+    # just created (or recreated) the content in this call, which already has a
+    # pending revision.
+    if (!createdContent) {
       taskStart(quiet, "Updating content...")
       # Use appPrimaryDoc if available, otherwise fall back to inferredPrimaryFile
       primaryFile <- appMetadata$appPrimaryDoc %||%
@@ -649,6 +653,8 @@ deployApp <- function(
       taskComplete(quiet, "Environment variables updated")
     }
   }
+
+  bundle <- NULL
 
   if (upload) {
     python <- getPythonForTarget(python, accountDetails)
@@ -687,7 +693,6 @@ deployApp <- function(
       if (!success) {
         cli::cli_abort("Could not upload bundle.")
       }
-      bundle <- NULL # PCC doesn't use bundle objects like other servers
     } else if (isShinyappsServer(accountDetails$server)) {
       bundle <- uploadShinyappsBundle(
         client,

--- a/tests/testthat/test-deployApp.R
+++ b/tests/testthat/test-deployApp.R
@@ -337,3 +337,210 @@ test_that("openURL() launches the browser on success with a valid url", {
   )
   expect_true(launched)
 })
+
+# PCC deploy: updateContent / createdContent guard (#1370, #1369) ----------
+
+# Shared PCC test content fixture: existing content with NULL current_revision.
+pcc_existing_content_null_revision <- list(
+  id = "content-abc",
+  url = "https://connect.posit.cloud/myaccount/content/content-abc",
+  current_revision = NULL,
+  next_revision = list(
+    id = "rev-new",
+    source_bundle_upload_url = "https://upload.example.com/bundle"
+  )
+)
+
+# Shared PCC test content fixture: existing content with a current_revision.
+pcc_existing_content_with_revision <- utils::modifyList(
+  pcc_existing_content_null_revision,
+  list(current_revision = list(id = "rev-old"))
+)
+
+# Set up a PCC server, account, and (optionally) a re-deploy record.
+local_pcc_deploy_env <- function(
+  appDir,
+  appId = "content-abc",
+  env = parent.frame()
+) {
+  local_temp_config(env = env)
+  addTestServer(
+    url = "https://connect.posit.cloud",
+    name = "connect.posit.cloud"
+  )
+  addTestAccount("myaccount", server = "connect.posit.cloud")
+  if (!is.null(appId)) {
+    addTestDeployment(
+      appDir,
+      appName = "myapp",
+      appId = appId,
+      account = "myaccount",
+      server = "connect.posit.cloud"
+    )
+  }
+}
+
+test_that("#1370: existing PCC content with NULL current_revision calls updateContent", {
+  skip_on_cran()
+  appDir <- local_temp_app(list("app.R" = "library(shiny)"))
+  local_pcc_deploy_env(appDir)
+
+  update_content_called <- FALSE
+  local_mocked_bindings(
+    clientForAccount = function(...) {
+      list(
+        getContent = function(id) pcc_existing_content_null_revision,
+        updateContent = function(id, envVars, newBundle, primaryFile, appMode) {
+          update_content_called <<- TRUE
+          pcc_existing_content_null_revision
+        },
+        uploadBundle = function(bundlePath, url) TRUE,
+        publish = function(id) invisible(NULL),
+        awaitCompletion = function(revisionId) {
+          list(
+            success = TRUE,
+            url = "https://connect.posit.cloud/myaccount/content/content-abc"
+          )
+        }
+      )
+    },
+    bundleApp = function(...) {
+      tmp <- tempfile(fileext = ".tar.gz")
+      file.create(tmp)
+      tmp
+    }
+  )
+
+  suppressMessages(deployApp(
+    appDir,
+    appName = "myapp",
+    account = "myaccount",
+    server = "connect.posit.cloud",
+    logLevel = "quiet",
+    lint = FALSE,
+    launch.browser = FALSE
+  ))
+
+  expect_true(update_content_called)
+})
+
+test_that("#1370: newly-created PCC content (no prior record) does NOT call updateContent", {
+  skip_on_cran()
+  appDir <- local_temp_app(list("app.R" = "library(shiny)"))
+  local_pcc_deploy_env(appDir, appId = NULL)
+
+  update_content_called <- FALSE
+  local_mocked_bindings(
+    clientForAccount = function(...) {
+      list(
+        createContent = function(...) pcc_existing_content_null_revision,
+        updateContent = function(...) {
+          update_content_called <<- TRUE
+          pcc_existing_content_null_revision
+        },
+        uploadBundle = function(bundlePath, url) TRUE,
+        publish = function(id) invisible(NULL),
+        awaitCompletion = function(revisionId) {
+          list(
+            success = TRUE,
+            url = "https://connect.posit.cloud/myaccount/content/content-abc"
+          )
+        }
+      )
+    },
+    bundleApp = function(...) {
+      tmp <- tempfile(fileext = ".tar.gz")
+      file.create(tmp)
+      tmp
+    }
+  )
+
+  suppressMessages(deployApp(
+    appDir,
+    appName = "myapp",
+    account = "myaccount",
+    server = "connect.posit.cloud",
+    logLevel = "quiet",
+    lint = FALSE,
+    launch.browser = FALSE
+  ))
+
+  expect_false(update_content_called)
+})
+
+test_that("#1370: existing PCC content with non-null current_revision still calls updateContent", {
+  skip_on_cran()
+  appDir <- local_temp_app(list("app.R" = "library(shiny)"))
+  local_pcc_deploy_env(appDir)
+
+  update_content_called <- FALSE
+  local_mocked_bindings(
+    clientForAccount = function(...) {
+      list(
+        getContent = function(id) pcc_existing_content_with_revision,
+        updateContent = function(...) {
+          update_content_called <<- TRUE
+          pcc_existing_content_with_revision
+        },
+        uploadBundle = function(bundlePath, url) TRUE,
+        publish = function(id) invisible(NULL),
+        awaitCompletion = function(revisionId) {
+          list(
+            success = TRUE,
+            url = "https://connect.posit.cloud/myaccount/content/content-abc"
+          )
+        }
+      )
+    },
+    bundleApp = function(...) {
+      tmp <- tempfile(fileext = ".tar.gz")
+      file.create(tmp)
+      tmp
+    }
+  )
+
+  suppressMessages(deployApp(
+    appDir,
+    appName = "myapp",
+    account = "myaccount",
+    server = "connect.posit.cloud",
+    logLevel = "quiet",
+    lint = FALSE,
+    launch.browser = FALSE
+  ))
+
+  expect_true(update_content_called)
+})
+
+test_that("#1369: deployApp(upload=FALSE) on PCC does not error with 'bundle not found'", {
+  skip_on_cran()
+  appDir <- local_temp_app(list("app.R" = "library(shiny)"))
+  local_pcc_deploy_env(appDir)
+
+  local_mocked_bindings(
+    clientForAccount = function(...) {
+      list(
+        getContent = function(id) pcc_existing_content_with_revision,
+        updateContent = function(...) pcc_existing_content_with_revision,
+        publish = function(id) invisible(NULL),
+        awaitCompletion = function(revisionId) {
+          list(
+            success = TRUE,
+            url = "https://connect.posit.cloud/myaccount/content/content-abc"
+          )
+        }
+      )
+    }
+  )
+
+  expect_no_error(suppressMessages(deployApp(
+    appDir,
+    appName = "myapp",
+    account = "myaccount",
+    server = "connect.posit.cloud",
+    upload = FALSE,
+    logLevel = "quiet",
+    lint = FALSE,
+    launch.browser = FALSE
+  )))
+})


### PR DESCRIPTION
This PR fixes the two issues:

- **#1370**: Redeploying Posit Connect Cloud content whose initial publish failed permanently failed with "Invalid token". Such content is left with a null `current_revision` (no revision was ever promoted), and the guard `!is.null(application$current_revision)` treated that as newly-created content — so `updateContent` (the only call that mints a fresh `source_bundle_upload_url`) was skipped, and the deploy reused an expired token. The fix keys off whether this call created the content instead, so existing content always gets a fresh upload URL.

- **#1369**: `deployApp(upload = FALSE)` on Posit Connect Cloud errored with `object 'bundle' not found` because `bundle` was only assigned inside the `if (upload)` branch, but read unconditionally afterward.

### Fixes

**#1370**: Replace the `current_revision` guard with a `createdContent` flag that tracks whether _this call_ created or 404-recreated the content:
- `isNewContent <- is.null(deployment$appId)` before the create/lookup block
- `isNewContent <<- TRUE` inside the PCC 404 handler (recreated content already has a pending revision)
- Guard becomes `if (!isNewContent)` — existing content always gets `updateContent`; freshly created/recreated content skips it

**#1369**: Initialize `bundle <- NULL` once before the `if (upload)` block; remove the now-redundant `bundle <- NULL` inside the PCC upload branch. `bundle$id` is `NULL` when `upload = FALSE`, which `deploymentRecord()` already handles as optional.
